### PR TITLE
fix: start maximized on Linux, drop the resize nudge

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -136,33 +136,17 @@ pub fn run() {
                 win = win
                     .title(format!("WeatherDesk — tablet: http://{}:{}", lan_ip(), port))
                     .inner_size(1280.0, 800.0)
+                    // Start maximized on Linux: KWin maximizes a restored window after mapping
+                    // it, and GTK can miss that configure entirely — the webview then paints at
+                    // the startup size in the corner of a full-screen window, with no way for
+                    // the process to notice. Owning the state from the first frame sidesteps it.
+                    .maximized(cfg!(target_os = "linux"))
                     // the window isn't same-origin with the LAN server, so it needs the port told to it
                     .initialization_script(&format!("window.__WD_UDP='http://localhost:{port}/udp'"));
             }
 
-            let window = win.build()?;
+            win.build()?;
 
-            // webkit2gtk on Wayland can miss the resize that lands while the page is still
-            // loading: the window ends up full-screen sized with the page still laid out at
-            // `inner_size`, drawn in a small block with the rest blank. Any resize after that
-            // makes it catch up — so hand it one, once, a beat after startup.
-            #[cfg(desktop)]
-            {
-                let w = window.clone();
-                std::thread::spawn(move || {
-                    std::thread::sleep(std::time::Duration::from_millis(900));
-                    if let Ok(s) = w.inner_size() {
-                        let maximized = w.is_maximized().unwrap_or(false);
-                        let _ = w.set_size(tauri::PhysicalSize::new(s.width, s.height - 1));
-                        std::thread::sleep(std::time::Duration::from_millis(80));
-                        if maximized {
-                            let _ = w.maximize();
-                        } else {
-                            let _ = w.set_size(s);
-                        }
-                    }
-                });
-            }
             Ok(())
         })
         .run(tauri::generate_context!())


### PR DESCRIPTION
Fixes the dashboard painting into a corner of a maximized window with the controls unclickable.

**What the process can see, measured in both states:**

| | broken | healthy small window |
|---|---|---|
| `inner_size` | 1370x890 | 1370x890 |
| `is_maximized()` | false | false |
| `outer_position` | 0,0 | 0,0 |
| page `innerWidth` | 1280 | 1280 |
| KWin's actual frame | **2560x1080 maximized** | 1370x938 |

Identical from the inside. Detect-and-correct cannot work; three attempts confirmed it, including asking the webview for its own viewport over IPC. Creating the window maximized avoids the handshake instead.

Verified with a repro harness (launch, maximize after load, compare KWin's frame against the region the page painted): BUG on every run before, OK on four runs after, plus a confirmed manual run.

Also deletes the 1.1.1 nudge, which fired mid-animation and pinned the webview at a half-size - it made 1.1.1 worse than 1.1.0.

Trade-off: on Linux the window always opens maximized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)