### PR TITLE
feat: report the webview viewport in Diagnostics

### DIFF
--- a/site/js/boot.js
+++ b/site/js/boot.js
@@ -145,8 +145,13 @@ $('btn-layout-save').onclick = () => {
 
 $('btn-diag').onclick = async () => {
   $('diag').innerHTML = '<div class="muted">running…</div>';
+  // Viewport first, because it is the one number that explains a dashboard drawn at the wrong
+  // size: WebKitGTK on Wayland sometimes hands the page a viewport that doesn't match the window
+  // it lives in, and there is otherwise no way to tell that from the inside.
+  const view = `${window.innerWidth}×${window.innerHeight} @ ${window.devicePixelRatio}× DPR`;
   const rows = await api.diagnostics();
-  $('diag').innerHTML = rows.map((r) =>
+  $('diag').innerHTML = `<div><span>Viewport</span><span class="ok">${view}</span></div>`
+    + rows.map((r) =>
     `<div><span>${r.name}</span><span class="${r.ok ? 'ok' : 'fail'}">${r.ok ? '✓ ' : '✗ '}${r.detail}</span></div>`
   ).join('');
 };


### PR DESCRIPTION
Chasing a report of "the scaling is messed up" on KDE Wayland (mixed DPI, NVIDIA): a maximized 2560x1080 window drew the dashboard in a ~1000x620 block in the corner, the rest blank.

The one measurement that separates a webview bug from a layout bug — what viewport the page was actually given — was unavailable from inside the page (nothing shows it) and from outside the process (a release build has no devtools). I ended up inferring it from pixel archaeology on screenshots, which is not a thing anyone should have to do twice.

Settings → Diagnostics now leads with `innerWidth × innerHeight @ DPR`.

## On the underlying bug

Not fixed here, and not diagnosed. What was ruled out:

- **Fractional scaling is not the trigger.** Setting the two 1.45-scaled outputs to 1 and retesting reproduced nothing.
- **Not reproducible by script.** Maximize in place, move from a 1.45 screen to a scale-1 screen then maximize, open-maximized before the page loads, and a 40-step ramped resize to 2500px all painted the full window correctly.
- **`WEBKIT_DISABLE_DMABUF_RENDERER=1` is not a fix.** It looked like one until I ran a control: the app renders correctly with no env vars at all.
- A `WebKitWebProcess` coredump seen during testing was self-inflicted — `pkill` on the UI process, which WebKit aborts on ("WebProcess didn't exit as expected after the UI process connection was closed").

So it's intermittent, and the next report will come with the viewport line attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)