### PR TITLE
v1.3.0 — big hero clock, network config sync, metric precip label, Lab view persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,13 @@ double-click it. The app opens in its own window *and* serves the same dashboard
 network on port 8088 — the wall tablet just opens the URL shown in the window title. Nothing else to
 install; leave the app running.
 
+**One config for the whole house.** The desktop app also keeps your settings and dashboard layout
+on the host computer. Any browser that opens the LAN URL loads that configuration — no re-typing the
+token, no re-arranging panels per device — and a save from any of those browsers writes back, so the
+next device to load picks it up. Open sessions don't update live; reload to fetch. Note that this
+means anyone on your network can read the Tempest token from the host. Self-hosting the `site/`
+folder statically has no config server, so those browsers keep their own settings as before.
+
 The app also listens for your hub's UDP broadcasts on port 50222 and re-serves them to the tablet,
 so live wind and lightning keep flowing with the internet unplugged. A browser can't hold a UDP
 socket, so the no-install option below uses the cloud websocket only. If another Tempest app owns

--- a/site/index.html
+++ b/site/index.html
@@ -155,6 +155,10 @@
   /* hero */
   #hero { padding: 16px 20px 20px; color: #fff; overflow: hidden; border-radius: 12px;
     background: linear-gradient(160deg, #1f6fb8, #7fb6e6); }
+  #hero-clock { display: flex; align-items: baseline; gap: 14px; flex-wrap: wrap; margin-bottom: 10px;
+    font-variant-numeric: tabular-nums; }
+  #clock-time { font-size: 56px; font-weight: 700; line-height: 1; }
+  #clock-date { font-size: 18px; }
   .hero-top { display: flex; justify-content: space-between; font-size: 14px; }
   .hero-right { text-align: right; }
   .hero-dim { opacity: .78; }
@@ -341,10 +345,10 @@
   <section class="page" id="desk">
     <div id="desk-stack">
     <div id="hero" data-panel="hero">
+      <div id="hero-clock"><span id="clock-time">--:--:--</span> <span id="clock-date" class="hero-dim"></span></div>
       <div class="hero-top">
         <div>
           <div id="hero-place"></div>
-          <div id="hero-time" class="hero-dim"></div>
         </div>
         <div class="hero-right">
           <div id="hero-sun"></div>

--- a/site/js/boot.js
+++ b/site/js/boot.js
@@ -13,6 +13,43 @@ import { initHome } from './home.js';
 
 const $ = (id) => document.getElementById(id);
 
+// ---------- config sync ----------
+// The desktop app's LAN server keeps one settings+layout blob, so every browser in the house
+// loads the host's configuration instead of being set up by hand. Static self-hosts have no
+// /config route: the fetches fail and each browser keeps its own localStorage, as before.
+const SRV = window.__WD_SRV || '';
+let syncing = false;
+
+async function pullConfig() {
+  syncing = true;
+  try {
+    const r = await fetch(`${SRV}/config`, { signal: AbortSignal.timeout(2000) });
+    if (!r.ok) return;
+    const j = await r.json();
+    if (j.settings) saveSettings(j.settings);
+    if (j.layout) restore(j.layout);
+  } catch {
+    // no config server (static host, or app not running) — nothing to sync
+  } finally {
+    syncing = false;
+  }
+}
+
+// ponytail: server wins on load, last writer wins on save. No merge — every save pushes the
+// whole blob, so there is nothing to reconcile.
+function pushConfig() {
+  if (syncing) return;
+  fetch(`${SRV}/config`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ at: Date.now(), settings: settings(), layout: load('wd.layout', {}) }),
+  }).catch(() => {});
+}
+
+let pushTimer;
+window.addEventListener('wd:layout', () => { clearTimeout(pushTimer); pushTimer = setTimeout(pushConfig, 2000); });
+
+
 function fillDrawer() {
   const s = settings();
   $('set-token').value = s.token;
@@ -95,6 +132,7 @@ $('btn-save').onclick = async () => {
     });
   }
   await hydrateStation();
+  pushConfig();
   openDrawer(false);
   // Point the radars at whatever the settings now say (a changed site, or a first station fix).
   for (const id of ['desk-radar-frame', 'lab-frame']) {
@@ -272,7 +310,7 @@ window.addEventListener('message', (e) => {
 window.addEventListener('wd:section', (e) => {
   const f = $('lab-frame');
   if (e.detail !== 'lab' || f.src) return;
-  f.src = radarUrl(8, false);
+  f.src = radarUrl(8);
 });
 
 // Inline radar strip on the Desk: embedded, so it holds one frame a minute until touched. A live
@@ -282,6 +320,8 @@ function loadDeskRadar() {
   if (!f.src) f.src = radarUrl(6.5);
   $('desk-radar').classList.add('loaded');
 }
+
+await pullConfig();
 
 initNav();
 initPlaces();

--- a/site/js/layout.js
+++ b/site/js/layout.js
@@ -24,7 +24,11 @@ const $ = (id) => document.getElementById(id);
 
 const load = () => { try { return JSON.parse(localStorage.getItem(KEY)) || {}; } catch { return {}; } };
 let state = load();
-const save = () => localStorage.setItem(KEY, JSON.stringify(state));
+const save = () => {
+  localStorage.setItem(KEY, JSON.stringify(state));
+  // boot.js debounces this into a config-server push; a drag fires save() per frame batch.
+  window.dispatchEvent(new CustomEvent('wd:layout'));
+};
 
 const entry = (id) => (state[id] ||= {});
 

--- a/site/js/pro.js
+++ b/site/js/pro.js
@@ -64,7 +64,6 @@ function renderHero(fc) {
   const [a, b] = skyFor(Date.now() / 1000, d.sunrise, d.sunset);
   $('hero').style.background = `linear-gradient(160deg, ${a}, ${b})`;
   $('hero-place').textContent = settings().stationName || 'Station';
-  $('hero-time').textContent = new Date().toLocaleString([], { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
   $('hero-temp').textContent = `${num(c.air_temperature)}°`;
   $('hero-cond').textContent = c.conditions || '';
   $('hero-hilo').textContent = `High ${num(d.air_temp_high)}° / Low ${num(d.air_temp_low)}°`;
@@ -234,7 +233,7 @@ function renderDays(fc) {
           <div class="dc-icon">${icon.wx(d.icon, 30)}</div>
           <div class="dc-temp"><b>${num(d.air_temp_high)}°</b><span>/${num(d.air_temp_low)}°</span></div>
           <div class="dc-cond">${d.conditions || ''}</div>
-          <div class="dc-pop">${num(d.precip_probability)}%${amount != null ? ` · ${num(amount, 2)}"` : ''}</div>
+          <div class="dc-pop">${num(d.precip_probability)}%${amount != null ? ` · ${num(amount, 2)} ${U.precip()}` : ''}</div>
         </div>
       </div>
     </div>`;
@@ -376,7 +375,6 @@ function renderLocal(o) {
 
   const temp = t(o[I.temp]), rh = o[I.rh];
   $('hero-place').textContent = settings().stationName || 'Local station · UDP';
-  $('hero-time').textContent = new Date().toLocaleString([], { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
   $('hero-temp').textContent = `${num(temp)}°`;
   $('hero-cond').textContent = 'Live · hub broadcast';
   $('hero-live').className = 'live on';
@@ -418,6 +416,11 @@ export function initPro() {
   every('pro-history', 300, async () => { await loadHistory(); renderPro(); });
   every('pro-consensus', 900, async () => { await loadConsensus(); renderPro(); });
   every('pro-qpf', 1800, async () => { await loadQpf(); renderPro(); });
+  every('clock', 1, () => {
+    const d = new Date();
+    $('clock-time').textContent = d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit', second: '2-digit' });
+    $('clock-date').textContent = d.toLocaleDateString([], { weekday: 'short', month: 'short', day: 'numeric' });
+  });
   every('pro-clock', 60, () => { if (deskForecast()) renderHero(deskForecast()); });
 
   // A class, not an inline style: inline would outrank the rule that stops the animation whenever

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3868,7 +3868,7 @@ dependencies = [
 
 [[package]]
 name = "weatherdesk"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "serde_json",
  "tauri",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weatherdesk"
-version = "1.2.0"
+version = "1.3.0"
 description = "Self-hosted WeatherFlow Tempest dashboard"
 authors = ["David May"]
 license = "MIT"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,12 +8,14 @@
 #[cfg(desktop)]
 use std::collections::HashMap;
 #[cfg(desktop)]
+use std::io::Read;
+#[cfg(desktop)]
 use std::net::UdpSocket;
 #[cfg(desktop)]
 use std::sync::{Arc, Mutex};
 #[cfg(desktop)]
 use std::time::{SystemTime, UNIX_EPOCH};
-use tauri::{WebviewUrl, WebviewWindowBuilder};
+use tauri::{Manager, WebviewUrl, WebviewWindowBuilder};
 #[cfg(desktop)]
 use tiny_http::{Header, Response, Server};
 
@@ -81,6 +83,13 @@ fn lan_ip() -> String {
         .unwrap_or_else(|_| "localhost".into())
 }
 
+/// One settings+layout blob for the whole house. Anything on the LAN can read it — same trust
+/// model as the CORS-`*` `/udp` route — and that includes the Tempest token.
+#[cfg(desktop)]
+fn cors(res: Response<std::io::Empty>) -> Response<std::io::Empty> {
+    res.with_header(Header::from_bytes("Access-Control-Allow-Origin", "*").unwrap())
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -103,9 +112,11 @@ pub fn run() {
                 let listener = packets.clone();
                 std::thread::spawn(move || listen_udp(listener));
 
+                let cfg_path = app.path().app_config_dir().map(|d| d.join("config.json")).ok();
+
                 let resolver = app.asset_resolver();
                 std::thread::spawn(move || {
-                    for req in server.incoming_requests() {
+                    for mut req in server.incoming_requests() {
                         let path = req.url().split('?').next().unwrap_or("/").to_string();
                         // ponytail: a plain polled route, not SSE — this request loop is
                         // single-threaded, and a hanging stream would stall every other asset.
@@ -117,6 +128,39 @@ pub fn run() {
                                     .with_header(Header::from_bytes("Content-Type", "application/json").unwrap())
                                     .with_header(Header::from_bytes("Access-Control-Allow-Origin", "*").unwrap()),
                             );
+                            continue;
+                        }
+                        if path == "/config" {
+                            let Some(file) = cfg_path.clone() else {
+                                let _ = req.respond(Response::empty(503));
+                                continue;
+                            };
+                            match *req.method() {
+                                tiny_http::Method::Get => {
+                                    let body = std::fs::read_to_string(&file).unwrap_or_else(|_| "{}".into());
+                                    let _ = req.respond(
+                                        Response::from_string(body)
+                                            .with_header(Header::from_bytes("Content-Type", "application/json").unwrap())
+                                            .with_header(Header::from_bytes("Access-Control-Allow-Origin", "*").unwrap()),
+                                    );
+                                }
+                                tiny_http::Method::Put => {
+                                    let mut body = String::new();
+                                    // capped: this loop is single-threaded, and the blob is a few KB
+                                    let ok = req.as_reader().take(256 * 1024).read_to_string(&mut body).is_ok()
+                                        && file.parent().map(|d| std::fs::create_dir_all(d).is_ok()).unwrap_or(false)
+                                        && std::fs::write(&file, body).is_ok();
+                                    let _ = req.respond(cors(Response::empty(if ok { 204 } else { 500 })));
+                                }
+                                tiny_http::Method::Options => {
+                                    let _ = req.respond(
+                                        cors(Response::empty(204))
+                                            .with_header(Header::from_bytes("Access-Control-Allow-Methods", "GET, PUT, OPTIONS").unwrap())
+                                            .with_header(Header::from_bytes("Access-Control-Allow-Headers", "Content-Type").unwrap()),
+                                    );
+                                }
+                                _ => { let _ = req.respond(Response::empty(405)); }
+                            }
                             continue;
                         }
                         let _ = match resolver.get(path) {
@@ -142,7 +186,9 @@ pub fn run() {
                     // the process to notice. Owning the state from the first frame sidesteps it.
                     .maximized(cfg!(target_os = "linux"))
                     // the window isn't same-origin with the LAN server, so it needs the port told to it
-                    .initialization_script(&format!("window.__WD_UDP='http://localhost:{port}/udp'"));
+                    .initialization_script(&format!(
+                        "window.__WD_UDP='http://localhost:{port}/udp';window.__WD_SRV='http://localhost:{port}'"
+                    ));
             }
 
             win.build()?;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "WeatherDesk",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "identifier": "io.github.davidmay87.weatherdesk",
   "build": {
     "frontendDist": "../site"


### PR DESCRIPTION
## Hero clock
Time (with seconds) and date at 56px, bold, at the top of the hero above the temperature; the small dim line beside the station name is gone. Driven by `every('clock', 1, …)` — the existing scheduler already fires immediately, pauses while the tab is hidden and replays on return. `tabular-nums` keeps the ticking seconds from shifting the layout.

## Network config sync
> "set it up on one computer and the browser will load that configuration on any other computer on the network"

The desktop app's LAN server gets `GET`/`PUT`/`OPTIONS /config`, persisted to `config.json` in the app config dir. The site pulls settings + layout before boot and pushes on settings save and (debounced) on layout change. Server wins on load, last writer wins on save — no merge logic. Static self-hosts (`python3 -m http.server`) have no route: fetch fails, each browser keeps its own localStorage exactly as before. The radar view is deliberately not synced.

Any device on the LAN can read the Tempest token from `/config` — same trust model as the existing CORS-`*` `/udp`, and the README now says so.

## Precip label (Sean Armstrong)
`pro.js` day cards hardcoded `"`, so metric users saw millimetres marked as inches. The values were already correct; now the label uses `U.precip()` like every other precip render.

## Lab radar view persistence (Sean Armstrong)
The Lab tab loaded the viewer non-embed, and Hook Echo only posts camera state in embed mode — so Lab pans and zooms were never saved. It's an embed now (identical chrome), sharing `wd.radar` with the Desk pane.

Safari black-flash is fixed separately in d4vid87/hookecho#45.

## Verified
`node --check` on the touched modules; headless Chrome `?selftest` — no assertion failures, no uncaught errors, clock renders. Desktop app built and run: `GET /config` → `{}`, `PUT` → 204, `GET` returns the blob, file lands in the app config dir, `OPTIONS` returns the CORS headers, asset serving unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)