### PR TITLE
v1.2.0: error surfacing, unit fix, UDP-only mode, hide tabs and panels

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ leave it on *Nearest to my station* and it follows the station. Wherever you lea
 product, tilt, basemap, zoom — is remembered here and handed back to the viewer on the next launch.
 It has to work that way round: browsers partition an iframe's storage, so the embedded viewer
 cannot remember anything on its own. The Desk and the Lab share one remembered view.
+
+**Is the radar live?** It is as live as NEXRAD gets: a WSR-88D takes 4–10 minutes to finish a
+volume scan, and delivery adds a little more, so the newest frame is always a few minutes behind
+the sky. Nothing on the internet is fresher — that delay is the radar itself, not the viewer.
 - **Local Signals** — nearby-station comparison table, the Tempest live wind feed, a 24-hour
   lightning-strike log and the notification history.
 - **Data** — ten boards off 7-day device history, including a wind rose, plus multi-model output
@@ -113,6 +117,19 @@ Two limits worth knowing: publishing only happens while the dashboard is open so
 desktop app running — that is the always-on copy), and a browser tab served over `https` cannot
 reach a `ws://` broker at all. The desktop app and the LAN URL are both plain origins, so they can.
 
+## Quick start
+
+1. **Token** — tempestwx.com → Settings → **Data Authorizations** → *Create Token*. Any personal
+   use token works; paste it into Settings → *Tempest API token*.
+2. **Station ID** — the number in your station's URL, `tempestwx.com/station/NNNNN`. That number,
+   not the station name and not the serial on the sensor.
+3. **Device ID** — leave it blank. The station lookup fills it in. (A station ID pasted here is
+   numeric too, and used to break every history chart in silence; the app now corrects it and says
+   so.)
+
+Everything is saved in the browser's `localStorage`, per install — the desktop app and a browser
+tab don't share settings.
+
 ## Download & run
 
 Grab the installer for your OS from [Releases](https://github.com/d4vid87/weatherdesk/releases) and
@@ -124,6 +141,13 @@ The app also listens for your hub's UDP broadcasts on port 50222 and re-serves t
 so live wind and lightning keep flowing with the internet unplugged. A browser can't hold a UDP
 socket, so the no-install option below uses the cloud websocket only. If another Tempest app owns
 port 50222 first, WeatherDesk skips it and falls back to the websocket by itself.
+
+**UDP-only mode — no token at all.** On the desktop app, with your hub on the same network, leave
+the token and station ID empty and the hub's own broadcasts still drive the hero, the wind, rain,
+humidity, pressure, dew point and UV gauges, the live wind feed and the lightning log — and MQTT
+publishing, if you use it. What needs the (free) token is everything that isn't your sensor:
+forecasts, the 10-day list, history charts, model agreement, alerts. The pressure gauge reads
+*station pressure* in this mode rather than sea-level pressure, because that is what the hub sends.
 
 - **Windows** — run the `.msi`. The app is unsigned, so SmartScreen shows a warning: **More info →
   Run anyway**. Allow the Windows Firewall prompt on first launch, or the tablet can't connect.
@@ -164,7 +188,33 @@ station lookup fills in the name, coordinates and numeric device ID. Everything 
 refresh interval, saved places, notification categories, forecast snapshots and the verification
 log — lives in `localStorage`; there is nothing to configure on the server.
 
-For a permanent install, a systemd user unit running that same command is enough.
+### Headless / home lab
+
+No screen, no desktop session — just serve `site/` and open it from anywhere. Drop this in
+`~/.config/systemd/user/weatherdesk.service`:
+
+```ini
+[Unit]
+Description=WeatherDesk (static site)
+After=network-online.target
+
+[Service]
+ExecStart=/usr/bin/python3 -m http.server 8088 --bind 0.0.0.0 --directory %h/weatherdesk/site
+Restart=on-failure
+
+[Install]
+WantedBy=default.target
+```
+
+```sh
+loginctl enable-linger "$USER"          # keeps it running with nobody logged in
+systemctl --user daemon-reload
+systemctl --user enable --now weatherdesk
+```
+
+There is no hub UDP feed in this mode — a browser can't hold a UDP socket, so every client rides
+WeatherFlow's websocket, which means it needs a token and the internet. The desktop app is the only
+build that listens on 50222.
 
 The desktop app serves from its own origin, so settings saved in a browser install (token included)
 don't carry over — paste the token once more in the app.
@@ -179,6 +229,37 @@ desktop jobs. Paste the token once per device.
 Building the desktop app yourself: `cargo tauri build` in `src-tauri/` (Rust + the Tauri
 [prerequisites](https://tauri.app/start/prerequisites/) for your OS). Iterate on the HTML/JS with
 the python command above; the app embeds `site/` at compile time.
+
+## Other devices
+
+- **Windows 10 / 11** — the `.msi` on the Releases page is the whole answer; it's a normal desktop
+  app on both.
+- **iPad, iPhone, Echo Show, any other browser-only screen** — there is no native app, and there
+  won't be. Run the desktop app or the headless server on a machine that stays on, then point
+  Safari (or the Show's Silk browser) at that LAN URL. The Echo Show's browser is untested.
+- **Android TV boxes (onn, Shield, Fire TV)** — the APK installs, but the dashboard is built for
+  touch and mouse: a D-pad remote can't reach the settings drawer or drag a panel. Plug in a USB or
+  Bluetooth mouse, or use an air-mouse remote.
+- **Every public Tempest on a map** — that's WeatherFlow's own [tempestwx.com/map](https://tempestwx.com/map),
+  which is also where you find the IDs for the Local Signals comparison table.
+
+## Troubleshooting
+
+Settings → **Diagnostics** pings every source and prints ✓/✗ plus latency for each, along with the
+viewport size. Start there — it separates "my token is wrong" from "NWS is down".
+
+| What you see | What it means |
+|---|---|
+| *token rejected: create or check a personal use token…* | The token is wrong, expired, or was never created. tempestwx.com → Settings → Data Authorizations. |
+| *Token works but has no access to station N* | The token is valid but belongs to a different account, or the station ID isn't yours. The ID is the number in your `tempestwx.com/station/NNNNN` URL. |
+| *not found: check the station/device ID* | A real 404 — usually a station ID typo, or a serial number (`ST-00176465`) where a numeric ID belongs. |
+| *Device ID corrected* | Something that wasn't one of this station's devices was in the Device ID box. Fixed automatically; leave that box blank. |
+| *Forecast stale — showing cached copy* | The last good forecast is on screen with its age marked; the source is unreachable right now. |
+| *network unreachable* / *timed out (15s)* | Wi-Fi, DNS or the API itself. Diagnostics will show whether it's one source or all of them. |
+| A nearby station row shows an error | Only **public** stations can be read. Pick one from tempestwx.com/map. |
+
+On Windows, if the tablet can't load the LAN URL, it's the firewall prompt that was dismissed on
+first launch — allow WeatherDesk on private networks.
 
 ## License
 

--- a/site/index.html
+++ b/site/index.html
@@ -122,6 +122,8 @@
     background: #0b111ad9; border: 1px solid var(--line); opacity: 0; transition: opacity .15s;
     font-size: 15px; line-height: 1; z-index: 6; user-select: none; touch-action: none; }
   .grip:active { cursor: grabbing; }
+  /* Hide sits beside the grip and inherits its show/hide rules, including the locked-layout one. */
+  .grip-hide { right: 40px; cursor: pointer; font-size: 18px; padding: 0; }
   .panel-hidden { display: none; }
 
   /* Fat, visible, touch-sized targets. `touch-action: none` is what lets a finger drag them
@@ -272,8 +274,9 @@
   .place-hit:hover { color: var(--accent); }
   #place-q { flex: 1; padding: 8px; background: var(--bg); color: var(--text);
     border: 1px solid var(--line); border-radius: 8px; font: inherit; }
-  #notif-toggles label { display: flex; align-items: center; gap: 8px; color: var(--text); margin: 6px 0; }
-  #notif-toggles input { width: auto; }
+  #notif-toggles label, #tab-toggles label { display: flex; align-items: center; gap: 8px; color: var(--text); margin: 6px 0; }
+  #notif-toggles input, #tab-toggles input { width: auto; }
+  #hidden-list { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 6px; }
 
   /* tablet landscape: tighter chrome, two columns of cards */
   @media (max-height: 820px) and (orientation: landscape) {
@@ -505,9 +508,18 @@
       <button id="btn-layout-save" style="flex:0 0 auto">Save layout</button>
     </div>
     <div id="layout-list"></div>
+    <div id="hidden-list"></div>
     <div class="muted" style="font-size:12px;margin-top:6px">
       Hover a panel for its grip: drag the grip to move it, drag the bottom-right corner to resize,
-      double-click the grip to restore that panel's size.
+      double-click the grip to restore that panel's size. The × beside the grip hides a panel;
+      hidden panels come back from the list above.
+    </div>
+
+    <h2 style="font-size:13px;margin-top:18px">Tabs</h2>
+    <div id="tab-toggles">
+      <label><input type="checkbox" data-tab="lab"> Forecast Lab</label>
+      <label><input type="checkbox" data-tab="signals"> Local Signals</label>
+      <label><input type="checkbox" data-tab="data"> Data</label>
     </div>
     <h2 style="font-size:13px;margin-top:18px">Places</h2>
     <div class="row" style="margin-top:6px">
@@ -537,7 +549,9 @@
     <label>Entities to show</label><input id="set-ha-entities" placeholder="light.porch, sensor.attic_temp">
 
     <div id="diag" style="margin-top:12px"></div>
-    <p class="muted" style="font-size:12px">Token: tempestwx.com → Settings → Data Authorizations → create personal use token.</p>
+    <p class="muted" style="font-size:12px">Token: tempestwx.com → Settings → Data Authorizations → create personal use token.
+      Station ID is the number in your tempestwx.com station URL; leave Device ID blank and it fills itself in.
+      On the desktop app with a Tempest hub on the same network, live local readings work with no token at all.</p>
   </aside>
 </main>
 

--- a/site/js/api.js
+++ b/site/js/api.js
@@ -14,11 +14,29 @@ function qs(obj) {
   return new URLSearchParams(obj).toString();
 }
 
+// What to do about it, in the message itself. "401 Unauthorized" told nobody where the token
+// comes from. Tempest-only: a 404 from open-meteo is not a station-ID problem.
+export function errHint(status, url) {
+  if (!url.startsWith(SWD)) return '';
+  if (status === 401 || status === 403) {
+    return ' — token rejected: create or check a personal use token at tempestwx.com → Settings → Data Authorizations';
+  }
+  if (status === 404) return ' — not found: check the station/device ID';
+  return '';
+}
+
 async function getJSON(url, opts) {
   // A wall tablet on a dropped Wi-Fi link otherwise leaves a fetch hanging for minutes and the
   // panel's next refresh never fires.
-  const r = await fetch(url, { signal: AbortSignal.timeout(15000), ...opts });
-  if (!r.ok) throw new Error(`${r.status} ${r.statusText} — ${url.split('?')[0]}`);
+  let r;
+  try {
+    r = await fetch(url, { signal: AbortSignal.timeout(15000), ...opts });
+  } catch (e) {
+    // the token rides in the query string — never let it into a notification body
+    const where = url.split('?')[0];
+    throw new Error(e.name === 'TimeoutError' ? `timed out (15s) — ${where}` : `network unreachable — ${where}`);
+  }
+  if (!r.ok) throw new Error(`${r.status} ${r.statusText} — ${url.split('?')[0]}${errHint(r.status, url)}`);
   return r.json();
 }
 
@@ -34,8 +52,6 @@ export function stationObs(id = settings().stationId) {
 
 // obs_st tuple layout, per the Tempest UDP/REST reference. One copy: two drifting
 // copies of a positional index map is a silently-wrong chart.
-// ponytail: device history may come back in SI regardless of the unit params below —
-// unverified without a live token. If your imperial charts read metric, that's why.
 export const OBS = {
   time: 0, windLull: 1, windAvg: 2, windGust: 3, windDir: 4, windInterval: 5,
   press: 6, temp: 7, rh: 8, lux: 9, uv: 10, solar: 11, rain: 12, precipType: 13,
@@ -43,10 +59,28 @@ export const OBS = {
 };
 
 // history: epoch seconds range, device-level (1min buckets)
-export function deviceObs(deviceId, timeStart, timeEnd) {
-  return getJSON(`${SWD}/observations/device/${deviceId}?${qs({
-    token: settings().token, time_start: timeStart, time_end: timeEnd, ...unitParams(),
+//
+// This endpoint ignores the unit params and always answers in SI (m/s, °C, mb, mm, km) — charts
+// and trends were reading metric numbers under imperial labels, and a 0.30 *mb* 3h pressure delta
+// tripped the inHg "rising rapidly" band forever. Convert here, once, and every consumer
+// (boards.js, pro.js trends) is right without knowing about it.
+export async function deviceObs(deviceId, timeStart, timeEnd) {
+  const j = await getJSON(`${SWD}/observations/device/${deviceId}?${qs({
+    token: settings().token, time_start: timeStart, time_end: timeEnd,
   })}`);
+  const metric = settings().units === 'metric';
+  const conv = (o, i, f) => { if (o[i] != null) o[i] = o[i] * f; };
+  for (const o of j.obs || []) {
+    // wind is m/s in both systems — even metric needs km/h
+    for (const i of [OBS.windLull, OBS.windAvg, OBS.windGust]) conv(o, i, metric ? 3.6 : 2.23694);
+    if (metric) continue;
+    if (o[OBS.temp] != null) o[OBS.temp] = o[OBS.temp] * 9 / 5 + 32;
+    conv(o, OBS.press, 0.02953);
+    conv(o, OBS.rain, 1 / 25.4);
+    conv(o, OBS.dayRain, 1 / 25.4);
+    conv(o, OBS.strikeDist, 0.621371);
+  }
+  return j;
 }
 
 export function betterForecast(stationId = settings().stationId) {
@@ -112,6 +146,14 @@ export function geocode(q) {
 
 export function stormReports(hours = 24) {
   return getJSON(`https://mesonet.agron.iastate.edu/geojson/lsr.geojson?${qs({ hours })}`);
+}
+
+// ponytail-lite self-check: the error hints and the SI conversion, the two places a silent
+// wrong answer would look plausible.
+if (location.search.includes('selftest')) {
+  console.assert(errHint(401, `${SWD}/stations/1`).includes('token'), 'api: 401 names the token');
+  console.assert(errHint(404, `${SWD}/stations/1`).includes('station'), 'api: 404 names the ID');
+  console.assert(errHint(404, 'https://api.open-meteo.com/v1/forecast') === '', 'api: no station hint off Tempest');
 }
 
 // --- Diagnostics: ping each source, return [{name, ok, detail}] ---

--- a/site/js/app.js
+++ b/site/js/app.js
@@ -4,7 +4,7 @@ const DEFAULTS = {
   token: '', stationId: '', deviceId: '', lat: null, lon: null, stationName: '',
   units: 'imperial', refreshSec: 60, places: [], activePlace: null,
   nearbyStations: [], notif: { severe: true, precip: true, lightning: true, wind: true, winter: true, changes: true },
-  windGustAlert: 30, layoutLocked: false,
+  windGustAlert: 30, layoutLocked: false, hiddenTabs: [],
   // '' = whichever radar site is nearest the station. The camera itself lives in `wd.radar`,
   // written once a second by the embedded viewer — not here, where it would re-init the app.
   radarSite: '',
@@ -180,6 +180,20 @@ export function initNav() {
   };
   tabs.forEach((t) => (t.onclick = () => show(t.dataset.section)));
   show(location.hash.slice(1) || 'desk');
+  applyTabs();
+}
+
+// Desk has no checkbox in the drawer, so it can never be hidden — that is the guard against
+// hiding every tab and stranding the user on a blank shell.
+export function applyTabs() {
+  const hidden = _settings.hiddenTabs || [];
+  let bounce = false;
+  document.querySelectorAll('.tab').forEach((t) => {
+    const off = hidden.includes(t.dataset.section);
+    t.style.display = off ? 'none' : '';
+    if (off && t.classList.contains('active')) bounce = true;
+  });
+  if (bounce) document.querySelector('.tab[data-section="desk"]').click();
 }
 
 export function fullscreen() {

--- a/site/js/boot.js
+++ b/site/js/boot.js
@@ -1,5 +1,5 @@
 // Wire the shell: settings drawer, diagnostics, nav, section modules.
-import { settings, saveSettings, configured, initNav, fullscreen, refreshAll, notify, load, store } from './app.js';
+import { settings, saveSettings, configured, initNav, applyTabs, fullscreen, refreshAll, notify, load, store } from './app.js';
 import * as api from './api.js';
 import { initDesk, refreshDesk, refreshObs, refreshAlerts, refreshAqi } from './desk.js';
 import { initIntel, refreshModels, refreshNowcast } from './intel.js';
@@ -7,7 +7,7 @@ import { initSignals, refreshSignals } from './signals.js';
 import { initBoards } from './boards.js';
 import { initPlaces, renderPlaces } from './places.js';
 import { initPro } from './pro.js';
-import { initLayout, snapshot, restore } from './layout.js';
+import { initLayout, snapshot, restore, hiddenPanels, unhide } from './layout.js';
 import { initUdp } from './udp.js';
 import { initHome } from './home.js';
 
@@ -27,7 +27,24 @@ function fillDrawer() {
   $('set-ha-url').value = s.haUrl;
   $('set-ha-token').value = s.haToken;
   $('set-ha-entities').value = s.haEntities;
+  document.querySelectorAll('#tab-toggles input').forEach((c) => {
+    c.checked = !(s.hiddenTabs || []).includes(c.dataset.tab);
+  });
+  renderHiddenPanels();
   fillSites();
+}
+
+// Panels are hidden from their own grip; this is the only way back, so it lists them by id —
+// short enough to recognise, and no second name to keep in sync with the markup.
+function renderHiddenPanels() {
+  const ids = hiddenPanels();
+  $('hidden-list').innerHTML = ids.length
+    ? ids.map((id, i) => `<button class="place-hit" data-hidden="${i}" style="flex:0 0 auto"></button>`).join('')
+    : '<div class="muted" style="font-size:12px">No hidden panels</div>';
+  $('hidden-list').querySelectorAll('[data-hidden]').forEach((b) => {
+    b.textContent = `${ids[+b.dataset.hidden]} ×`;
+    b.onclick = () => { unhide(ids[+b.dataset.hidden]); renderHiddenPanels(); };
+  });
 }
 
 // Radar site picker: every site, nearest first, so the one the user wants is at the top of the
@@ -68,7 +85,15 @@ $('btn-save').onclick = async () => {
     haUrl: $('set-ha-url').value.trim(),
     haToken: $('set-ha-token').value.trim(),
     haEntities: $('set-ha-entities').value.trim(),
+    hiddenTabs: [...document.querySelectorAll('#tab-toggles input')].filter((c) => !c.checked).map((c) => c.dataset.tab),
   });
+  applyTabs();
+  if (!configured()) {
+    notify({
+      title: 'Setup incomplete',
+      body: 'Token + station ID are needed for forecasts. Desktop with a Tempest hub on the LAN still shows live local data.',
+    });
+  }
   await hydrateStation();
   openDrawer(false);
   // Point the radars at whatever the settings now say (a changed site, or a first station fix).
@@ -86,11 +111,27 @@ async function hydrateStation() {
   try {
     const j = await api.station();
     const st = j.stations?.[0];
-    if (!st) return;
+    // A valid token for the wrong account answers 200 with an empty list, and the old silent
+    // return left the whole dashboard blank with nothing to go on.
+    if (!st) {
+      notify({
+        title: 'Station lookup failed',
+        body: `Token works but has no access to station ${settings().stationId}. `
+          + 'The station ID is the number in your tempestwx.com station URL.',
+      });
+      return;
+    }
     const tempest = st.devices?.find((d) => d.device_type === 'ST') || st.devices?.find((d) => d.device_type === 'AR');
-    // history API wants the numeric device_id; a pasted serial (ST-00176465) won't work
-    const numeric = /^\d+$/.test(settings().deviceId) ? settings().deviceId
-      : (tempest ? String(tempest.device_id) : '');
+    // history API wants the numeric device_id; a pasted serial (ST-00176465) won't work — and
+    // neither does a station ID pasted in the device box, which is numeric and used to sail
+    // through this guard and 404 every history call in silence.
+    const entered = settings().deviceId;
+    const known = (st.devices || []).map((d) => String(d.device_id));
+    let numeric = tempest ? String(tempest.device_id) : '';
+    if (/^\d+$/.test(entered) && known.includes(entered)) numeric = entered;
+    else if (/^\d+$/.test(entered) && entered !== numeric) {
+      notify({ title: 'Device ID corrected', body: `${entered} isn't a device on this station — using ${numeric || 'none'}.` });
+    }
     saveSettings({
       stationName: st.name,
       lat: st.latitude, lon: st.longitude,
@@ -157,7 +198,7 @@ $('btn-diag').onclick = async () => {
 };
 
 window.addEventListener('wd:refresh', () => {
-  refreshDesk().catch((e) => notify({ title: 'Forecast failed', body: e.message }));
+  refreshDesk().catch(() => {}); // refreshDesk owns the failure toast
   refreshObs().catch(() => {});
   refreshAlerts().catch(() => {});
   refreshAqi().catch(() => {});
@@ -253,13 +294,19 @@ renderLayouts();
 if (!configured()) {
   fillDrawer();
   openDrawer(true);
-} else {
-  // lat/lon must land before the open-meteo/NWS jobs start
-  hydrateStation().then(() => {
-    loadDeskRadar();
-    initDesk(); initIntel(); initSignals(); initBoards(); initPro(); initUdp(); initHome();
-  });
+  // UDP-only mode: a desktop install with a hub on the LAN has real local data with no token at
+  // all, so the modules start either way. Every refresh job early-returns without a token, so an
+  // unconfigured init is a handful of no-ops.
+  for (const id of ['tenday', 'alerts', 'story', 'agree-verdict', 'changes', 'verify']) {
+    const el = $(id);
+    if (el) el.innerHTML = '<div class="muted">Needs a Tempest token — open ⚙ Settings</div>';
+  }
 }
+// lat/lon must land before the open-meteo/NWS jobs start (resolves immediately when unconfigured)
+hydrateStation().then(() => {
+  loadDeskRadar();
+  initDesk(); initIntel(); initSignals(); initBoards(); initPro(); initUdp(); initHome();
+});
 
 // ponytail-lite self-check: `?selftest` asserts the site maths and the link the viewer is handed.
 if (location.search.includes('selftest')) {

--- a/site/js/desk.js
+++ b/site/js/desk.js
@@ -12,9 +12,14 @@ async function cached(key, fetcher) {
   } catch (e) {
     const j = load(key, null);
     if (!j) throw e;
-    return { j, fresh: false };
+    return { j, fresh: false, err: e };
   }
 }
+
+// One toast per outage, not one per refresh cycle: `every()` retries the forecast every 5
+// minutes and a banner each time would bury the dashboard. Deliberately no `id` — notify()
+// dedupes ids forever, so the first failure would silence every later one.
+let toldFcFail = false;
 
 let latestForecast = null;
 export const forecast = () => latestForecast;
@@ -33,7 +38,19 @@ export const icon = (k) => ICON[k] || '·';
 
 export async function refreshDesk() {
   if (!configured()) return;
-  const { j: fc, fresh } = await cached('wd.cache.fc', api.betterForecast);
+  let res;
+  try {
+    res = await cached('wd.cache.fc', api.betterForecast);
+  } catch (e) {
+    if (!toldFcFail) { toldFcFail = true; notify({ title: 'Forecast failed', body: e.message }); }
+    throw e;
+  }
+  const { j: fc, fresh } = res;
+  if (fresh) toldFcFail = false;
+  else if (!toldFcFail) {
+    toldFcFail = true;
+    notify({ title: 'Forecast stale — showing cached copy', body: res.err.message });
+  }
   latestForecast = fc;
   renderCurrent(fc.current_conditions);
   renderTenDay(fc.forecast.daily);

--- a/site/js/layout.js
+++ b/site/js/layout.js
@@ -246,10 +246,31 @@ function wire(container) {
     });
     el.appendChild(grip);
     ['e', 's', 'se'].forEach((dir) => el.appendChild(resizeHandle(el, dir)));
+
+    // Hide sits on the grip rather than in a drawer checklist: 29 panels make an unreadable list,
+    // and `.layout-locked .grip` already puts it out of reach when the layout is locked.
+    const hide = document.createElement('button');
+    hide.className = 'grip grip-hide';
+    hide.textContent = '×';
+    hide.title = 'Hide this panel — restore it under Settings';
+    hide.onclick = () => {
+      entry(el.dataset.panel).hidden = true;
+      el.classList.add('panel-hidden');
+      save();
+    };
+    el.appendChild(hide);
   });
 }
 
 export const snapshot = () => structuredClone(state);
+
+export const hiddenPanels = () => Object.keys(state).filter((id) => state[id].hidden);
+
+export function unhide(id) {
+  delete entry(id).hidden;
+  document.querySelector(`[data-panel="${id}"]`)?.classList.remove('panel-hidden');
+  save();
+}
 
 // Swap the whole arrangement at once. Inline styles have to be stripped first: a panel the new
 // state says nothing about would otherwise keep the old one's pixel height.
@@ -306,5 +327,19 @@ if (location.search.includes('selftest')) {
   console.assert(insertPoint(row, 220, 40) === row.lastElementChild, 'drop before it');
   dragged = null;
   row.remove();
+
+  // hide → applySaved paints it out; unhide takes the class and the flag back off
+  const p = document.createElement('div');
+  p.dataset.panel = 'sel-hide';
+  document.body.appendChild(p);
+  state = { 'sel-hide': { hidden: true } };
+  applySaved(p);
+  console.assert(p.classList.contains('panel-hidden'), 'layout: hidden panel painted out');
+  console.assert(hiddenPanels().join() === 'sel-hide', 'layout: hiddenPanels lists it');
+  unhide('sel-hide');
+  console.assert(!p.classList.contains('panel-hidden') && !hiddenPanels().length, 'layout: unhide restores');
+  p.remove();
+
   state = JSON.parse(before);
+  save(); // the hide/unhide asserts wrote through to storage — put the real layout back
 }

--- a/site/js/pro.js
+++ b/site/js/pro.js
@@ -1,7 +1,7 @@
 // Desk layout matching myWeatherDesk: sky hero, signal ticker, trend strip,
 // 48h combined chart, day cards, dial gauges. Driven by the wd:forecast event.
 import * as api from './api.js';
-import { settings, U, num, timeStr, deg2compass, every } from './app.js';
+import { settings, coords, U, num, timeStr, deg2compass, every } from './app.js';
 import { forecast as deskForecast } from './desk.js';
 import * as icon from './icons.js';
 import { initLayout } from './layout.js';
@@ -247,6 +247,26 @@ function renderDays(fc) {
 // like (compass needle, barometer dial, filling droplet) rather than every quantity being a ring.
 const gauge = (face, inner) => `<div class="gwrap">${face}<div class="ginner">${inner}</div></div>`;
 
+// Sea-level pressure from the station's own obs (every `refreshSec`, 60s by default) rather than
+// the forecast payload, which is rounded to two decimals and only refreshes every five minutes —
+// on a quiet day the gauge looked frozen.
+let slp = null;
+
+function renderPress(v, label = 'sea level') {
+  const metric = settings().units === 'metric';
+  const pLo = metric ? 970 : 28.5, pHi = metric ? 1040 : 31;
+  const pT = trend(I.press, 3);
+  $('g-press').innerHTML = gauge(icon.dial((v - pLo) / (pHi - pLo)),
+    `<b>${num(v, 2)}</b><small>${U.press()}</small><span>${pT == null ? label : `${pT >= 0 ? '↑' : '↓'} ${num(Math.abs(pT), 2)} / 3h · ${pressWord(pT)}`}</span>`);
+}
+
+window.addEventListener('wd:obs', (e) => {
+  const v = e.detail?.sea_level_pressure;
+  if (v == null) return;
+  slp = v;
+  if (deskForecast()) renderPress(v);
+});
+
 function renderGauges(fc) {
   const c = fc.current_conditions;
   const last = history[history.length - 1] || [];
@@ -264,10 +284,7 @@ function renderGauges(fc) {
   $('g-hum').innerHTML = gauge(icon.ring(c.relative_humidity / 100, '#4fb8ff'),
     `<b>${num(c.relative_humidity)}%</b><span>${rhT == null ? '' : `${rhT >= 0 ? '↑' : '↓'} ${num(Math.abs(rhT))} pts / 3h`}</span>`);
 
-  const pLo = metric ? 970 : 28.5, pHi = metric ? 1040 : 31;
-  const pT = trend(I.press, 3);
-  $('g-press').innerHTML = gauge(icon.dial((c.sea_level_pressure - pLo) / (pHi - pLo)),
-    `<b>${num(c.sea_level_pressure, 2)}</b><small>${U.press()}</small><span>${pT == null ? '' : `${pT >= 0 ? '↑' : '↓'} ${num(Math.abs(pT), 2)} / 3h · ${pressWord(pT)}`}</span>`);
+  renderPress(slp ?? c.sea_level_pressure);
 
   const dT = trend(I.temp, 3, true);
   $('g-dew').innerHTML = gauge(icon.droplet(c.dew_point / (metric ? 30 : 85)),
@@ -302,6 +319,7 @@ async function loadHistory() {
 }
 
 async function loadConsensus() {
+  if (coords().lat == null) return;
   try {
     const m = await api.multiModel();
     const now = Date.now();
@@ -314,6 +332,7 @@ async function loadConsensus() {
 }
 
 async function loadQpf() {
+  if (coords().lat == null) return;
   try {
     const j = await api.dailyPrecip();
     qpf = j.daily?.precipitation_sum || null;
@@ -333,8 +352,69 @@ export function renderPro(fc = deskForecast()) {
   initLayout();
 }
 
+// ---------- UDP-only mode ----------
+//
+// With a hub on the LAN and no token there is no forecast at all, but the hub still broadcasts
+// everything the sensors measure. Fill the parts of the hero and the gauges that come straight
+// off the sensor and leave the rest alone — hi/lo, sun, moon and feels-like are forecast data
+// and there is nothing honest to put there.
+//
+// obs_st is SI on the wire by design (MQTT depends on it), so convert here.
+// Magnus formula — the hub sends temperature and humidity, not dew point. °C in, °C out.
+function dewPointC(c, rh) {
+  if (c == null || !(rh > 0)) return null;
+  const g = (17.625 * c) / (243.04 + c) + Math.log(rh / 100);
+  return (243.04 * g) / (17.625 - g);
+}
+
+function renderLocal(o) {
+  const metric = settings().units === 'metric';
+  const t = (c) => (c == null ? null : metric ? c : c * 9 / 5 + 32);
+  const w = (mps) => (mps == null ? null : mps * (metric ? 3.6 : 2.23694));
+  const p = (mb) => (mb == null ? null : metric ? mb : mb * 0.02953);
+  const r = (mm) => (mm == null ? null : metric ? mm : mm / 25.4);
+
+  const temp = t(o[I.temp]), rh = o[I.rh];
+  $('hero-place').textContent = settings().stationName || 'Local station · UDP';
+  $('hero-time').textContent = new Date().toLocaleString([], { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
+  $('hero-temp').textContent = `${num(temp)}°`;
+  $('hero-cond').textContent = 'Live · hub broadcast';
+  $('hero-live').className = 'live on';
+  $('hero-live').textContent = '● Live · UDP';
+  $('hero-batt').textContent = o[I.battery] ? `${num(o[I.battery], 2)} V` : '';
+
+  const windMax = metric ? 60 : 40;
+  const avg = w(o[I.windAvg]), gust = w(o[I.windGust]), dir = o[I.windDir];
+  $('g-wind').innerHTML = gauge(icon.compass(dir, avg / windMax),
+    `<b>${num(avg)}</b><small>${U.wind()}</small><span>gust ${num(gust)} · ${deg2compass(dir)}</span>`);
+
+  const rain = r(o[I.dayRain]) || 0;
+  $('g-rain').innerHTML = gauge(icon.rainRing(rain / (metric ? 25 : 1), rain > 0),
+    `<b>${rain > 0 ? num(rain, 2) : 'Dry'}</b><span>${num(rain, 2)} ${U.precip()} today</span>`);
+
+  $('g-hum').innerHTML = gauge(icon.ring(rh / 100, '#4fb8ff'), `<b>${num(rh)}%</b><span>relative humidity</span>`);
+
+  // index 6 is the pressure at the sensor, not reduced to sea level — say so rather than let it
+  // read as a barometer reading that disagrees with everyone else's.
+  renderPress(p(o[I.press]), 'station pressure');
+
+  const dpC = dewPointC(o[I.temp], o[I.rh]);
+  if (dpC != null) {
+    const dp = t(dpC);
+    $('g-dew').innerHTML = gauge(icon.droplet(dp / (metric ? 30 : 85)), `<b>${num(dp)}°</b><span>dew point</span>`);
+  }
+
+  $('g-uv').innerHTML = gauge(icon.uvRing(o[I.uv]),
+    `<b>UV ${num(o[I.uv])}</b><span>${uvWord(o[I.uv])}${o[I.solar] ? ` · ${num(o[I.solar])} W/m²` : ''}</span>`);
+}
+
+// Module level, not inside initPro: initPro re-runs on every settings save and a listener per
+// save stacks up. Both the websocket and the UDP poller dispatch wd:ws-obs; with a forecast in
+// hand the normal render owns the screen and this does nothing.
+window.addEventListener('wd:ws-obs', (e) => { if (!deskForecast()) renderLocal(e.detail); });
+window.addEventListener('wd:forecast', (e) => renderPro(e.detail));
+
 export function initPro() {
-  window.addEventListener('wd:forecast', (e) => renderPro(e.detail));
   every('pro-history', 300, async () => { await loadHistory(); renderPro(); });
   every('pro-consensus', 900, async () => { await loadConsensus(); renderPro(); });
   every('pro-qpf', 1800, async () => { await loadQpf(); renderPro(); });
@@ -346,4 +426,11 @@ export function initPro() {
     const paused = $('ticker-track').classList.toggle('paused');
     $('ticker-pause').textContent = paused ? '▶' : '❚❚';
   };
+}
+
+// ponytail-lite self-check: the only arithmetic here that isn't a straight unit multiply.
+if (location.search.includes('selftest')) {
+  console.assert(Math.abs(dewPointC(20, 100) - 20) < 0.1, 'pro: saturated air dews at the air temperature');
+  console.assert(Math.abs(dewPointC(20, 50) - 9.3) < 0.3, 'pro: 20°C at 50% dews near 9.3°C');
+  console.assert(dewPointC(20, 0) === null, 'pro: no humidity, no dew point');
 }

--- a/site/js/signals.js
+++ b/site/js/signals.js
@@ -27,7 +27,9 @@ export async function refreshSignals() {
   $('signals-table').innerHTML = `<div class="sig-row sig-head">
       <span>Station</span><span>Temp</span><span>Δ</span><span>Wind</span><span>Δ</span><span>Rain today</span><span>Age</span>
     </div>` + rows.map((r) => {
-    if (!r.o) return `<div class="sig-row"><span>${r.name}</span><span class="fail" style="grid-column:span 6">${r.err || 'no data'}</span>
+    // A private station answers the same way a wrong number does, and the bare status code sent
+    // people looking for a bug that isn't there.
+    if (!r.o) return `<div class="sig-row"><span>${r.name}</span><span class="fail" style="grid-column:span 6">${r.err ? `${r.err} · private stations can't be read — use a public station's ID from tempestwx.com/map` : 'no data'}</span>
       <button class="sig-x" data-id="${r.id}">×</button></div>`;
     const ageMin = Math.round((Date.now() / 1000 - r.o.timestamp) / 60);
     return `<div class="sig-row${ageMin > 20 ? ' stale' : ''}">

--- a/site/js/udp.js
+++ b/site/js/udp.js
@@ -9,8 +9,13 @@ import { renderRapid, onStrike } from './signals.js';
 // webview; the LAN tablet is same-origin with the server and uses the relative path.
 const URL = window.__WD_UDP || '/udp';
 const FRESH_SEC = 10;
+// obs_st is a once-a-minute report, so the 10s window that suits 3s rapid_wind would reject
+// every one of them.
+const OBS_FRESH_SEC = 120;
 
-let misses = 0, off = false;
+let misses = 0, off = false, slow = false, lastObs = 0;
+
+const schedule = (sec) => every('udp', sec, poll);
 
 async function poll() {
   if (off) return;
@@ -20,10 +25,18 @@ async function poll() {
     if (!r.ok) throw new Error(r.status);
     j = await r.json();
     misses = 0;
+    if (slow) { slow = false; schedule(3); }
   } catch {
     // Three strikes rather than one: a single hiccup on the loopback shouldn't cost the
     // rest of the session's local feed.
-    if (++misses >= 3) off = true;
+    if (++misses < 3) return;
+    misses = 0;
+    // A plain browser or the Android build has no /udp route at all and never will — switch off.
+    // On the desktop the route exists, so a miss means the hub is unplugged or the app just
+    // started: back off to a minute and keep looking, because the local feed is the only feed
+    // in UDP-only mode.
+    if (!window.__WD_UDP) off = true;
+    else if (!slow) { slow = true; schedule(60); }
     return;
   }
 
@@ -39,10 +52,19 @@ async function poll() {
 
   const s = j.evt_strike;
   if (fresh(s) && s.evt) onStrike(s.evt);
+
+  // Same SI tuple the cloud websocket sends, so it rides the same event — the hero, the gauges
+  // and the MQTT publisher all get a local feed without a token. Dedupe by the report's own
+  // timestamp: a 3s poll sees each minute-old report about twenty times.
+  const o = j.obs_st;
+  if (o?.obs?.[0] && now - o._at < OBS_FRESH_SEC && o.obs[0][0] !== lastObs) {
+    lastObs = o.obs[0][0];
+    window.dispatchEvent(new CustomEvent('wd:ws-obs', { detail: o.obs[0] }));
+  }
 }
 
 export function initUdp() {
-  every('udp', 3, poll);
+  schedule(slow ? 60 : 3);
 }
 
 // ponytail-lite self-check alongside layout.js's: the freshness window is the only arithmetic here.
@@ -51,4 +73,6 @@ if (location.search.includes('selftest')) {
   console.assert(now - (now - 3) < FRESH_SEC, 'udp: recent packet counts as fresh');
   console.assert(!(now - (now - 60) < FRESH_SEC), 'udp: minute-old packet is stale');
   console.assert(num(1.5, 1) === '1.5', 'udp: app.js helpers imported');
+  console.assert(now - (now - 60) < OBS_FRESH_SEC, 'udp: minute-old obs_st still counts');
+  console.assert(!(now - (now - 600) < OBS_FRESH_SEC), 'udp: ten-minute-old obs_st is stale');
 }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3868,7 +3868,7 @@ dependencies = [
 
 [[package]]
 name = "weatherdesk"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "serde_json",
  "tauri",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weatherdesk"
-version = "1.1.2"
+version = "1.2.0"
 description = "Self-hosted WeatherFlow Tempest dashboard"
 authors = ["David May"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "WeatherDesk",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "identifier": "io.github.davidmay87.weatherdesk",
   "build": {
     "frontendDist": "../site"


### PR DESCRIPTION
Everything reported on the app page since 1.1.2.

## Bugs
- **"Forecast Failed" / "station lookup failed" / "no data"** — errors were near-invisible. `api.js` now appends what to do (401/403 names Data Authorizations, 404 names the ID), `getJSON` distinguishes timeout from unreachable, `hydrateStation` speaks up when a token has no access to the station, a station ID in the Device ID box is detected and corrected instead of 404ing every history call silently, and `refreshDesk` owns one toast per outage. No `id` on those toasts — `notify()` dedupes ids forever.
- **Metric readings under imperial labels + a pressure trend stuck on "rising rapidly"** — `observations/device` returns SI regardless of unit params. `deviceObs` converts once; all ten Data boards, the trend strip and the lightning distance are correct with no changes of their own.
- **Pressure gauge stuck at 30.10** — driven from the station's own obs (60s) instead of the forecast payload (5 min, 2 decimals).
- **Nearby-station rows showing a bare status code** — private stations read the same as wrong IDs; the row says so.

## Features
- **UDP-only mode.** Desktop + hub on the LAN, no token: hero, wind/rain/humidity/pressure/dew/UV gauges, live wind, lightning log and MQTT publishing all work. The hub's `obs_st` rides the existing `wd:ws-obs` event; zero Rust changes. The poller backs off to 60s instead of switching off permanently when `/udp` exists.
- **Hide tabs and panels.** × on a panel's grip, checkboxes for tabs; both restore from the drawer. Desk has no checkbox, so the shell can't be emptied.

## Docs
Quick start (token, station ID, device ID), the UDP-only answer to "why do I need a key", NEXRAD latency, a troubleshooting table of every new error string, a pasteable headless systemd unit, and platform answers for Windows 10/11, iPad, Echo Show, Android TV remotes and the all-stations map.

## Verification
`?selftest` extended (error hints, hide/unhide round trip, obs_st freshness window, Magnus dew point) and clean in headless Chrome, with no new console warnings versus `main`. Still to check on hardware: a live hub for UDP-only mode and a token for the corrected unit conversions.

Still open: Marc's report of the browser view flashing black every few seconds — not reproducible without his browser and device, so nothing was guessed at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)