### PR TITLE
fix(ci): install tauri-cli as a cargo subcommand for the APK build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,8 +115,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          npm install -g @tauri-apps/cli@^2
-          tauri android build ${{ matrix.args }}
+          # As a cargo subcommand, not the npm package: Gradle's rust plugin shells out to
+          # `cargo tauri` while assembling the APK, and an npm-installed `tauri` on PATH does not
+          # satisfy that. Prebuilt binary — `cargo install tauri-cli` compiles for ~10 minutes.
+          curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+          cargo binstall -y --force 'tauri-cli@^2'
+          cargo tauri android build ${{ matrix.args }}
           apk=$(find src-tauri/gen/android -name 'app-universal-release.apk' | head -1)
           test -n "$apk"
           gh api --method POST \


### PR DESCRIPTION
Second Android-only failure on `v1.1.0`: `error: no such command: tauri`.

Gradle's rust plugin shells out to `cargo tauri` while assembling the APK, so installing the npm `@tauri-apps/cli` binary on PATH (what #2 did) doesn't satisfy it. Installs the cargo subcommand instead, prebuilt via binstall — `cargo install tauri-cli` would spend ~10 minutes compiling on every release.

Desktop rows continue to pass; this is the only remaining blocker on the APK asset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)