### PR TITLE
feat: add nearby sensors automatically within a radius

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,11 @@ cannot remember anything on its own. The Desk and the Lab share one remembered v
 **Is the radar live?** It is as live as NEXRAD gets: a WSR-88D takes 4–10 minutes to finish a
 volume scan, and delivery adds a little more, so the newest frame is always a few minutes behind
 the sky. Nothing on the internet is fresher — that delay is the radar itself, not the viewer.
-- **Local Signals** — nearby-station comparison table, the Tempest live wind feed, a 24-hour
-  lightning-strike log and the notification history.
+- **Local Signals** — nearby-sensor comparison table, the Tempest live wind feed, a 24-hour
+  lightning-strike log and the notification history. Set a **nearby sensor radius** in Settings
+  and the airports (NWS/METAR) inside it are added on their own, with the same table on the Desk
+  as a *Nearby sensors* panel. Other people's Tempest stations can't be read unless they are
+  shared publicly, so those are still added by ID (or by pasting their tempestwx.com link).
 - **Data** — ten boards off 7-day device history, including a wind rose, plus multi-model output
   and the local verification log.
 

--- a/site/index.html
+++ b/site/index.html
@@ -434,6 +434,12 @@
         <div id="aqi-label" class="muted"></div>
         <div id="aqi-detail" class="muted" style="font-size:12px"></div>
       </div>
+
+      <div class="card" data-panel="nearby">
+        <h2>Nearby sensors</h2>
+        <div id="nearby-ltg" class="muted" style="font-size:13px"></div>
+        <div id="nearby-table"></div>
+      </div>
     </div>
     </div>
   </section>
@@ -497,6 +503,7 @@
     <select id="set-units"><option value="imperial">Imperial</option><option value="metric">Metric</option></select>
     <label>Obs refresh (seconds)</label><input id="set-refresh" type="number" min="10" step="10">
     <label>Wind gust alert threshold</label><input id="set-gust" type="number" min="0">
+    <label>Nearby sensor radius (mi, 0 = manual only)</label><input id="set-nearby-radius" type="number" min="0">
     <label>Radar site</label>
     <select id="set-radar-site"><option value="">Nearest to my station</option></select>
     <label><input id="set-desk-radar" type="checkbox"> Radar panel on the Desk</label>

--- a/site/js/api.js
+++ b/site/js/api.js
@@ -50,6 +50,27 @@ export function stationObs(id = settings().stationId) {
   return getJSON(`${SWD}/observations/stn/${id}?${qs({ token: settings().token, ...unitParams() })}`);
 }
 
+// --- METAR via NWS, shaped like a Tempest station obs so the comparison rows need no branches ---
+
+export async function metarObs(id) {
+  const j = await getJSON(`https://api.weather.gov/stations/${id}/observations/latest`);
+  const p = j.properties || {};
+  const metric = settings().units === 'metric';
+  const c = p.temperature?.value;       // degC
+  const w = p.windSpeed?.value;         // km_h-1
+  return {
+    latitude: j.geometry?.coordinates?.[1],
+    longitude: j.geometry?.coordinates?.[0],
+    obs: [{
+      timestamp: p.timestamp ? Date.parse(p.timestamp) / 1000 : null,
+      air_temperature: c == null ? null : (metric ? c : c * 9 / 5 + 32),
+      wind_avg: w == null ? null : (metric ? w : w * 0.621371),
+      wind_direction: p.windDirection?.value,
+      precip_accum_local_day: null, // airports report precip on their own schedule; not comparable
+    }],
+  };
+}
+
 // obs_st tuple layout, per the Tempest UDP/REST reference. One copy: two drifting
 // copies of a positional index map is a silently-wrong chart.
 export const OBS = {

--- a/site/js/app.js
+++ b/site/js/app.js
@@ -3,7 +3,13 @@
 const DEFAULTS = {
   token: '', stationId: '', deviceId: '', lat: null, lon: null, stationName: '',
   units: 'imperial', refreshSec: 60, places: [], activePlace: null,
-  nearbyStations: [], notif: { severe: true, precip: true, lightning: true, wind: true, winter: true, changes: true },
+  // nearbyStations stays bare id strings: an older client on the same /config reads it directly,
+  // and anything object-shaped would land in its URLs as [object Object]. New keys are additive.
+  nearbyStations: [],
+  nearbyRadius: 0,   // miles; 0 = manual adds only, no airport scanning
+  nearbyMetar: [],   // discovered airports, [{ id: 'KGVT', name }]
+  nearbyExclude: [], // airports the user dismissed; the daily scan won't bring them back
+  notif: { severe: true, precip: true, lightning: true, wind: true, winter: true, changes: true },
   windGustAlert: 30, layoutLocked: false, hiddenTabs: [],
   // '' = whichever radar site is nearest the station. The camera itself lives in `wd.radar`,
   // written once a second by the embedded viewer — not here, where it would re-init the app.

--- a/site/js/boot.js
+++ b/site/js/boot.js
@@ -58,6 +58,7 @@ function fillDrawer() {
   $('set-units').value = s.units;
   $('set-refresh').value = s.refreshSec;
   $('set-gust').value = s.windGustAlert;
+  $('set-nearby-radius').value = s.nearbyRadius ?? 0;
   $('set-desk-radar').checked = !!s.deskRadar;
   $('set-mqtt-url').value = s.mqttUrl;
   $('set-mqtt-user').value = s.mqttUser;
@@ -117,6 +118,7 @@ $('btn-save').onclick = async () => {
     units: $('set-units').value,
     refreshSec: +$('set-refresh').value || 60,
     windGustAlert: +$('set-gust').value || 30,
+    nearbyRadius: +$('set-nearby-radius').value || 0,
     deskRadar: $('set-desk-radar').checked,
     mqttUrl: $('set-mqtt-url').value.trim(),
     mqttUser: $('set-mqtt-user').value.trim(),

--- a/site/js/signals.js
+++ b/site/js/signals.js
@@ -1,55 +1,128 @@
 // 03 Local Signals — nearby public Tempest stations vs yours, plus the live websocket feed.
 import * as api from './api.js';
-import { settings, saveSettings, configured, U, num, deg2compass, every, notify, store, load, notifHistory } from './app.js';
+import { settings, saveSettings, configured, U, num, deg2compass, every, notify, store, load, notifHistory, timeStr } from './app.js';
+import { milesBetween } from './boot.js';
 
 const $ = (id) => document.getElementById(id);
 const MPS = { imperial: 2.23694, metric: 3.6 }; // rapid_wind is always m/s
 
+// --- discovery: what is within nearbyRadius of the station ---
+
+// Airports only. The Tempest map's own endpoint does list every neighbouring station inside a
+// bounding box, with name, position and device ids — but observations for a station you don't own
+// answer 404 on every path the map itself uses (`observations/location`, `observations/device`,
+// `observations/stn`). Reading other people's stations is what WeatherFlow's commercial licence
+// sells, so auto-discovered Tempest neighbours could only ever be a list of names. Add public
+// station IDs by hand on the Signals tab; those work, because a shared station is readable.
+//
+// Failure keeps the last good list: a dead endpoint should cost freshness, not the panel.
+// Radius 0 means "manual only" and clears what was discovered.
+async function scanNearby() {
+  const s = settings();
+  const r = s.nearbyRadius;
+  if (!r || s.lat == null) {
+    if (s.nearbyMetar.length) {
+      saveSettings({ nearbyMetar: [] });
+      refreshSignals();
+    }
+    return;
+  }
+  const near = (lat, lon) => milesBetween(s.lat, s.lon, lat, lon) <= r;
+
+  try {
+    const point = await api.nwsPoint(s.lat, s.lon);
+    const list = await fetch(point.properties.observationStations).then((x) => x.json());
+    // NWS returns these nearest-first. Past the closest few the airports are all reporting the
+    // same air mass, half an hour late.
+    const metar = (list.features || [])
+      .map((f) => ({ id: f.properties.stationIdentifier, name: f.properties.name, c: f.geometry.coordinates }))
+      .filter((x) => !s.nearbyExclude.includes(x.id) && near(x.c[1], x.c[0]))
+      .slice(0, 3);
+    saveSettings({ nearbyMetar: metar.map(({ id, name }) => ({ id, name })) });
+  } catch (e) { console.warn('nearby METAR scan:', e.message); }
+  refreshSignals();
+}
+
 // --- nearby station comparison ---
 
 export async function refreshSignals() {
-  const ids = settings().nearbyStations;
+  const s = settings();
+  const entries = [
+    ...s.nearbyStations.map((id) => ({ id, type: 'wf' })),
+    ...s.nearbyMetar.map((m) => ({ id: m.id, type: 'metar', name: m.name })),
+  ];
   const mine = await api.stationObs().then((j) => j.obs?.[0]).catch(() => null);
-  if (!ids.length) {
-    $('signals-table').innerHTML = '<div class="muted">No nearby stations added. Find public station IDs at tempestwx.com/map.</div>';
+  if (!entries.length) {
+    const empty = '<div class="muted">No nearby sensors. Set a radius in Settings, or add a public station ID from tempestwx.com/map.</div>';
+    for (const el of [$('signals-table'), $('nearby-table')]) if (el) el.innerHTML = empty;
+    if ($('nearby-ltg')) $('nearby-ltg').textContent = '';
     return;
   }
-  const rows = await Promise.all(ids.map(async (id) => {
+  const rows = await Promise.all(entries.map(async (en) => {
     try {
-      const j = await api.stationObs(id);
-      return { id, name: j.station_name || `#${id}`, o: j.obs?.[0] };
-    } catch (e) { return { id, name: `#${id}`, err: e.message }; }
+      const j = en.type === 'metar' ? await api.metarObs(en.id) : await api.stationObs(en.id);
+      const lat = en.lat ?? j.latitude, lon = en.lon ?? j.longitude;
+      const dist = lat == null || s.lat == null ? null : milesBetween(s.lat, s.lon, lat, lon);
+      return { ...en, name: en.name || j.station_name || j.location_name || `#${en.id}`, o: j.obs?.[0], dist };
+    } catch (e) { return { ...en, name: en.name || `#${en.id}`, err: e.message }; }
   }));
+  rows.sort((a, b) => (a.dist ?? 1e9) - (b.dist ?? 1e9));
 
   const d = (a, b) => (a == null || b == null ? null : a - b);
   const sign = (v, digits = 1) => (v == null ? '--' : `${v >= 0 ? '+' : ''}${num(v, digits)}`);
+  const label = (r) => `${r.name}${r.dist == null ? '' : ` <small class="muted">${num(r.dist, 1)} ${U.dist()}</small>`}`;
 
-  $('signals-table').innerHTML = `<div class="sig-row sig-head">
+  const html = `<div class="sig-row sig-head">
       <span>Station</span><span>Temp</span><span>Δ</span><span>Wind</span><span>Δ</span><span>Rain today</span><span>Age</span>
     </div>` + rows.map((r) => {
     // A private station answers the same way a wrong number does, and the bare status code sent
-    // people looking for a bug that isn't there.
-    if (!r.o) return `<div class="sig-row"><span>${r.name}</span><span class="fail" style="grid-column:span 6">${r.err ? `${r.err} · private stations can't be read — use a public station's ID from tempestwx.com/map` : 'no data'}</span>
-      <button class="sig-x" data-id="${r.id}">×</button></div>`;
+    // people looking for a bug that isn't there. One line per row, full message in the title —
+    // several failing rows used to fill the panel with the same red paragraph.
+    if (!r.o) return `<div class="sig-row"><span>${label(r)}</span><span class="fail" style="grid-column:span 6" title="${(r.err || '').replace(/"/g, '')}">${r.err ? `${(r.err.match(/^\d+/) || ['error'])[0]} · can't be read — only stations shared publicly answer` : 'no data'}</span>
+      <button class="sig-x" data-id="${r.id}" data-type="${r.type}">×</button></div>`;
     const ageMin = Math.round((Date.now() / 1000 - r.o.timestamp) / 60);
     return `<div class="sig-row${ageMin > 20 ? ' stale' : ''}">
-      <span>${r.name}</span>
+      <span>${label(r)}</span>
       <span>${num(r.o.air_temperature, 1)}${U.temp()}</span>
       <span>${sign(d(r.o.air_temperature, mine?.air_temperature))}</span>
       <span>${num(r.o.wind_avg, 1)} ${deg2compass(r.o.wind_direction)}</span>
       <span>${sign(d(r.o.wind_avg, mine?.wind_avg))}</span>
       <span>${num(r.o.precip_accum_local_day, 2)} ${U.precip()}</span>
       <span>${ageMin}m</span>
-      <button class="sig-x" data-id="${r.id}">×</button>
+      <button class="sig-x" data-id="${r.id}" data-type="${r.type}">×</button>
     </div>`;
   }).join('');
 
-  $('signals-table').querySelectorAll('.sig-x').forEach((b) => {
-    b.onclick = () => {
-      saveSettings({ nearbyStations: settings().nearbyStations.filter((x) => x !== b.dataset.id) });
-      refreshSignals();
-    };
-  });
+  for (const el of [$('signals-table'), $('nearby-table')]) {
+    if (!el) continue;
+    el.innerHTML = html;
+    el.querySelectorAll('.sig-x').forEach((b) => { b.onclick = () => dropRow(b.dataset); });
+  }
+  renderNearbyLightning(rows);
+}
+
+// A dismissed airport has to be remembered, or the next scan puts it straight back.
+function dropRow({ id, type }) {
+  const s = settings();
+  if (type === 'metar') saveSettings({ nearbyMetar: s.nearbyMetar.filter((m) => m.id !== id), nearbyExclude: [...s.nearbyExclude, id] });
+  else saveSettings({ nearbyStations: s.nearbyStations.filter((x) => x !== id) });
+  refreshSignals();
+}
+
+// Lightning without a second network to pay for: the neighbours' own strike counters, summed.
+function renderNearbyLightning(rows) {
+  const el = $('nearby-ltg');
+  if (!el) return;
+  // Airports don't report strikes, so with no readable Tempest neighbour there is nothing to say.
+  const obs = rows.filter((r) => r.type !== 'metar' && r.o).map((r) => r.o);
+  if (!obs.length) { el.textContent = ''; return; }
+  const total = obs.reduce((n, o) => n + (o.lightning_strike_count_last_3hr || 0), 0);
+  if (!total) { el.textContent = '⚡ no strikes reported nearby (3h)'; return; }
+  const dists = obs.map((o) => o.lightning_strike_last_distance).filter((x) => x != null);
+  const last = Math.max(...obs.map((o) => o.lightning_strike_last_epoch || 0));
+  el.textContent = `⚡ ${total} strikes/3h across ${obs.length} stations`
+    + (dists.length ? ` · nearest ${num(Math.min(...dists), 1)} ${U.dist()}` : '')
+    + (last ? ` · last ${timeStr(last)}` : '');
 }
 
 // --- live websocket: rapid wind (3s) + full obs ---
@@ -162,8 +235,10 @@ export function initSignals() {
   renderStrikes();
   renderNotifLog();
   $('btn-add-station').onclick = () => {
-    const id = $('add-station-id').value.trim();
-    if (!/^\d+$/.test(id)) return;
+    // Pasting the map/station URL is what people actually have in hand. Station ids run 4+
+    // digits, so the first such run is the id in every form of the link.
+    const id = ($('add-station-id').value.match(/\d{4,}/) || [])[0];
+    if (!id) return;
     const list = settings().nearbyStations;
     if (!list.includes(id)) saveSettings({ nearbyStations: [...list, id] });
     $('add-station-id').value = '';
@@ -171,6 +246,9 @@ export function initSignals() {
   };
   if (configured()) {
     every('signals', 300, refreshSignals);
+    // every() runs its job immediately, and Save re-runs initSignals — so this is a rescan on
+    // boot, on every settings save, and once a day, with no change detection to keep in sync.
+    every('nearby-scan', 86400, scanNearby);
     connectWs();
     // socket goes quiet without closing on some networks — force a reconnect
     every('ws-watchdog', 120, () => {


### PR DESCRIPTION
Set a radius in Settings and the airports (NWS/METAR) inside it are added on their own, rescanned on boot, on every save and once a day. They render in the existing Local Signals comparison table and in a new "Nearby sensors" Desk panel — same rows, now distance-sorted with a distance column and the delta against your own station. Dismissing an airport is remembered, so the next scan does not bring it back.

Tempest neighbours are deliberately not auto-added. The map's own endpoint does list them, but observations for a station you do not own answer 404 on every path the map itself uses; reading other people's stations is what WeatherFlow's commercial licence sells. Public stations added by ID still work, and the add box now accepts a pasted tempestwx.com station or map link.

Airport observations are reshaped to look like a Tempest station obs so the row renderer needs no per-source branches, and are converted from degC/km_h-1 to the configured units.