### PR TITLE
chore: 1.1.1

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3868,7 +3868,7 @@ dependencies = [
 
 [[package]]
 name = "weatherdesk"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "serde_json",
  "tauri",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weatherdesk"
-version = "1.1.0"
+version = "1.1.1"
 description = "Self-hosted WeatherFlow Tempest dashboard"
 authors = ["David May"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "WeatherDesk",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "identifier": "io.github.davidmay87.weatherdesk",
   "build": {
     "frontendDist": "../site"


### PR DESCRIPTION
Version bump for the startup-viewport fix (#5) and the Diagnostics viewport readout (#4). Rust-side change, so it needs a fresh build to reach users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)