### PR TITLE
fix: make the webview pick up the startup resize

### DIFF
--- a/site/js/boot.js
+++ b/site/js/boot.js
@@ -145,8 +145,13 @@ $('btn-layout-save').onclick = () => {
 
 $('btn-diag').onclick = async () => {
   $('diag').innerHTML = '<div class="muted">running…</div>';
+  // Viewport first, because it is the one number that explains a dashboard drawn at the wrong
+  // size: WebKitGTK on Wayland sometimes hands the page a viewport that doesn't match the window
+  // it lives in, and there is otherwise no way to tell that from the inside.
+  const view = `${window.innerWidth}×${window.innerHeight} @ ${window.devicePixelRatio}× DPR`;
   const rows = await api.diagnostics();
-  $('diag').innerHTML = rows.map((r) =>
+  $('diag').innerHTML = `<div><span>Viewport</span><span class="ok">${view}</span></div>`
+    + rows.map((r) =>
     `<div><span>${r.name}</span><span class="${r.ok ? 'ok' : 'fail'}">${r.ok ? '✓ ' : '✗ '}${r.detail}</span></div>`
   ).join('');
 };

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -140,7 +140,29 @@ pub fn run() {
                     .initialization_script(&format!("window.__WD_UDP='http://localhost:{port}/udp'"));
             }
 
-            win.build()?;
+            let window = win.build()?;
+
+            // webkit2gtk on Wayland can miss the resize that lands while the page is still
+            // loading: the window ends up full-screen sized with the page still laid out at
+            // `inner_size`, drawn in a small block with the rest blank. Any resize after that
+            // makes it catch up — so hand it one, once, a beat after startup.
+            #[cfg(desktop)]
+            {
+                let w = window.clone();
+                std::thread::spawn(move || {
+                    std::thread::sleep(std::time::Duration::from_millis(900));
+                    if let Ok(s) = w.inner_size() {
+                        let maximized = w.is_maximized().unwrap_or(false);
+                        let _ = w.set_size(tauri::PhysicalSize::new(s.width, s.height - 1));
+                        std::thread::sleep(std::time::Duration::from_millis(80));
+                        if maximized {
+                            let _ = w.maximize();
+                        } else {
+                            let _ = w.set_size(s);
+                        }
+                    }
+                });
+            }
             Ok(())
         })
         .run(tauri::generate_context!())


### PR DESCRIPTION
The scaling bug, actually diagnosed this time.

**Measured on the live broken window:** KWin reported the frame at 2560x1080 on a scale-1 output, while the page painted 1280x800 — exactly `inner_size`. So the window resized and the webview never followed. Resizing the broken window by hand made the page fill it immediately, which pins it to the startup resize specifically, not to scaling, not to the DMABUF renderer, not to fractional-scale outputs.

**Fix:** 900ms after startup, shrink the window one pixel and put it back (re-maximizing if it was maximized). That is the resize webkit missed.

Verified: clean launch on the maximized 2560x1080 output now paints 2560x1080, and the window is left maximized at the right size, not one pixel short.

Supersedes nothing in #4, which only adds the Diagnostics viewport readout — worth keeping as the measurement for any recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)