### PR TITLE
feat: v2.0 — eco pacing, observation log, alert rules, themes, public page

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ chart](docs/screenshot.png)
   in `localStorage`; sky-gradient hero (astro + moon phase + battery + live-observation age), signal ticker,
   station-vs-model trend strip, 48h temp/rain/wind chart, inline radar, six day cards with
   temperature arcs, eight dial gauges, 10-day list, alert center, weather story, model agreement,
-  forecast changes, forecast accuracy, air quality.
+  forecast changes, forecast accuracy, air quality, sun & moon detail (golden hour, day-length
+  change, moonrise/set), fire weather & dryness, and station health (battery, signal, sensor
+  faults, time since the last report).
 - **Forecast Lab** — radar, embedded from [Hook Echo-WX](https://hookecho.netlify.app/).
 
 The Desk radar loads itself, in Hook Echo's embedded mode: no chrome, and one frame a minute until
@@ -50,7 +52,36 @@ the sky. Nothing on the internet is fresher — that delay is the radar itself, 
   as a *Nearby sensors* panel. Other people's Tempest stations can't be read unless they are
   shared publicly, so those are still added by ID (or by pasting their tempestwx.com link).
 - **Data** — ten boards off 7-day device history, including a wind rose, plus multi-model output
-  and the local verification log.
+  and the local verification log, a garden card (growing degree days, evaporation, watering
+  shortfall), and the almanac: all-time records, this day last year and rain month by month, from
+  the app's own observation log.
+
+## Alert rules and push
+
+Settings → **Alert rules** builds thresholds on live readings: a metric (temperature, dew point,
+gust, wind, humidity, rain rate, UV, 3h lightning count, 3h pressure change), above or below, a
+value, and how long it has to hold. A rule fires once and re-arms when the reading falls back
+through 90% of its threshold, so a gust hovering on the line does not notify all afternoon.
+
+Any alert can leave the machine:
+
+- **ntfy** — put a topic in Settings and install the ntfy app on your phone. The topic is the
+  whole of the security on ntfy.sh, so make it long and unguessable, or run your own server and
+  point the ntfy server field at it.
+- **Webhook** — a POST of `{title, body, category, t}` to any URL.
+- **MQTT** — every alert is also published to `weatherdesk/<station>/alert` when a broker is
+  configured.
+
+None of these ever carry your Tempest token, station ID or broker password — title, body and
+category only.
+
+## Eco mode and pacing
+
+Settings → **Eco mode** halves how often everything polls, stops the ticker and drops the seconds
+from the clock. On *Auto* it turns itself on when the browser reports four cores or fewer, which
+covers the tablets and old laptops this is often left running on. Overnight (sunset+1h to
+sunrise−1h) everything slows further on its own, and an active Severe or Extreme NWS alert puts
+the whole dashboard back to full speed — and brings the radar panel up if it was hidden.
 
 A panel that has stopped updating keeps its last good numbers and marks itself with its age in the
 corner, rather than blanking or lying. The forecast and current observations are cached, so a
@@ -242,9 +273,34 @@ devices, Fire OS 6 and newer. The phone build talks to WeatherFlow's websocket o
 listens for the hub's LAN broadcasts nor serves the dashboard to other devices, both of which stay
 desktop jobs. Paste the token once per device.
 
+**The observation log.** The desktop app writes every observation the hub broadcasts to
+`<app data>/log/obs-YYYY-MM.jsonl` — raw SI, about 15 MB a year, never rotated. That log is what
+the almanac and the garden card read, and `Settings → History CSV` hands the whole thing over as a
+spreadsheet. It starts the day you first run the app; nothing backfills it, so the almanac says
+how far back it actually goes rather than pretending.
+
 Building the desktop app yourself: `cargo tauri build` in `src-tauri/` (Rust + the Tauri
 [prerequisites](https://tauri.app/start/prerequisites/) for your OS). Iterate on the HTML/JS with
 the python command above; the app embeds `site/` at compile time.
+
+## Sharing a read-only dashboard
+
+The desktop app serves `http://<host>:8088/public` — the same dashboard with the settings drawer
+gone and a config the server strips every credential out of before sending. It is the URL to give
+a family tablet, a guest, or a reverse proxy pointed at the outside world.
+
+Note the trust model of the ordinary `/` dashboard: `GET /config` deliberately serves the whole
+settings blob, token included, to anything on the LAN, because that is how a second browser in the
+house sets itself up without being configured by hand. Anyone on your network can read your Tempest
+token. `/public` is the address to hand out if that is not what you want, and the only one to put
+behind a proxy.
+
+## Installing on a phone
+
+The dashboard ships a web manifest, so any phone browser pointed at the LAN URL can add it to the
+home screen and run it full-screen. There is no service worker and there won't be: the LAN server
+is plain http, which cannot register one, and a cached copy of a live dashboard would be showing
+yesterday's weather with today's confidence.
 
 ## Other devices
 

--- a/site/icon.svg
+++ b/site/icon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="WeatherDesk">
+  <rect width="512" height="512" rx="96" fill="#0b0f14"/>
+  <circle cx="196" cy="196" r="66" fill="#ffb84f"/>
+  <path d="M150 330a74 74 0 0 1 12-147 104 104 0 0 1 196 30 62 62 0 0 1-14 122z" fill="#4fb8ff"/>
+  <g stroke="#4fb8ff" stroke-width="22" stroke-linecap="round">
+    <path d="M170 380l-18 46M250 380l-18 46M330 380l-18 46"/>
+  </g>
+</svg>

--- a/site/index.html
+++ b/site/index.html
@@ -3,13 +3,46 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-<meta name="color-scheme" content="dark">
+<meta name="color-scheme" content="dark light">
+<meta name="theme-color" content="#0b0f14">
+<!-- Installable from a phone's browser. No service worker on purpose: the LAN server is plain
+     http, which cannot register one, and an offline cache of a live dashboard would be a lie. -->
+<link rel="manifest" href="manifest.json">
+<link rel="icon" href="icon.svg" type="image/svg+xml">
 <title>WeatherDesk</title>
 <style>
   :root {
     --bg: #0b0f14; --panel: #131a22; --panel2: #1a232d; --line: #253141;
     --text: #e6edf5; --muted: #8ea0b5; --accent: #4fb8ff; --warn: #ffb84f; --bad: #ff5f56; --good: #4fdc8b;
     --gap: 12px;
+  }
+  /* Light theme is the same palette inverted, not a second stylesheet — every rule below reads
+     these six variables and nothing else knows a theme exists. */
+  html[data-theme="light"] {
+    --bg: #f2f5f8; --panel: #ffffff; --panel2: #e8edf3; --line: #ccd6e0;
+    --text: #16202b; --muted: #5c6b7d; --accent: #0b74d1; --warn: #a35a00; --bad: #c02a22; --good: #187a45;
+  }
+  html[data-density="compact"] { --gap: 7px; }
+  html[data-density="compact"] .card { padding: 8px 10px; }
+  body.big-numbers .now-temp { font-size: 88px; }
+  body.big-numbers .kv-rows { font-size: 16px; }
+  /* Night dim: one overlay, no repaint of anything underneath. */
+  #wizard { position: fixed; inset: 0; z-index: 1001; background: #000a;
+    display: flex; align-items: center; justify-content: center; padding: 16px; }
+  #wizard[hidden] { display: none; }
+  .wizard-box { background: var(--panel); border: 1px solid var(--line); border-radius: 12px;
+    padding: 20px; width: min(520px, 100%); max-height: 90vh; overflow: auto; }
+  .wizard-box input { width: 100%; padding: 8px; background: var(--bg); color: var(--text);
+    border: 1px solid var(--line); border-radius: 8px; font: inherit; }
+  #shortcuts {
+    position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%); z-index: 1000;
+    background: var(--panel); border: 1px solid var(--line); border-radius: 12px; padding: 16px 20px;
+    min-width: 260px;
+  }
+  #shortcuts[hidden] { display: none; }
+  body.dimmed::after {
+    content: ''; position: fixed; inset: 0; background: #000; opacity: .45;
+    pointer-events: none; z-index: 999;
   }
   * { box-sizing: border-box; }
   html, body { margin: 0; height: 100%; }
@@ -81,6 +114,9 @@
   .aqi-good { color: var(--good); } .aqi-mod { color: var(--warn); }
   .aqi-usg, .aqi-bad, .aqi-vbad { color: var(--bad); }
 
+  /* the public dashboard hides the drawer rather than removing it — see boot.js */
+  #drawer[hidden], #btn-settings[hidden] { display: none; }
+
   /* settings drawer */
   #drawer {
     position: absolute; inset: 0 0 0 auto; width: min(420px, 100%); background: var(--panel);
@@ -98,7 +134,7 @@
     background: var(--panel2); color: var(--text); font: inherit; cursor: pointer; }
   .row button.primary { background: var(--accent); color: #04121d; border-color: var(--accent); }
   #diag div { display: flex; justify-content: space-between; padding: 3px 0; font-size: 13px; }
-  .ok { color: var(--good); } .fail { color: var(--bad); }
+  .ok { color: var(--good); } .fail { color: var(--bad); } .warn { color: var(--warn); }
 
   /* ---- pro desk ---- */
   #desk { padding: 0; }
@@ -186,6 +222,15 @@
      never scrolls away for good. */
   @keyframes tick { from { transform: translateX(0); } to { transform: translateX(-50%); } }
   #ticker-track.still { animation: none; }
+  /* Eco: the ticker is a composited transform running forever, and every transition here is a
+     repaint on a machine that has none to spare. Reduced-motion gets the same treatment for the
+     reason it asks for it. */
+  body.eco #ticker-track, body.eco #ticker-track.paused { animation: none; }
+  body.eco * { transition: none !important; }
+  @media (prefers-reduced-motion: reduce) {
+    #ticker-track, body.ticker-live #ticker-track { animation: none; }
+    * { transition: none !important; }
+  }
   .tick { font-size: 15px; }
   .tick b { background: #1a2432; border: 1px solid var(--line); color: var(--warn); font-size: 11px;
     letter-spacing: .1em; padding: 3px 8px; border-radius: 5px; margin-right: 9px; }
@@ -289,6 +334,20 @@
     .chart { height: 120px; }
     header { padding: 5px 10px; }
   }
+  /* phone: one column, and saved column spans stop applying — a panel resized to a third of a
+     desktop screen is unreadable on a handset, and the layout is per-install, not per-device. */
+  @media (max-width: 720px) {
+    #desk-stack, #desk-stack > *, #desk-radar, #trends, #c48 { grid-column: span 12 !important; }
+    #desk-radar { grid-row: span 1; }
+    .grid { grid-template-columns: 1fr; }
+    .grid > .card { grid-column: span 1 !important; }
+    .now-temp { font-size: 56px; }
+    nav { overflow-x: auto; flex-wrap: nowrap; }
+    .tab { padding: 8px 12px; white-space: nowrap; }
+    /* thumbs, not mouse pointers */
+    .iconbtn, button { min-height: 40px; }
+    #drawer { width: 100%; }
+  }
   .live-wind-wrap { display: flex; align-items: center; gap: 16px; }
   .compass { width: 74px; height: 74px; border: 2px solid var(--line); border-radius: 50%;
     position: relative; flex: none; }
@@ -333,6 +392,7 @@
     <button class="tab" data-section="data">Data</button>
   </nav>
   <span id="station-name" class="muted"></span>
+  <select id="station-switch" class="iconbtn" hidden title="Switch station"></select>
   <button class="iconbtn" id="btn-refresh">↻</button>
   <button class="iconbtn" id="btn-full">⛶</button>
   <button class="iconbtn" id="btn-lock" title="Lock panel layout">🔓</button>
@@ -341,6 +401,36 @@
 
 <main>
   <div id="notif-stack"></div>
+<div id="wizard" hidden>
+  <div class="wizard-box">
+    <h2 style="margin-top:0">Welcome to WeatherDesk</h2>
+    <p class="muted" style="font-size:13px">Paste a Tempest personal use token and pick your station.
+      Get one at tempestwx.com → Settings → Data Authorizations.</p>
+    <div class="row">
+      <input id="wiz-token" type="password" placeholder="personal use token">
+      <button class="primary" id="btn-wiz-find" style="flex:0 0 auto">Find stations</button>
+    </div>
+    <div id="wiz-list" style="margin-top:8px"></div>
+    <div class="row" style="margin-top:10px">
+      <button id="btn-wiz-demo">Skip — just show me the weather somewhere</button>
+      <button id="btn-wiz-close" style="flex:0 0 auto">Close</button>
+    </div>
+    <p class="muted" style="font-size:12px">No station? The desktop app also reads a Tempest hub
+      directly off the network with no token at all.</p>
+  </div>
+</div>
+
+<div id="shortcuts" hidden>
+  <h2 style="margin-top:0">Keyboard</h2>
+  <div class="kv-rows">
+    <div><span>1 – 9</span><span>switch tab</span></div>
+    <div><span>r</span><span>refresh everything</span></div>
+    <div><span>f</span><span>fullscreen</span></div>
+    <div><span>s</span><span>settings</span></div>
+    <div><span>?</span><span>this list</span></div>
+    <div><span>Esc</span><span>close</span></div>
+  </div>
+</div>
 
   <section class="page" id="desk">
     <div id="desk-stack">
@@ -428,6 +518,10 @@
       <div class="card" data-panel="changes"><h2>Forecast changes</h2><div id="changes" class="muted">--</div></div>
       <div class="card" data-panel="verify"><h2>Forecast accuracy</h2><div id="verify" class="muted">--</div></div>
 
+      <div class="card" data-panel="sky"><h2>Sun &amp; moon</h2><div id="sky" class="kv-rows"></div></div>
+      <div class="card" data-panel="fire"><h2>Fire &amp; dryness</h2><div id="fire" class="kv-rows"></div></div>
+      <div class="card" data-panel="health"><h2>Station health</h2><div id="health" class="kv-rows"></div></div>
+
       <div class="card" data-panel="aqi">
         <h2>Air quality</h2>
         <div id="aqi-val">--</div>
@@ -491,6 +585,9 @@
       <div class="card"><h2 id="board-accuracy">Forecast accuracy</h2><canvas id="c-accuracy" class="chart"></canvas></div>
       <div class="card"><h2>NWS vs Tempest</h2><div id="official" class="kv-rows"></div></div>
       <div class="card"><h2 id="board-qpf">Precip outlook</h2><canvas id="c-qpf" class="chart"></canvas></div>
+      <div class="card"><h2>Garden</h2><div id="garden" class="kv-rows"></div></div>
+      <div class="card"><h2>Almanac · all time</h2><div id="almanac" class="kv-rows"></div></div>
+      <div class="card"><h2 id="board-monthly">Month by month</h2><canvas id="c-monthly" class="chart"></canvas></div>
     </div>
   </section>
 
@@ -504,9 +601,47 @@
     <label>Obs refresh (seconds)</label><input id="set-refresh" type="number" min="10" step="10">
     <label>Wind gust alert threshold</label><input id="set-gust" type="number" min="0">
     <label>Nearby sensor radius (mi, 0 = manual only)</label><input id="set-nearby-radius" type="number" min="0">
+    <div class="row"><button id="btn-station-save">Remember this station</button></div>
+    <div id="station-list"></div>
     <label>Radar site</label>
     <select id="set-radar-site"><option value="">Nearest to my station</option></select>
     <label><input id="set-desk-radar" type="checkbox"> Radar panel on the Desk</label>
+    <label><input id="set-storm-auto" type="checkbox"> Show the radar automatically during warnings</label>
+    <h2 style="font-size:13px;margin-top:18px">Appearance</h2>
+    <label>Theme</label>
+    <select id="set-theme">
+      <option value="dark">Dark</option>
+      <option value="light">Light</option>
+      <option value="auto">Auto — light by day</option>
+    </select>
+    <label>Accent colour</label><input id="set-accent" type="color" value="#4fb8ff">
+    <label>Text size</label>
+    <select id="set-font">
+      <option value="0.85">Small</option>
+      <option value="1">Normal</option>
+      <option value="1.15">Large</option>
+      <option value="1.35">Extra large</option>
+    </select>
+    <label>Density</label>
+    <select id="set-density"><option value="normal">Normal</option><option value="compact">Compact</option></select>
+    <label><input id="set-big-numbers" type="checkbox"> Oversized readings</label>
+
+    <h2 style="font-size:13px;margin-top:18px">Kiosk</h2>
+    <label>Cycle tabs every (seconds, 0 = off)</label><input id="set-kiosk" type="number" min="0" step="5">
+    <label><input id="set-night-dim" type="checkbox"> Dim the screen overnight</label>
+
+    <label style="margin-top:14px">Eco mode (slower polling, no animation)</label>
+    <select id="set-eco">
+      <option value="auto">Auto — on for slow hardware</option>
+      <option value="on">Always on</option>
+      <option value="off">Off</option>
+    </select>
+    <div class="row">
+      <button id="btn-export">Export settings</button>
+      <button id="btn-import">Import settings</button>
+      <button id="btn-csv">History CSV</button>
+    </div>
+    <input id="import-file" type="file" accept="application/json,.json" hidden>
     <div class="row">
       <button class="primary" id="btn-save">Save</button>
       <button id="btn-diag">Diagnostics</button>
@@ -549,8 +684,29 @@
       <label><input type="checkbox" data-cat="wind"> High wind</label>
       <label><input type="checkbox" data-cat="winter"> Snow / ice</label>
       <label><input type="checkbox" data-cat="changes"> Forecast changes</label>
+      <label><input type="checkbox" data-cat="rule"> My alert rules</label>
+      <label><input type="checkbox" data-cat="station"> Station health</label>
     </div>
     <div class="row"><button id="btn-notif-test">Test notifications</button></div>
+
+    <h2 style="font-size:13px;margin-top:18px">Alert rules</h2>
+    <div id="rule-list"></div>
+    <div class="row" style="margin-top:6px">
+      <select id="rule-metric"></select>
+      <select id="rule-op" style="flex:0 0 auto"><option value="&gt;">above</option><option value="&lt;">below</option></select>
+    </div>
+    <div class="row" style="margin-top:6px">
+      <input id="rule-value" type="number" step="any" placeholder="value">
+      <input id="rule-dur" type="number" min="0" placeholder="minutes" style="flex:0 0 90px">
+      <button id="btn-rule-add" style="flex:0 0 auto">Add</button>
+    </div>
+
+    <h2 style="font-size:13px;margin-top:18px">Push notifications</h2>
+    <label>ntfy topic (phone push)</label><input id="set-ntfy-topic" placeholder="pick something unguessable">
+    <label>ntfy server</label><input id="set-ntfy-url" placeholder="https://ntfy.sh">
+    <label>Webhook URL</label><input id="set-webhook" placeholder="https://…">
+    <p class="muted" style="font-size:12px">Alerts are sent as title, body and category only — never your token.
+      An ntfy.sh topic is public to anyone who guesses it, so make it long.</p>
 
     <h2 style="font-size:13px;margin-top:18px">Smart home</h2>
     <label>MQTT WebSocket URL</label><input id="set-mqtt-url" placeholder="ws://homeassistant.local:9001">

--- a/site/js/almanac.js
+++ b/site/js/almanac.js
@@ -1,0 +1,133 @@
+// 04b Almanac — all-time records, this day last year, month by month.
+//
+// Source is the desktop app's own observation log (`/history/daily`), not the Tempest REST API:
+// the REST history is capped and paged, and the point of the log is to keep going once it ends.
+// Nothing here backfills — the archive starts the day the app was first run, and the panel says
+// so rather than pretending the record is older than it is.
+import { settings, U, num, every } from './app.js';
+import { chart } from './charts.js';
+
+const $ = (id) => document.getElementById(id);
+const SRV = window.__WD_SRV || '';
+
+// The log is SI, exactly as the hub broadcast it — the same conversion deviceObs() does, in the
+// one place the almanac needs it.
+export function toDisplay(row) {
+  const metric = settings().units === 'metric';
+  const t = (c) => (c == null ? null : metric ? c : c * 9 / 5 + 32);
+  const wind = (ms) => (ms == null ? null : ms * (metric ? 3.6 : 2.23694));
+  const rain = (mm) => (mm == null ? null : mm * (metric ? 1 : 1 / 25.4));
+  return {
+    day: row.day,
+    tempMin: t(row.tempMin), tempMax: t(row.tempMax),
+    gustMax: wind(row.gustMax), rain: rain(row.rain),
+    strikes: row.strikes, battMin: row.battMin,
+  };
+}
+
+let days = [];
+
+async function load() {
+  // The browser's own offset, because the process has no timezone and "a day" has to mean the
+  // day the user lived through.
+  const tz = -new Date().getTimezoneOffset();
+  const r = await fetch(`${SRV}/history/daily?tz=${tz}`, { signal: AbortSignal.timeout(10000) });
+  if (!r.ok) throw new Error(`${r.status}`);
+  days = (await r.json()).map(toDisplay);
+}
+
+const note = (msg) => {
+  $('almanac').innerHTML = `<div class="muted">${msg}</div>`;
+  $('board-monthly').textContent = 'Month by month';
+};
+
+// Widest value of a column, and the day it happened on.
+export function extreme(rows, key, cmp) {
+  let best = null;
+  for (const d of rows) {
+    if (d[key] == null) continue;
+    if (!best || cmp(d[key], best[key])) best = d;
+  }
+  return best;
+}
+
+const pretty = (day) => new Date(`${day}T12:00:00`).toLocaleDateString([], { month: 'short', day: 'numeric', year: 'numeric' });
+
+export async function refreshAlmanac() {
+  try {
+    await load();
+  } catch {
+    // Browser and Android installs have no log server; say which app has the archive rather
+    // than leaving an empty card.
+    note('Records come from the desktop app’s observation log — open WeatherDesk on the machine with the hub.');
+    return;
+  }
+  if (!days.length) {
+    note('Collecting. Records appear after the first full day of observations.');
+    return;
+  }
+
+  const hi = extreme(days, 'tempMax', (a, b) => a > b);
+  const lo = extreme(days, 'tempMin', (a, b) => a < b);
+  const gust = extreme(days, 'gustMax', (a, b) => a > b);
+  const wet = extreme(days, 'rain', (a, b) => a > b);
+  const zap = extreme(days, 'strikes', (a, b) => a > b);
+
+  // Same calendar day, a year back. Missing is the normal case in year one.
+  const now = new Date();
+  const lastYear = new Date(now.getFullYear() - 1, now.getMonth(), now.getDate());
+  const key = `${lastYear.getFullYear()}-${String(lastYear.getMonth() + 1).padStart(2, '0')}-${String(lastYear.getDate()).padStart(2, '0')}`;
+  const then = days.find((d) => d.day === key);
+
+  const row = (k, v, when) => `<div><span>${k}</span><span>${v}${when ? ` <span class="muted">${pretty(when)}</span>` : ''}</span></div>`;
+  $('almanac').innerHTML = [
+    hi && row('Hottest', `${num(hi.tempMax, 1)}${U.temp()}`, hi.day),
+    lo && row('Coldest', `${num(lo.tempMin, 1)}${U.temp()}`, lo.day),
+    gust && row('Peak gust', `${num(gust.gustMax, 1)} ${U.wind()}`, gust.day),
+    wet && row('Wettest day', `${num(wet.rain, 2)} ${U.precip()}`, wet.day),
+    zap && zap.strikes ? row('Most lightning', `${num(zap.strikes)} strikes`, zap.day) : '',
+    row('This day last year', then
+      ? `${num(then.tempMax, 0)}° / ${num(then.tempMin, 0)}°, ${num(then.rain, 2)} ${U.precip()}`
+      : 'no record yet'),
+    row('Collecting since', pretty(days[0].day)),
+    row('Days on record', num(days.length)),
+  ].filter(Boolean).join('');
+
+  drawMonthly();
+}
+
+// Rain by month, because it is the number a year of logging actually answers.
+function drawMonthly() {
+  const months = new Map();
+  for (const d of days) {
+    const m = d.day.slice(0, 7);
+    const acc = months.get(m) || { rain: 0, hi: null, lo: null };
+    acc.rain += d.rain || 0;
+    if (d.tempMax != null) acc.hi = acc.hi == null ? d.tempMax : Math.max(acc.hi, d.tempMax);
+    if (d.tempMin != null) acc.lo = acc.lo == null ? d.tempMin : Math.min(acc.lo, d.tempMin);
+    months.set(m, acc);
+  }
+  const data = [...months].map(([m, v]) => ({ x: new Date(`${m}-15T12:00:00`).getTime(), y: v.rain }));
+  chart($('c-monthly'), [{ data, type: 'bar', color: '#4fb8ff' }], { yMin: 0, digits: 2 });
+  $('board-monthly').textContent = `Rain by month (${U.precip()}) — ${months.size} month${months.size === 1 ? '' : 's'} on record`;
+}
+
+export function initAlmanac() {
+  window.addEventListener('wd:section', (e) => { if (e.detail === 'data') refreshAlmanac(); });
+  every('almanac', 3600, () => {
+    if ($('data').classList.contains('active')) refreshAlmanac();
+  });
+}
+
+// ponytail-lite self-check: the record picker and the SI conversion, the two places a wrong
+// answer would read as a plausible record.
+if (location.search.includes('selftest')) {
+  const rows = [{ day: '2025-01-01', tempMax: 10 }, { day: '2025-01-02', tempMax: null }, { day: '2025-01-03', tempMax: 30 }];
+  console.assert(extreme(rows, 'tempMax', (a, b) => a > b).day === '2025-01-03', 'almanac: hottest day');
+  console.assert(extreme(rows, 'tempMax', (a, b) => a < b).day === '2025-01-01', 'almanac: coldest ignores nulls');
+  console.assert(extreme([], 'tempMax', (a, b) => a > b) === null, 'almanac: empty log has no record');
+  const d = toDisplay({ day: '2025-01-01', tempMax: 0, gustMax: 10, rain: 25.4, strikes: 1, battMin: 2.6 });
+  const imperial = settings().units !== 'metric';
+  console.assert(Math.abs(d.tempMax - (imperial ? 32 : 0)) < 0.01, 'almanac: temp conversion');
+  console.assert(Math.abs(d.rain - (imperial ? 1 : 25.4)) < 0.01, 'almanac: rain conversion');
+}

--- a/site/js/api.js
+++ b/site/js/api.js
@@ -25,25 +25,48 @@ export function errHint(status, url) {
   return '';
 }
 
+// NWS answers every request with an ETag and honours If-None-Match, and the alert feed is polled
+// every 5 minutes to say "no active alerts" over and over. A 304 is a few hundred bytes and no
+// JSON parse. Bounded on purpose: only api.weather.gov URLs land here, and there are a handful.
+const etags = new Map();
+const cacheable = (url) => url.startsWith('https://api.weather.gov/');
+
 async function getJSON(url, opts) {
   // A wall tablet on a dropped Wi-Fi link otherwise leaves a fetch hanging for minutes and the
   // panel's next refresh never fires.
   let r;
+  const hit = cacheable(url) ? etags.get(url) : null;
   try {
-    r = await fetch(url, { signal: AbortSignal.timeout(15000), ...opts });
+    r = await fetch(url, {
+      signal: AbortSignal.timeout(15000),
+      ...opts,
+      ...(hit ? { headers: { 'If-None-Match': hit.etag, ...(opts?.headers || {}) } } : {}),
+    });
   } catch (e) {
     // the token rides in the query string — never let it into a notification body
     const where = url.split('?')[0];
     throw new Error(e.name === 'TimeoutError' ? `timed out (15s) — ${where}` : `network unreachable — ${where}`);
   }
+  if (r.status === 304 && hit) return structuredClone(hit.body);
   if (!r.ok) throw new Error(`${r.status} ${r.statusText} — ${url.split('?')[0]}${errHint(r.status, url)}`);
-  return r.json();
+  const body = await r.json();
+  const tag = cacheable(url) && r.headers.get('ETag');
+  // Callers mutate what they get back (deviceObs converts in place), so the cache keeps its own
+  // copy and hands out clones.
+  if (tag) etags.set(url, { etag: tag, body: structuredClone(body) });
+  return body;
 }
 
 // --- WeatherFlow Tempest ---
 
 export function station(id = settings().stationId) {
   return getJSON(`${SWD}/stations/${id}?${qs({ token: settings().token })}`);
+}
+
+// Every station the token can see. The setup wizard's whole job: a station ID is a number
+// nobody has memorised, and it is right there in the account.
+export function stations() {
+  return getJSON(`${SWD}/stations?${qs({ token: settings().token })}`);
 }
 
 export function stationObs(id = settings().stationId) {

--- a/site/js/app.js
+++ b/site/js/app.js
@@ -9,7 +9,12 @@ const DEFAULTS = {
   nearbyRadius: 0,   // miles; 0 = manual adds only, no airport scanning
   nearbyMetar: [],   // discovered airports, [{ id: 'KGVT', name }]
   nearbyExclude: [], // airports the user dismissed; the daily scan won't bring them back
-  notif: { severe: true, precip: true, lightning: true, wind: true, winter: true, changes: true },
+  notif: { severe: true, precip: true, lightning: true, wind: true, winter: true, changes: true, rule: true, station: true },
+  // User-built thresholds — see rules.js. [{ metric, op, value, durMin }]
+  rules: [],
+  // Push channels. All three dark until filled in, all three fire-and-forget: a dashboard must
+  // not stall on a phone notification.
+  ntfyUrl: 'https://ntfy.sh', ntfyTopic: '', webhookUrl: '',
   windGustAlert: 30, layoutLocked: false, hiddenTabs: [],
   // '' = whichever radar site is nearest the station. The camera itself lives in `wd.radar`,
   // written once a second by the embedded viewer — not here, where it would re-init the app.
@@ -17,9 +22,22 @@ const DEFAULTS = {
   // The inline viewer on the Desk. Heaviest thing the page loads, and on Linux it shares one
   // WebKit process with the whole Desk — see FIRST_RUN below.
   deskRadar: true,
+  // Bring the radar back on screen by itself when NWS has something serious out.
+  stormAuto: true,
+  // Stations the user can flip between from the header. One token, one set of preferences —
+  // only the identity fields change. [{ id, name, deviceId, lat, lon }]
+  savedStations: [],
   // Smart home: an MQTT broker to publish to, and a Home Assistant to read back from. Both dark
   // until filled in.
   mqttUrl: '', mqttUser: '', mqttPass: '', haUrl: '', haToken: '', haEntities: '',
+  // Look and feel. 'auto' theme follows the station's own sunrise/sunset, not the OS — a wall
+  // panel in a dark hallway wants the room's light, not the laptop's setting.
+  theme: 'dark', accent: '', fontScale: 1, density: 'normal', bigNumbers: false,
+  // Kiosk: seconds per tab when cycling (0 = off), and dimming through the night window.
+  kioskCycleSec: 0, nightDim: false,
+  // 'auto' | 'on' | 'off' — see ecoOn(). Auto is the point of the setting: the tablet on the wall
+  // should not need anyone to know it is the slow machine.
+  eco: 'auto',
 };
 
 // A fresh install starts with the Desk radar off: it is megabytes of wasm in the same WebKit
@@ -98,10 +116,13 @@ export function notify({ id, category = 'info', title, body }) {
     seen.add(id);
   }
   if (category !== 'info' && _settings.notif[category] === false) return;
-  notifLog.unshift({ t: Date.now(), id, category, title, body });
+  const entry = { t: Date.now(), id, category, title, body };
+  notifLog.unshift(entry);
   notifLog.splice(100);
   store('wd.notifLog', notifLog);
-  window.dispatchEvent(new CustomEvent('wd:notif'));
+  // detail is what home.js republishes to the broker — it needs no second copy of this logic
+  window.dispatchEvent(new CustomEvent('wd:notif', { detail: entry }));
+  if (category !== 'info') push(entry);
   const wrap = document.getElementById('notif-stack');
   const el = document.createElement('div');
   el.className = `notif notif-${category}`;
@@ -111,6 +132,32 @@ export function notify({ id, category = 'info', title, body }) {
   el.querySelector('.notif-x').onclick = () => el.remove();
   wrap.prepend(el);
   chime();
+}
+
+// Off the machine: a banner is no use to anyone who isn't looking at the dashboard.
+//
+// Security: the payloads carry the title, the body and the category and nothing else. The
+// Tempest token, the broker password and the station ID are deliberately absent — ntfy.sh is a
+// public relay by default and a webhook goes wherever the user pointed it.
+function push({ category, title, body }) {
+  const s = _settings;
+  if (s.ntfyTopic) {
+    fetch(`${s.ntfyUrl || 'https://ntfy.sh'}/${encodeURIComponent(s.ntfyTopic)}`, {
+      method: 'POST',
+      // ntfy takes the title as a header, and a header value cannot contain a line break —
+      // NWS headlines do.
+      headers: { Title: String(title).replace(/[\r\n]+/g, ' ').slice(0, 200), Tags: category },
+      body: body || title,
+    }).catch((e) => console.warn('ntfy:', e.message));
+  }
+  if (s.webhookUrl) {
+    fetch(s.webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title, body, category, t: Date.now() }),
+    }).catch((e) => console.warn('webhook:', e.message));
+  }
+  // MQTT rides the wd:notif event — home.js already owns the one connection.
 }
 
 let audioCtx;
@@ -128,20 +175,152 @@ function chime() {
 
 const jobs = new Map();
 
+// Jobs that pace themselves for a reason and must not be stretched: the clock is the display,
+// the UDP poll is the only live data a hub-only install has, and alerts are the one thing worth
+// a battery percent.
+// 'pace' itself is exempt for an obvious reason: stretched to 45 minutes it would be the thing
+// that never notices the night window closing.
+const PACE_EXEMPT = ['clock', 'udp', 'desk-alerts', 'pace', 'stale-sweep', 'kiosk', 'appearance'];
+
+// Set by desk.js when NWS has a Severe/Extreme alert out. Beats eco and night both.
+let storm = false;
+export function setStorm(on) {
+  if (storm === !!on) return;
+  storm = !!on;
+  repace();
+  window.dispatchEvent(new CustomEvent('wd:storm', { detail: storm }));
+}
+export const stormMode = () => storm;
+
+// Sunrise/sunset for the night window, filled from whatever forecast the Desk last got. No
+// import from desk.js — that would be a cycle, and the event is already on the wire.
+let sunTimes = null;
+window.addEventListener('wd:forecast', (e) => {
+  const d = e.detail?.forecast?.daily?.[0];
+  if (d?.sunrise && d?.sunset) sunTimes = { sunrise: d.sunrise, sunset: d.sunset };
+  repace();
+});
+
+export function ecoOn() {
+  if (_settings.eco === 'on') return true;
+  if (_settings.eco === 'off') return false;
+  // Two cores is a G Pad; four is an old Chromebook. Anything bigger can afford the full rate.
+  return (navigator.hardwareConcurrency || 8) <= 4;
+}
+
+// Quiet hours: sunset+1h to sunrise−1h, so the dashboard is back at full rate before anyone
+// looks at it. No forecast yet (or a station without sun times) falls back to the clock.
+export function isNight(now = new Date()) {
+  if (sunTimes) {
+    const t = now.getTime() / 1000;
+    return t > sunTimes.sunset + 3600 || t < sunTimes.sunrise - 3600;
+  }
+  const h = now.getHours();
+  return h >= 21 || h < 6;
+}
+
+// Seconds this job should actually run at.
+export function paceFor(name, base) {
+  if (storm) return name === 'desk-obs' || name === 'desk-alerts' ? Math.max(30, base / 2) : base;
+  if (PACE_EXEMPT.includes(name)) return base;
+  if (isNight()) return base * 3;
+  return ecoOn() ? base * 2 : base;
+}
+
+// Re-arm every job at its current pace. Deliberately does not run any of them: pacing is not a
+// refresh, and a settings save that re-paced ten jobs would fire ten fetches.
+function repace() {
+  for (const [name, job] of jobs) {
+    const secs = paceFor(name, job.base);
+    if (secs === job.paced) continue;
+    job.paced = secs;
+    clearInterval(job.id);
+    job.id = setInterval(job.run, secs * 1000);
+  }
+}
+
 // Nothing here is worth a request or a repaint while the window is hidden — a wall tablet with
 // its screen off would otherwise poll every source all night. Whatever came due in the meantime
 // runs once on the way back.
 export function every(name, seconds, fn) {
   const prev = jobs.get(name);
   if (prev) clearInterval(prev.id);
-  const job = { due: false };
+  const job = { due: false, base: seconds };
   job.run = async () => {
     if (document.hidden) { job.due = true; return; }
     try { await fn(); } catch (e) { console.warn(`job ${name}:`, e.message); }
   };
-  job.id = setInterval(job.run, seconds * 1000);
+  job.paced = paceFor(name, seconds);
+  job.id = setInterval(job.run, job.paced * 1000);
   jobs.set(name, job);
   job.run();
+}
+
+// The night window opens on its own; nothing else would notice.
+every('pace', 900, repace);
+window.addEventListener('wd:settings', () => { applyEco(); repace(); });
+
+// Eco is a class, and everything it costs is in CSS (the ticker is a 60s composited transform,
+// the transitions repaint on every hover).
+export function applyEco() {
+  document.body.classList.toggle('eco', ecoOn());
+}
+
+// --- appearance ---
+
+export function applyTheme() {
+  const s = _settings;
+  const light = s.theme === 'light' || (s.theme === 'auto' && !isNight());
+  document.documentElement.dataset.theme = light ? 'light' : 'dark';
+  document.documentElement.dataset.density = s.density || 'normal';
+  // A scale, not a size: everything on the page is already relative to the root font.
+  // `zoom`, not a root font-size: the stylesheet is in px throughout (deliberately — panel sizes
+  // are stored in px too), so a root font-size would scale almost nothing on screen. Zoom is
+  // supported by every engine this runs on, WebKitGTK and the G Pad's WebView included.
+  document.documentElement.style.zoom = Math.min(2, Math.max(0.7, +s.fontScale || 1));
+  document.body.classList.toggle('big-numbers', !!s.bigNumbers);
+  if (s.accent) document.documentElement.style.setProperty('--accent', s.accent);
+  else document.documentElement.style.removeProperty('--accent');
+  document.body.classList.toggle('dimmed', !!s.nightDim && isNight());
+}
+
+// --- kiosk ---
+//
+// Nobody is going to touch a panel on a wall, so the panel has to move on its own: cycle the
+// visible tabs, and nudge the whole page a couple of pixels each hour so a static header does
+// not etch itself into an OLED.
+let kioskAt = 0;
+function kioskStep() {
+  const secs = +_settings.kioskCycleSec || 0;
+  if (!secs) return;
+  const tabs = [...document.querySelectorAll('.tab')].filter((t) => t.style.display !== 'none');
+  if (tabs.length < 2) return;
+  kioskAt = (kioskAt + 1) % tabs.length;
+  tabs[kioskAt].click();
+}
+
+let burn = 0;
+function burnInStep() {
+  if (!+_settings.kioskCycleSec) { document.body.style.transform = ''; return; }
+  burn = (burn + 1) % 4;
+  document.body.style.transform = `translate(${[0, 2, 0, -2][burn]}px, ${[0, -2, 2, 0][burn]}px)`;
+}
+
+export function initKiosk() {
+  applyTheme();
+  // Re-registering replaces the old job, so a changed cycle time takes effect on save.
+  const secs = +_settings.kioskCycleSec || 0;
+  clearJob('kiosk');
+  if (secs) every('kiosk', secs, kioskStep);
+  every('appearance', 900, () => { applyTheme(); burnInStep(); });
+}
+
+// A job turned off in settings has to actually stop — every() only ever replaces.
+export function clearJob(name) {
+  const job = jobs.get(name);
+  if (!job) return;
+  clearInterval(job.id);
+  jobs.delete(name);
 }
 
 document.addEventListener('visibilitychange', () => {
@@ -207,6 +386,24 @@ export function applyTabs() {
     if (off && t.classList.contains('active')) bounce = true;
   });
   if (bounce) document.querySelector('.tab[data-section="desk"]').click();
+}
+
+// ponytail-lite self-check: the pace table, where a wrong branch means a dashboard that quietly
+// stops updating.
+if (location.search.includes('selftest')) {
+  const save = { ..._settings };
+  _settings.eco = 'on';
+  const night = isNight();
+  console.assert(paceFor('clock', 1) === 1, 'pace: exempt jobs untouched');
+  console.assert(paceFor('desk-forecast', 300) === (night ? 900 : 600), 'pace: eco/night factor');
+  setStorm(true);
+  console.assert(paceFor('desk-forecast', 300) === 300, 'pace: storm restores full rate');
+  console.assert(paceFor('desk-obs', 60) === 30, 'pace: storm halves obs');
+  console.assert(paceFor('desk-obs', 30) === 30, 'pace: storm never goes below 30s');
+  setStorm(false);
+  _settings.eco = 'off';
+  console.assert(paceFor('desk-forecast', 300) === (night ? 900 : 300), 'pace: eco off');
+  _settings = save;
 }
 
 export function fullscreen() {

--- a/site/js/boot.js
+++ b/site/js/boot.js
@@ -1,10 +1,13 @@
 // Wire the shell: settings drawer, diagnostics, nav, section modules.
-import { settings, saveSettings, configured, initNav, applyTabs, fullscreen, refreshAll, notify, load, store } from './app.js';
+import { settings, saveSettings, configured, initNav, applyTabs, fullscreen, refreshAll, notify, load, store, applyEco, initKiosk } from './app.js';
 import * as api from './api.js';
 import { initDesk, refreshDesk, refreshObs, refreshAlerts, refreshAqi } from './desk.js';
 import { initIntel, refreshModels, refreshNowcast } from './intel.js';
 import { initSignals, refreshSignals } from './signals.js';
 import { initBoards } from './boards.js';
+import { initAlmanac } from './almanac.js';
+import { initRules, renderRules } from './rules.js';
+import { initEnv } from './env.js';
 import { initPlaces, renderPlaces } from './places.js';
 import { initPro } from './pro.js';
 import { initLayout, snapshot, restore, hiddenPanels, unhide } from './layout.js';
@@ -20,10 +23,14 @@ const $ = (id) => document.getElementById(id);
 const SRV = window.__WD_SRV || '';
 let syncing = false;
 
+// The /public dashboard: same page, injected flag, credential-free config. Everything that
+// could change the host's settings — or read its token — is off from here on.
+const PUBLIC = !!window.__WD_PUBLIC;
+
 async function pullConfig() {
   syncing = true;
   try {
-    const r = await fetch(`${SRV}/config`, { signal: AbortSignal.timeout(2000) });
+    const r = await fetch(`${SRV}/${PUBLIC ? 'config-public' : 'config'}`, { signal: AbortSignal.timeout(2000) });
     if (!r.ok) return;
     const j = await r.json();
     if (j.settings) saveSettings(j.settings);
@@ -38,7 +45,7 @@ async function pullConfig() {
 // ponytail: server wins on load, last writer wins on save. No merge — every save pushes the
 // whole blob, so there is nothing to reconcile.
 function pushConfig() {
-  if (syncing) return;
+  if (syncing || PUBLIC) return;
   fetch(`${SRV}/config`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
@@ -60,6 +67,19 @@ function fillDrawer() {
   $('set-gust').value = s.windGustAlert;
   $('set-nearby-radius').value = s.nearbyRadius ?? 0;
   $('set-desk-radar').checked = !!s.deskRadar;
+  $('set-eco').value = s.eco || 'auto';
+  $('set-storm-auto').checked = !!s.stormAuto;
+  $('set-theme').value = s.theme || 'dark';
+  $('set-accent').value = s.accent || '#4fb8ff';
+  $('set-font').value = String(s.fontScale || 1);
+  $('set-density').value = s.density || 'normal';
+  $('set-big-numbers').checked = !!s.bigNumbers;
+  $('set-kiosk').value = s.kioskCycleSec || 0;
+  $('set-night-dim').checked = !!s.nightDim;
+  $('set-ntfy-topic').value = s.ntfyTopic || '';
+  $('set-ntfy-url').value = s.ntfyUrl || '';
+  $('set-webhook').value = s.webhookUrl || '';
+  renderRules();
   $('set-mqtt-url').value = s.mqttUrl;
   $('set-mqtt-user').value = s.mqttUser;
   $('set-mqtt-pass').value = s.mqttPass;
@@ -70,6 +90,7 @@ function fillDrawer() {
     c.checked = !(s.hiddenTabs || []).includes(c.dataset.tab);
   });
   renderHiddenPanels();
+  renderStations();
   fillSites();
 }
 
@@ -120,6 +141,19 @@ $('btn-save').onclick = async () => {
     windGustAlert: +$('set-gust').value || 30,
     nearbyRadius: +$('set-nearby-radius').value || 0,
     deskRadar: $('set-desk-radar').checked,
+    eco: $('set-eco').value,
+    stormAuto: $('set-storm-auto').checked,
+    theme: $('set-theme').value,
+    // The picker cannot express "no accent", so the default colour means the default.
+    accent: $('set-accent').value === '#4fb8ff' ? '' : $('set-accent').value,
+    fontScale: +$('set-font').value || 1,
+    density: $('set-density').value,
+    bigNumbers: $('set-big-numbers').checked,
+    kioskCycleSec: +$('set-kiosk').value || 0,
+    nightDim: $('set-night-dim').checked,
+    ntfyTopic: $('set-ntfy-topic').value.trim(),
+    ntfyUrl: $('set-ntfy-url').value.trim() || 'https://ntfy.sh',
+    webhookUrl: $('set-webhook').value.trim(),
     mqttUrl: $('set-mqtt-url').value.trim(),
     mqttUser: $('set-mqtt-user').value.trim(),
     mqttPass: $('set-mqtt-pass').value,
@@ -129,6 +163,7 @@ $('btn-save').onclick = async () => {
     hiddenTabs: [...document.querySelectorAll('#tab-toggles input')].filter((c) => !c.checked).map((c) => c.dataset.tab),
   });
   applyTabs();
+  initKiosk();
   if (!configured()) {
     notify({
       title: 'Setup incomplete',
@@ -144,7 +179,7 @@ $('btn-save').onclick = async () => {
   }
   loadDeskRadar();
   initDesk(); // idempotent: every() replaces existing jobs
-  initIntel(); initSignals(); initBoards(); initPro(); initLayout(); initUdp(); initHome();
+  initIntel(); initSignals(); initBoards(); initAlmanac(); initEnv(); initPro(); initLayout(); initUdp(); initHome();
 };
 
 // station meta fills name/lat/lon and the Tempest device id when blank
@@ -181,10 +216,128 @@ async function hydrateStation() {
     });
     fillDrawer();
     renderPlaces();
+    renderStations();
   } catch (e) {
     notify({ title: 'Station lookup failed', body: e.message });
   }
 }
+
+// --- first run ---
+//
+// The old first run opened the whole settings drawer at someone who had not yet decided to care.
+// This asks for one thing, then lists the stations the token can actually see — which is also
+// the fastest way to find out the token is wrong.
+async function wizardFind() {
+  const token = $('wiz-token').value.trim();
+  if (!token) return;
+  $('wiz-list').innerHTML = '<div class="muted">looking…</div>';
+  // Saved first: api.station() reads the token out of settings, and a token that turns out to
+  // be wrong is corrected in the same field a moment later.
+  saveSettings({ token });
+  try {
+    const list = (await api.stations()).stations || [];
+    if (!list.length) throw new Error('That token works but reaches no stations.');
+    $('wiz-list').innerHTML = list
+      .map((st, i) => `<button class="place-hit" data-wiz="${i}">${st.name} · ${st.location_item?.[0]?.name || st.station_id}</button>`)
+      .join('');
+    $('wiz-list').querySelectorAll('[data-wiz]').forEach((b) => {
+      b.onclick = async () => {
+        const st = list[+b.dataset.wiz];
+        saveSettings({ stationId: String(st.station_id) });
+        $('wizard').hidden = true;
+        await hydrateStation();
+        refreshAll();
+        for (const el of ['tenday', 'alerts', 'story', 'agree-verdict', 'changes', 'verify']) {
+          const node = $(el);
+          if (node && node.textContent.includes('Needs a Tempest token')) node.innerHTML = '<div class="muted">loading…</div>';
+        }
+      };
+    });
+  } catch (e) {
+    $('wiz-list').innerHTML = `<div class="fail">${e.message}</div>`;
+  }
+}
+
+$('btn-wiz-find').onclick = () => wizardFind();
+$('wiz-token').onkeydown = (e) => { if (e.key === 'Enter') wizardFind(); };
+$('btn-wiz-close').onclick = () => { $('wizard').hidden = true; };
+$('btn-wiz-demo').onclick = () => {
+  // Demo mode is not a fixture: it is the real dashboard on the keyless sources, pointed at
+  // whatever place the user searches for. Everything Tempest stays empty and says so.
+  $('wizard').hidden = true;
+  document.querySelector('.tab[data-section="signals"]')?.click();
+  fillDrawer();
+  openDrawer(true);
+  $('place-q').focus();
+  notify({ title: 'Demo mode', body: 'Search a city in Settings — forecasts, models and alerts work without a station.' });
+};
+
+// --- what's new ---
+//
+// A dashboard that gains a feature nobody notices has not gained a feature.
+const APP_VERSION = '2.0.0';
+function changelog() {
+  // Raw string, not store(): this is compared to a literal, and a JSON-quoted one never matches.
+  const seen = localStorage.getItem('wd.lastVersion');
+  if (seen === APP_VERSION) return;
+  try { localStorage.setItem('wd.lastVersion', APP_VERSION); } catch { /* full; nothing to do */ }
+  if (!seen) return; // a fresh install has nothing to be new since
+  notify({
+    title: `WeatherDesk ${APP_VERSION}`,
+    body: 'New: eco mode, observation log + almanac, custom alert rules with phone push, themes, '
+      + 'kiosk cycling, sun/moon and garden cards, station health, and a read-only /public page.',
+  });
+}
+
+// --- saved stations ---
+//
+// One token usually reaches several stations (a second house, a parent's Tempest, the club's).
+// Switching swaps the four identity fields and refetches; everything else — units, layout,
+// rules, broker — is the user's and stays put.
+function renderStations() {
+  const list = settings().savedStations || [];
+  const sel = $('station-switch');
+  sel.hidden = list.length < 2;
+  sel.innerHTML = list.map((s, i) => `<option value="${i}">${s.name || s.id}</option>`).join('');
+  const at = list.findIndex((s) => String(s.id) === String(settings().stationId));
+  if (at >= 0) sel.value = String(at);
+
+  $('station-list').innerHTML = list.length
+    ? list.map((s, i) => `<div class="row" style="margin:0">
+        <span class="place-hit" style="flex:1">${s.name || s.id}</span>
+        <button class="sig-x" data-station="${i}">×</button></div>`).join('')
+    : '<div class="muted" style="font-size:12px">No saved stations</div>';
+  $('station-list').querySelectorAll('[data-station]').forEach((b) => {
+    b.onclick = () => {
+      const next = [...(settings().savedStations || [])];
+      next.splice(+b.dataset.station, 1);
+      saveSettings({ savedStations: next });
+      renderStations();
+    };
+  });
+}
+
+async function switchStation(s) {
+  saveSettings({ stationId: String(s.id), deviceId: s.deviceId || '', lat: s.lat, lon: s.lon, stationName: s.name });
+  // The radar camera belongs to the station we just left.
+  store('wd.radar', null);
+  await hydrateStation();
+  refreshAll();
+}
+
+$('station-switch').onchange = (e) => {
+  const s = (settings().savedStations || [])[+e.target.value];
+  if (s) switchStation(s);
+};
+
+$('btn-station-save').onclick = () => {
+  const s = settings();
+  if (!s.stationId) return;
+  const list = (s.savedStations || []).filter((x) => String(x.id) !== String(s.stationId));
+  list.push({ id: String(s.stationId), name: s.stationName || s.stationId, deviceId: s.deviceId, lat: s.lat, lon: s.lon });
+  saveSettings({ savedStations: list });
+  renderStations();
+};
 
 // --- layout lock + presets ---
 //
@@ -224,6 +377,59 @@ $('btn-layout-save').onclick = () => {
   store('wd.layouts', { ...layouts(), [name]: snapshot() });
   $('layout-name').value = '';
   renderLayouts();
+};
+
+// --- backup / restore / raw history ---
+
+function download(name, blob) {
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(blob);
+  a.download = name;
+  a.click();
+  setTimeout(() => URL.revokeObjectURL(a.href), 1000);
+}
+
+$('btn-export').onclick = () => {
+  // The export is the whole settings blob, and that includes the Tempest API token and any
+  // broker password. Anyone the file is sent to can read the station. Say so before writing it.
+  if (!confirm('This file contains your Tempest API token and any MQTT/Home Assistant passwords in plain text. Keep it private?')) return;
+  download('weatherdesk-settings.json',
+    new Blob([JSON.stringify({ at: Date.now(), settings: settings(), layout: load('wd.layout', {}) }, null, 2)],
+      { type: 'application/json' }));
+};
+
+$('btn-import').onclick = () => $('import-file').click();
+
+$('import-file').onchange = async (e) => {
+  const file = e.target.files?.[0];
+  e.target.value = ''; // same file twice should still fire
+  if (!file) return;
+  try {
+    const j = JSON.parse(await file.text());
+    // Merged, not replaced: a backup from an older version is missing every key added since,
+    // and saveSettings over DEFAULTS is what fills those in.
+    if (j.settings) saveSettings(j.settings);
+    if (j.layout) restore(j.layout);
+    fillDrawer();
+    notify({ title: 'Settings imported', body: 'Reloading to apply.' });
+    pushConfig();
+    setTimeout(() => location.reload(), 800);
+  } catch (err) {
+    notify({ title: 'Import failed', body: err.message });
+  }
+};
+
+$('btn-csv').onclick = async () => {
+  try {
+    const r = await fetch(`${SRV}/history.csv`, { signal: AbortSignal.timeout(60000) });
+    if (!r.ok) throw new Error(`${r.status}`);
+    download('weatherdesk-history.csv', await r.blob());
+  } catch {
+    notify({
+      title: 'No observation log',
+      body: 'The raw history is kept by the desktop app on the machine that hears the hub.',
+    });
+  }
 };
 
 $('btn-diag').onclick = async () => {
@@ -310,6 +516,27 @@ window.addEventListener('message', (e) => {
   if (v && v.hookecho === 1) store('wd.radar', v);
 });
 
+// Storm mode: the one time the radar is worth its cost on a weak box is when a warning is out,
+// and that is exactly when nobody is going to be at the machine to switch it on. Restores the
+// user's own setting when the warning expires — a Desk that stayed changed after the storm
+// would be the app deciding what the dashboard looks like.
+let stormShowedRadar = false;
+window.addEventListener('wd:storm', (e) => {
+  if (!settings().stormAuto) return;
+  const panel = $('desk-radar');
+  if (!panel) return;
+  if (e.detail && panel.hidden) {
+    stormShowedRadar = true;
+    saveSettings({ deskRadar: true });
+    loadDeskRadar();
+    panel.scrollIntoView({ block: 'nearest' });
+  } else if (!e.detail && stormShowedRadar) {
+    stormShowedRadar = false;
+    saveSettings({ deskRadar: false });
+    loadDeskRadar();
+  }
+});
+
 // lazy-load the Lab iframe on first visit — full chrome there, it is the roomier view
 window.addEventListener('wd:section', (e) => {
   const f = $('lab-frame');
@@ -338,7 +565,7 @@ function loadDeskRadar() {
   if (f.src || loadDeskRadar.armed) return;
   // First run: the drawer is open and typing the token matters more than the map. Closing the
   // drawer (by saving, or by hand — a hub-only install has no token to type) calls back here.
-  if ($('drawer').classList.contains('open')) return;
+  if ($('drawer').classList.contains('open') || !$('wizard').hidden) return;
   loadDeskRadar.armed = true;
 
   const start = () => {
@@ -360,7 +587,45 @@ function loadDeskRadar() {
 
 await pullConfig();
 
+// A viewer cannot open the drawer, so a viewer cannot see or change anything the owner set. The
+// token is not in this page to begin with — the server never sent it.
+if (PUBLIC) {
+  document.body.classList.add('public');
+  $('btn-settings').hidden = true;
+  // Hidden, not removed: loadDeskRadar and the drawer helpers all reach for these nodes, and a
+  // public page is not the place to find out which ones. The fields are empty anyway — the
+  // server redacted every credential before it sent the config.
+  $('drawer').hidden = true;
+  $('btn-save').disabled = true;
+}
+
+applyEco();
+initKiosk();
+initRules();
 initNav();
+
+// --- keyboard ---
+//
+// A dashboard on a desk gets a keyboard, and the tabs are the only thing anyone reaches for.
+// Never while typing: the token field is one keystroke from being a tab switch otherwise.
+document.addEventListener('keydown', (e) => {
+  if (e.ctrlKey || e.altKey || e.metaKey) return;
+  const el = document.activeElement;
+  if (el && (el.tagName === 'INPUT' || el.tagName === 'SELECT' || el.tagName === 'TEXTAREA' || el.isContentEditable)) {
+    if (e.key === 'Escape') el.blur();
+    return;
+  }
+  if (e.key >= '1' && e.key <= '9') {
+    const tabs = [...document.querySelectorAll('.tab')].filter((t) => t.style.display !== 'none');
+    tabs[+e.key - 1]?.click();
+    return;
+  }
+  if (e.key === 'Escape') { openDrawer(false); $('shortcuts').hidden = true; loadDeskRadar(); return; }
+  if (e.key === '?') { $('shortcuts').hidden = !$('shortcuts').hidden; return; }
+  if (e.key === 'f') fullscreen();
+  else if (e.key === 'r') refreshAll();
+  else if (e.key === 's' && !PUBLIC) { fillDrawer(); openDrawer(true); }
+});
 initPlaces();
 // panel chrome doesn't depend on a token — wire it before the data path so an unconfigured
 // dashboard is still arrangeable
@@ -368,9 +633,11 @@ initLayout();
 applyLock();
 renderLayouts();
 
-if (!configured()) {
-  fillDrawer();
-  openDrawer(true);
+changelog();
+
+if (!configured() && !PUBLIC) {
+  $('wizard').hidden = false;
+  $('wiz-token').focus();
   // UDP-only mode: a desktop install with a hub on the LAN has real local data with no token at
   // all, so the modules start either way. Every refresh job early-returns without a token, so an
   // unconfigured init is a handful of no-ops.
@@ -382,7 +649,7 @@ if (!configured()) {
 // lat/lon must land before the open-meteo/NWS jobs start (resolves immediately when unconfigured)
 hydrateStation().then(() => {
   loadDeskRadar();
-  initDesk(); initIntel(); initSignals(); initBoards(); initPro(); initUdp(); initHome();
+  initDesk(); initIntel(); initSignals(); initBoards(); initAlmanac(); initEnv(); initPro(); initUdp(); initHome();
 });
 
 // ponytail-lite self-check: `?selftest` asserts the site maths and the link the viewer is handed.

--- a/site/js/charts.js
+++ b/site/js/charts.js
@@ -1,5 +1,12 @@
 // Minimal canvas chart helper. series: [{data:[{x,y}], color, type:'line'|'bar'}]
+// Canvas can't read CSS variables, so the theme has to be handed to it. Read per draw: a chart
+// is redrawn whenever anything changes, and a cached palette would be the one thing still dark
+// after a switch to the light theme.
+const css = (name, fallback) =>
+  getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback;
+
 export function chart(canvas, series, opts = {}) {
+  const MUTED = css('--muted', '#8ea0b5'), LINE = css('--line', '#253141');
   const dpr = window.devicePixelRatio || 1;
   const w = canvas.clientWidth || 300, h = canvas.clientHeight || 140;
   canvas.width = w * dpr; canvas.height = h * dpr;
@@ -9,7 +16,7 @@ export function chart(canvas, series, opts = {}) {
 
   const pts = series.flatMap((s) => s.data).filter((p) => p.y != null && !Number.isNaN(p.y));
   if (!pts.length) {
-    c.fillStyle = '#8ea0b5'; c.font = '12px system-ui';
+    c.fillStyle = MUTED; c.font = '12px system-ui';
     c.fillText('no data', 8, h / 2);
     return;
   }
@@ -23,7 +30,7 @@ export function chart(canvas, series, opts = {}) {
   const py = (y) => padT + (1 - (y - y0) / (y1 - y0)) * (h - padT - padB);
 
   // gridlines + y labels
-  c.strokeStyle = '#253141'; c.fillStyle = '#8ea0b5'; c.font = '10px system-ui'; c.lineWidth = 1;
+  c.strokeStyle = LINE; c.fillStyle = MUTED; c.font = '10px system-ui'; c.lineWidth = 1;
   for (let i = 0; i <= 3; i++) {
     const y = y0 + ((y1 - y0) * i) / 3, yy = Math.round(py(y)) + 0.5;
     c.beginPath(); c.moveTo(padL, yy); c.lineTo(w - padR, yy); c.stroke();
@@ -46,7 +53,7 @@ export function chart(canvas, series, opts = {}) {
   }
 
   // x labels: first + last
-  c.fillStyle = '#8ea0b5';
+  c.fillStyle = MUTED;
   const fmt = opts.xFormat || ((x) => new Date(x).toLocaleDateString([], { month: 'numeric', day: 'numeric' }));
   c.fillText(fmt(x0), padL, h - 4);
   const last = fmt(x1);

--- a/site/js/desk.js
+++ b/site/js/desk.js
@@ -1,6 +1,6 @@
 // 01 Desk — current conditions, near-term forecast, alerts, AQI.
 import * as api from './api.js';
-import { settings, coords, configured, U, num, timeStr, dayStr, notify, every, stamp, store, load } from './app.js';
+import { settings, coords, configured, U, num, timeStr, dayStr, notify, every, stamp, store, load, setStorm } from './app.js';
 
 // Last-good copies of the two payloads the Desk can't render without. An outage that spans a
 // reload would otherwise leave the whole page at `--`; in-session failures already keep the DOM.
@@ -95,6 +95,9 @@ export async function refreshAlerts() {
       }).join('')
     : '<div class="muted">No active alerts</div>';
   stamp('alerts', 300);
+  // Storm mode: while something serious is out, every panel goes back to full rate whatever eco
+  // and the hour say. This is the one time the dashboard is being watched.
+  setStorm(feats.some((f) => ['Severe', 'Extreme'].includes(f.properties?.severity)));
   feats.forEach((f) => notify({
     id: f.properties.id, category: 'severe',
     title: f.properties.event, body: f.properties.headline || '',

--- a/site/js/env.js
+++ b/site/js/env.js
@@ -1,0 +1,323 @@
+// 07 Environment — sun and moon detail, fire/dryness, the garden, and the station's own health.
+//
+// Everything here is either arithmetic on numbers the dashboard already has, or a keyless
+// endpoint. No new token, no new account: the point of these cards is that they cost nothing to
+// keep on screen all day.
+import { settings, coords, U, num, notify, every, stamp } from './app.js';
+import { forecast as deskForecast } from './desk.js';
+import { OBS } from './api.js';
+
+const $ = (id) => document.getElementById(id);
+const rad = Math.PI / 180;
+
+// --- solar position (NOAA low-precision equations, good to about a minute) ---
+
+// Sun altitude in degrees, for a moment and a place. Golden hour and blue hour are just two
+// bands of this number, so one function answers both and neither needs a table.
+export function solarAltitude(date, lat, lon) {
+  const d = date.getTime() / 86400000 - 10957.5; // days since J2000.0
+  const L = (280.460 + 0.9856474 * d) % 360;
+  const g = ((357.528 + 0.9856003 * d) % 360) * rad;
+  const lambda = (L + 1.915 * Math.sin(g) + 0.020 * Math.sin(2 * g)) * rad;
+  const eps = (23.439 - 0.0000004 * d) * rad;
+  const ra = Math.atan2(Math.cos(eps) * Math.sin(lambda), Math.cos(lambda)) / rad;
+  const dec = Math.asin(Math.sin(eps) * Math.sin(lambda));
+  const gmst = (18.697374558 + 24.06570982441908 * d) % 24;
+  const ha = ((gmst * 15 + lon - ra + 540) % 360 - 180) * rad;
+  const phi = lat * rad;
+  return Math.asin(Math.sin(phi) * Math.sin(dec) + Math.cos(phi) * Math.cos(dec) * Math.cos(ha)) / rad;
+}
+
+// When the sun last crossed `deg` on its way through `hours` either side of `around`. Scanned a
+// minute at a time rather than solved: the inverse has three special cases (polar day, polar
+// night, an altitude the sun never reaches) and the scan has none.
+export function crossing(around, lat, lon, deg, rising) {
+  const step = 60000;
+  let prev = null;
+  for (let t = around.getTime() - 3 * 3600000; t <= around.getTime() + 3 * 3600000; t += step) {
+    const alt = solarAltitude(new Date(t), lat, lon);
+    if (prev != null) {
+      const up = alt > prev;
+      if (up === rising && (prev - deg) * (alt - deg) <= 0) return new Date(t);
+    }
+    prev = alt;
+  }
+  return null;
+}
+
+const hhmm = (d) => (d ? d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' }) : '--');
+
+function renderSky() {
+  const fc = deskForecast();
+  const c = coords();
+  if (!fc || c.lat == null) return;
+  const [today, tomorrow] = fc.forecast.daily;
+  if (!today?.sunrise) return;
+
+  const sunrise = new Date(today.sunrise * 1000);
+  const sunset = new Date(today.sunset * 1000);
+  // Golden hour ends at 6° up in the morning and starts at 6° up in the evening; below the
+  // horizon to -4° is the blue hour on either side.
+  const morningGolden = crossing(sunrise, c.lat, c.lon, 6, true);
+  const eveningGolden = crossing(sunset, c.lat, c.lon, 6, false);
+
+  const len = today.sunset - today.sunrise;
+  const nextLen = tomorrow?.sunset ? tomorrow.sunset - tomorrow.sunrise : null;
+  const delta = nextLen == null ? null : nextLen - len;
+  const mins = (s) => `${Math.floor(s / 3600)}h ${Math.round((s % 3600) / 60)}m`;
+
+  const rows = [
+    ['Sunrise', hhmm(sunrise)],
+    ['Golden hour ends', hhmm(morningGolden)],
+    ['Golden hour starts', hhmm(eveningGolden)],
+    ['Sunset', hhmm(sunset)],
+    ['Daylight', mins(len)],
+    delta == null ? null
+      : ['Tomorrow', `${delta >= 0 ? '+' : '−'}${Math.abs(Math.round(delta / 60))} min`],
+    moonTimes ? ['Moonrise', hhmm(moonTimes.rise)] : null,
+    moonTimes ? ['Moonset', hhmm(moonTimes.set)] : null,
+  ].filter(Boolean);
+  $('sky').innerHTML = rows.map(([k, v]) => `<div><span>${k}</span><span>${v}</span></div>`).join('');
+  stamp('sky', 3600);
+}
+
+// --- moon rise/set: MET Norway, keyless, once a day ---
+//
+// The phase and illumination are already worked out locally in pro.js; only the rise and set
+// times want ephemerides, and one request a day is cheaper than carrying Meeus.
+let moonTimes = null;
+async function loadMoon() {
+  const c = coords();
+  if (c.lat == null) return;
+  const day = new Date().toISOString().slice(0, 10);
+  const off = -new Date().getTimezoneOffset();
+  const sign = off < 0 ? '-' : '+';
+  const offset = `${sign}${String(Math.floor(Math.abs(off) / 60)).padStart(2, '0')}:${String(Math.abs(off) % 60).padStart(2, '0')}`;
+  const url = `https://api.met.no/weatherapi/sunrise/3.0/moon?lat=${(+c.lat).toFixed(4)}&lon=${(+c.lon).toFixed(4)}&date=${day}&offset=${encodeURIComponent(offset)}`;
+  const r = await fetch(url, { signal: AbortSignal.timeout(15000) });
+  if (!r.ok) throw new Error(`${r.status}`);
+  const p = (await r.json()).properties || {};
+  moonTimes = {
+    rise: p.moonrise?.time ? new Date(p.moonrise.time) : null,
+    set: p.moonset?.time ? new Date(p.moonset.time) : null,
+  };
+  renderSky();
+}
+
+// --- fire weather and dryness ---
+//
+// Red flag comes out of the NWS alert feed the Desk already polls — a second request for the
+// same JSON would be a second chance to be rate-limited.
+//
+// ponytail: no US Drought Monitor. Its county API sends no Access-Control-Allow-Origin (checked
+// 2026-08-17) and the one CORS-enabled file it publishes is a 27 MB national GeoJSON, which is
+// not something a 2013 tablet is going to parse. Dryness here is measured from this station's
+// own rain log instead, which is the number that actually applies to this garden.
+let dryness = null;
+export function drynessFrom(days) {
+  if (!days.length) return null;
+  const last30 = days.slice(-30);
+  const total = last30.reduce((a, d) => a + (d.rain || 0), 0);
+  let since = 0;
+  for (let i = days.length - 1; i >= 0 && !(days[i].rain > 0); i--) since++;
+  return { total, since, days: last30.length };
+}
+
+function renderFire() {
+  const alerts = [...document.querySelectorAll('#alerts .alert-head')]
+    .map((el) => el.textContent)
+    .filter((t) => /red flag|fire weather/i.test(t));
+  const rows = [];
+  if (alerts.length) rows.push(['Fire weather', `<span class="fail">${alerts[0].split(' ')[0]} active</span>`]);
+  else rows.push(['Fire weather', 'no watches or warnings']);
+  if (dryness) {
+    rows.push([`Rain · last ${dryness.days} days`, `${num(dryness.total, 2)} ${U.precip()}`]);
+    rows.push(['Days since rain', num(dryness.since)]);
+  }
+  $('fire').innerHTML = rows.map(([k, v]) => `<div><span>${k}</span><span>${v}</span></div>`).join('');
+}
+
+// --- garden ---
+
+// Growing degree days, base 50°F / 10°C — the standard for corn, tomatoes and most of what
+// anyone with a Tempest is actually growing. Capped at 86°F the same way the model is: plants
+// stop gaining above it, and an August heatwave would otherwise invent a month of growth.
+export function gdd(dailyC) {
+  const base = 10, cap = 30;
+  let sum = 0;
+  for (const d of dailyC) {
+    if (d.tempMin == null || d.tempMax == null) continue;
+    const hi = Math.min(d.tempMax, cap), lo = Math.max(Math.min(d.tempMin, cap), 0);
+    sum += Math.max(0, (hi + lo) / 2 - base);
+  }
+  return sum;
+}
+
+let garden = { gddC: null, et0: null, rain7: null };
+
+function renderGarden() {
+  const metric = settings().units === 'metric';
+  const rows = [];
+  if (garden.gddC != null) {
+    // GDD is quoted in whatever degree the user reads; the Fahrenheit scale is 1.8× the Celsius one.
+    rows.push([`Growing degree days · base ${metric ? '10°C' : '50°F'}`, num(garden.gddC * (metric ? 1 : 1.8))]);
+  }
+  if (garden.et0 != null) {
+    const et = garden.et0 * (metric ? 1 : 1 / 25.4);
+    const rain = (garden.rain7 || 0) * (metric ? 1 : 1 / 25.4);
+    const need = Math.max(0, et - rain);
+    rows.push(['Evaporation · 7 days', `${num(et, 2)} ${U.precip()}`]);
+    rows.push(['Rain · 7 days', `${num(rain, 2)} ${U.precip()}`]);
+    rows.push(['Watering shortfall', need > 0.01
+      ? `<span class="warn">${num(need, 2)} ${U.precip()}</span>`
+      : '<span class="ok">none — rain covered it</span>']);
+  }
+  $('garden').innerHTML = rows.length
+    ? rows.map(([k, v]) => `<div><span>${k}</span><span>${v}</span></div>`).join('')
+    : '<div class="muted">Collecting.</div>';
+  stamp('garden', 3600);
+}
+
+async function loadGarden() {
+  const c = coords();
+  if (c.lat == null) return;
+  // ET₀ is the FAO reference evapotranspiration — how much water the last week took out of the
+  // ground. Paired with the rain that went in, it is the whole of "does the lawn need watering".
+  const r = await fetch('https://api.open-meteo.com/v1/forecast'
+    + `?latitude=${c.lat}&longitude=${c.lon}&daily=et0_fao_evapotranspiration,precipitation_sum`
+    + '&past_days=7&forecast_days=1&timezone=auto', { signal: AbortSignal.timeout(15000) });
+  if (!r.ok) throw new Error(`${r.status}`);
+  const j = await r.json();
+  const sum = (a) => (a || []).slice(0, 7).reduce((x, y) => x + (y || 0), 0);
+  garden.et0 = sum(j.daily?.et0_fao_evapotranspiration);
+  garden.rain7 = sum(j.daily?.precipitation_sum);
+  renderGarden();
+}
+
+// The season's growing degree days come out of the app's own log, which is the only record that
+// goes back to spring. No log (browser or Android install) simply leaves the row off.
+async function loadSeason() {
+  const tz = -new Date().getTimezoneOffset();
+  const r = await fetch(`${window.__WD_SRV || ''}/history/daily?tz=${tz}`, { signal: AbortSignal.timeout(10000) });
+  if (!r.ok) throw new Error(`${r.status}`);
+  const days = await r.json(); // SI
+  const yearStart = `${new Date().getFullYear()}-01-01`;
+  garden.gddC = gdd(days.filter((d) => d.day >= yearStart));
+  dryness = drynessFrom(days);
+  renderGarden();
+  renderFire();
+}
+
+// --- device health ---
+
+// sensor_status is a bitfield; the hub reports it every minute and nothing else in the app looks
+// at it. A failed haptic rain sensor is otherwise a rain total that quietly stays at zero.
+const FAULTS = [
+  [0x00000001, 'lightning sensor failed'],
+  [0x00000002, 'lightning noise'],
+  [0x00000004, 'lightning disturber'],
+  [0x00000008, 'pressure sensor failed'],
+  [0x00000010, 'temperature sensor failed'],
+  [0x00000020, 'humidity sensor failed'],
+  [0x00000040, 'wind sensor failed'],
+  [0x00000080, 'rain sensor failed'],
+  [0x00000100, 'light/UV sensor failed'],
+];
+
+export const faults = (bits) => FAULTS.filter(([m]) => bits & m).map(([, name]) => name);
+
+// Below this the Tempest starts shedding sensors to save itself — the wind and lightning go
+// first, and the readings simply stop rather than erroring.
+const LOW_VOLTS = 2.355;
+
+let lastObsAt = 0;
+window.addEventListener('wd:ws-obs', (e) => { lastObsAt = (e.detail[OBS.time] || 0) * 1000; });
+window.addEventListener('wd:obs', (e) => { lastObsAt = (e.detail.timestamp || 0) * 1000; });
+
+function renderHealth(st) {
+  const rows = [];
+  const v = st?.voltage;
+  if (v != null) {
+    rows.push(['Battery', `<span class="${v < LOW_VOLTS ? 'fail' : 'ok'}">${num(v, 2)} V</span>`]);
+  }
+  if (st?.rssi != null) rows.push(['Sensor signal', `${num(st.rssi)} dBm`]);
+  if (st?.hub_rssi != null) rows.push(['Hub signal', `${num(st.hub_rssi)} dBm`]);
+  if (st?.uptime != null) rows.push(['Uptime', `${num(st.uptime / 86400, 1)} days`]);
+  const bad = faults(st?.sensor_status || 0);
+  rows.push(['Sensors', bad.length ? `<span class="fail">${bad.join(', ')}</span>` : '<span class="ok">all reporting</span>']);
+  if (lastObsAt) {
+    const mins = (Date.now() - lastObsAt) / 60000;
+    rows.push(['Last report', mins > 30 ? `<span class="fail">${num(mins)} min ago</span>` : `${num(mins)} min ago`]);
+  }
+  $('health').innerHTML = rows.length
+    ? rows.map(([k, val]) => `<div><span>${k}</span><span>${val}</span></div>`).join('')
+    : '<div class="muted">Needs the desktop app and a hub on the same network.</div>';
+  stamp('health', 300);
+}
+
+// One warning per condition per day: a flat battery is not news every minute, and the whole
+// point of the category toggle is that someone chose to hear about it.
+function healthAlerts(st) {
+  const day = new Date().toDateString();
+  if (st?.voltage != null && st.voltage < LOW_VOLTS) {
+    notify({
+      id: `batt-${day}`, category: 'station',
+      title: 'Station battery low',
+      body: `${num(st.voltage, 2)} V — the Tempest starts switching sensors off below ${LOW_VOLTS} V.`,
+    });
+  }
+  for (const f of faults(st?.sensor_status || 0)) {
+    if (/noise|disturber/.test(f)) continue; // normal weather, not a fault
+    notify({ id: `fault-${f}-${day}`, category: 'station', title: 'Station sensor fault', body: f });
+  }
+}
+
+let lastStatus = null;
+window.addEventListener('wd:device-status', (e) => {
+  lastStatus = e.detail;
+  renderHealth(lastStatus);
+  healthAlerts(lastStatus);
+});
+
+export function initEnv() {
+  renderHealth(lastStatus);
+  window.addEventListener('wd:forecast', renderSky);
+  renderSky();
+  every('env-moon', 21600, () => loadMoon().catch(() => {}));
+  every('env-garden', 21600, () => loadGarden().catch(() => {}));
+  every('env-season', 3600, () => loadSeason().catch(() => {}));
+  every('env-fire', 900, renderFire);
+  every('env-health', 300, () => {
+    // Station offline is the one health check that has to run without a packet arriving.
+    if (!lastObsAt) return;
+    renderHealth(lastStatus);
+    if ((Date.now() - lastObsAt) / 60000 > 30) {
+      notify({
+        id: `offline-${Math.floor(Date.now() / 3600000)}`, category: 'station',
+        title: 'Station has stopped reporting',
+        body: `No observation for ${num((Date.now() - lastObsAt) / 60000)} minutes.`,
+      });
+    }
+  });
+}
+
+// ponytail-lite self-check: the solar maths and the two aggregates. A golden hour an hour out
+// looks perfectly reasonable on screen, which is exactly why it needs an assert.
+if (location.search.includes('selftest')) {
+  // Greenwich, equinox noon UTC: the sun is about 90° − latitude up.
+  const alt = solarAltitude(new Date(Date.UTC(2025, 2, 20, 12, 0)), 51.48, 0);
+  console.assert(Math.abs(alt - 38.5) < 1.5, 'env: solar altitude at Greenwich noon', alt);
+  const night = solarAltitude(new Date(Date.UTC(2025, 2, 20, 0, 0)), 51.48, 0);
+  console.assert(night < 0, 'env: sun is down at midnight');
+  const cross = crossing(new Date(Date.UTC(2025, 2, 20, 6, 0)), 51.48, 0, 6, true);
+  console.assert(cross && cross.getTime() > Date.UTC(2025, 2, 20, 6, 0), 'env: morning 6° crossing found');
+  // 20/30°C day = mean 25, base 10 => 15 GDD; a freezing day contributes nothing.
+  console.assert(gdd([{ tempMin: 20, tempMax: 30 }]) === 15, 'env: gdd base 10');
+  console.assert(gdd([{ tempMin: -5, tempMax: 5 }]) === 0, 'env: cold day earns no gdd');
+  console.assert(gdd([{ tempMin: 20, tempMax: 40 }]) === 15, 'env: gdd caps the high at 30');
+  console.assert(gdd([{ tempMin: null, tempMax: 30 }]) === 0, 'env: partial day skipped');
+  const dry = drynessFrom([{ rain: 5 }, { rain: 0 }, { rain: 0 }]);
+  console.assert(dry.since === 2 && dry.total === 5, 'env: dryness counts back to the last rain');
+  console.assert(faults(0) .length === 0, 'env: clean status has no faults');
+  console.assert(faults(0x40).includes('wind sensor failed'), 'env: wind fault decoded');
+}

--- a/site/js/home.js
+++ b/site/js/home.js
@@ -122,6 +122,14 @@ export function initHome() {
 }
 
 window.addEventListener('wd:ws-obs', (e) => publishObs(e.detail));
+
+// Every banner the dashboard raises, on one topic, for automations to hang off. Not retained:
+// an alert replayed on every broker reconnect would fire the same automation forever.
+window.addEventListener('wd:notif', (e) => {
+  const n = e.detail;
+  if (!n || n.category === 'info') return;
+  client?.publish(`${base()}/alert`, JSON.stringify({ title: n.title, body: n.body, category: n.category, t: n.t }));
+});
 window.addEventListener('wd:ws-strike', (e) => {
   // [epoch, distance km, energy]
   event('lightning', { event_type: 'strike', distance_km: e.detail[1] });

--- a/site/js/pro.js
+++ b/site/js/pro.js
@@ -1,7 +1,7 @@
 // Desk layout matching myWeatherDesk: sky hero, signal ticker, trend strip,
 // 48h combined chart, day cards, dial gauges. Driven by the wd:forecast event.
 import * as api from './api.js';
-import { settings, coords, U, num, timeStr, deg2compass, every } from './app.js';
+import { settings, coords, U, num, timeStr, deg2compass, every, ecoOn } from './app.js';
 import { forecast as deskForecast } from './desk.js';
 import * as icon from './icons.js';
 import { initLayout } from './layout.js';
@@ -416,9 +416,14 @@ export function initPro() {
   every('pro-history', 300, async () => { await loadHistory(); renderPro(); });
   every('pro-consensus', 900, async () => { await loadConsensus(); renderPro(); });
   every('pro-qpf', 1800, async () => { await loadQpf(); renderPro(); });
-  every('clock', 1, () => {
+  // A second hand is a repaint a second, forever — the single most expensive idle thing on the
+  // page. In eco the seconds go and so does 29 of every 30 repaints.
+  const eco = ecoOn();
+  every('clock', eco ? 30 : 1, () => {
     const d = new Date();
-    $('clock-time').textContent = d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit', second: '2-digit' });
+    $('clock-time').textContent = d.toLocaleTimeString([], eco
+      ? { hour: 'numeric', minute: '2-digit' }
+      : { hour: 'numeric', minute: '2-digit', second: '2-digit' });
     $('clock-date').textContent = d.toLocaleDateString([], { weekday: 'short', month: 'short', day: 'numeric' });
   });
   every('pro-clock', 60, () => { if (deskForecast()) renderHero(deskForecast()); });

--- a/site/js/rules.js
+++ b/site/js/rules.js
@@ -1,0 +1,201 @@
+// 06 Alert rules — user-built thresholds on live readings.
+//
+// The built-in alerts (NWS severe, high wind, rain start) answer the questions everyone has.
+// This is for the ones only one household has: "tell me when the greenhouse hits 95", "tell me
+// when the wind has been over 20 for a quarter of an hour".
+//
+// Fires through notify(), so a rule reaches every channel the banners already reach — the ntfy
+// topic, the webhook, the broker — with no per-channel code here.
+import { settings, saveSettings, notify, num, U } from './app.js';
+import { OBS } from './api.js';
+
+const $ = (id) => document.getElementById(id);
+
+// key -> [label, unit fn, digits]. The evaluator only ever sees this key set, so a saved rule
+// naming a metric that no longer exists is skipped, not a crash.
+export const METRICS = {
+  temp: ['Temperature', U.temp, 1],
+  dew: ['Dew point', U.temp, 1],
+  gust: ['Wind gust', U.wind, 1],
+  wind: ['Wind average', U.wind, 1],
+  rh: ['Humidity', () => '%', 0],
+  rain: ['Rain rate', () => `${U.precip()}/h`, 2],
+  uv: ['UV index', () => '', 1],
+  strikes3h: ['Lightning strikes · 3h', () => '', 0],
+  press3h: ['Pressure change · 3h', U.press, 2],
+};
+
+export const OPS = { '>': 'above', '<': 'below' };
+
+// --- reading the two obs shapes we get ---
+
+const metric = () => settings().units === 'metric';
+const toTemp = (c) => (c == null ? null : metric() ? c : c * 9 / 5 + 32);
+const toWind = (ms) => (ms == null ? null : ms * (metric() ? 3.6 : 2.23694));
+const toRain = (mm) => (mm == null ? null : mm * (metric() ? 1 : 1 / 25.4));
+const toPress = (mb) => (mb == null ? null : mb * (metric() ? 1 : 0.02953));
+
+// The REST station obs, already in display units.
+function fromStation(o) {
+  return {
+    temp: o.air_temperature, dew: o.dew_point, gust: o.wind_gust, wind: o.wind_avg,
+    rh: o.relative_humidity, rain: o.precip_accum_last_1hr, uv: o.uv,
+    _press: o.station_pressure ?? o.barometric_pressure, _strikes: o.lightning_strike_count ?? 0,
+    _t: o.timestamp || Math.floor(Date.now() / 1000),
+  };
+}
+
+// The UDP/websocket obs_st tuple, SI. Rain there is the accumulation for one report interval —
+// scale it to the hour so the threshold means what the label says.
+function fromTuple(t) {
+  const mins = t[OBS.reportInterval] || 1;
+  return {
+    temp: toTemp(t[OBS.temp]), dew: null, gust: toWind(t[OBS.windGust]), wind: toWind(t[OBS.windAvg]),
+    rh: t[OBS.rh], rain: toRain(t[OBS.rain] == null ? null : t[OBS.rain] * (60 / mins)), uv: t[OBS.uv],
+    _press: toPress(t[OBS.press]), _strikes: t[OBS.strikes] || 0,
+    _t: t[OBS.time] || Math.floor(Date.now() / 1000),
+  };
+}
+
+// Three hours of samples, for the two metrics that are a difference rather than a reading.
+// Bounded by time, not count: a hub reporting every minute and a REST poll every ten both land
+// here and neither should be able to grow it without limit.
+const ring = [];
+function derive(m) {
+  ring.push({ t: m._t, press: m._press, strikes: m._strikes });
+  const cutoff = m._t - 3 * 3600;
+  while (ring.length && ring[0].t < cutoff) ring.shift();
+  const first = ring.find((r) => r.press != null);
+  m.press3h = first && m._press != null ? m._press - first.press : null;
+  // Tempest reports strikes per interval, so 3h worth is a sum, not a difference.
+  m.strikes3h = ring.reduce((a, r) => a + (r.strikes || 0), 0);
+  return m;
+}
+
+// --- evaluation ---
+
+// Per-rule state: when the condition first became true, and whether it has already fired.
+const state = new Map();
+
+const holds = (v, op, target) => (op === '>' ? v > target : v < target);
+
+// Re-arm at 90% of the threshold (110% for a "below" rule): a gust hovering on 30 mph would
+// otherwise notify on every single report. Same latch the gust alert in home.js uses.
+const rearmed = (v, op, target) => (op === '>' ? v < target * 0.9 : v > target * 1.1);
+
+export function evaluate(m, rules = settings().rules || [], nowSec = Math.floor(Date.now() / 1000)) {
+  const fired = [];
+  rules.forEach((r, i) => {
+    const spec = METRICS[r.metric];
+    const v = m[r.metric];
+    if (!spec || v == null || Number.isNaN(v)) return;
+    const st = state.get(i) || { since: null, latched: false };
+    if (!holds(v, r.op, r.value)) {
+      st.since = null;
+      if (st.latched && rearmed(v, r.op, r.value)) st.latched = false;
+      state.set(i, st);
+      return;
+    }
+    st.since ??= nowSec;
+    if (!st.latched && nowSec - st.since >= (r.durMin || 0) * 60) {
+      st.latched = true;
+      fired.push({ rule: r, value: v });
+    }
+    state.set(i, st);
+  });
+  return fired;
+}
+
+function run(m) {
+  for (const { rule, value } of evaluate(derive(m))) {
+    const [label, unit, digits] = METRICS[rule.metric];
+    notify({
+      category: 'rule',
+      title: `${label} ${OPS[rule.op]} ${num(rule.value, digits)}${unit()}`,
+      body: `Now ${num(value, digits)}${unit()}${rule.durMin ? ` for ${rule.durMin} min` : ''}`,
+    });
+  }
+}
+
+window.addEventListener('wd:obs', (e) => run(fromStation(e.detail)));
+window.addEventListener('wd:ws-obs', (e) => run(fromTuple(e.detail)));
+
+// --- built-in: frost ---
+//
+// Not a rule the user has to think to write. The forecast low, not the reading: a warning that
+// arrives when it is already freezing is not a warning.
+window.addEventListener('wd:forecast', (e) => {
+  const days = e.detail?.forecast?.daily?.slice(0, 2) || [];
+  const limit = settings().units === 'metric' ? 1 : 34;
+  for (const d of days) {
+    if (d.air_temp_low == null || d.air_temp_low > limit) continue;
+    notify({
+      id: `frost-${d.day_start_local}`, category: 'winter',
+      title: 'Frost expected',
+      body: `Low ${num(d.air_temp_low)}${U.temp()} on ${new Date(d.day_start_local * 1000).toLocaleDateString([], { weekday: 'long' })}`,
+    });
+  }
+});
+
+// --- builder UI (settings drawer) ---
+
+export function renderRules() {
+  const rules = settings().rules || [];
+  const opts = Object.entries(METRICS).map(([k, [label]]) => `<option value="${k}">${label}</option>`).join('');
+  $('rule-metric').innerHTML = opts;
+  $('rule-list').innerHTML = rules.length
+    ? rules.map((r, i) => {
+        const [label, unit, digits] = METRICS[r.metric] || ['(unknown metric)', () => '', 0];
+        return `<div class="row" style="margin:0">
+          <span class="place-hit" style="flex:1">${label} ${OPS[r.op] || r.op} ${num(r.value, digits)}${unit()}${r.durMin ? ` · ${r.durMin} min` : ''}</span>
+          <button class="sig-x" data-rule="${i}">×</button></div>`;
+      }).join('')
+    : '<div class="muted" style="font-size:12px">No rules yet</div>';
+  $('rule-list').querySelectorAll('[data-rule]').forEach((b) => {
+    b.onclick = () => {
+      const next = [...(settings().rules || [])];
+      next.splice(+b.dataset.rule, 1);
+      state.clear(); // indices shift; stale latches would belong to the wrong rule
+      saveSettings({ rules: next });
+      renderRules();
+    };
+  });
+}
+
+export function initRules() {
+  $('btn-rule-add').onclick = () => {
+    const value = parseFloat($('rule-value').value);
+    if (Number.isNaN(value)) return;
+    saveSettings({
+      rules: [...(settings().rules || []), {
+        metric: $('rule-metric').value,
+        op: $('rule-op').value,
+        value,
+        durMin: +$('rule-dur').value || 0,
+      }],
+    });
+    $('rule-value').value = '';
+    renderRules();
+  };
+  renderRules();
+}
+
+// ponytail-lite self-check: the latch, which is the only part that can be wrong without being
+// obvious — a rule that never fires and a rule that fires every minute look the same from here.
+if (location.search.includes('selftest')) {
+  state.clear();
+  const r = [{ metric: 'gust', op: '>', value: 30, durMin: 0 }];
+  console.assert(evaluate({ gust: 40 }, r, 0).length === 1, 'rules: fires over threshold');
+  console.assert(evaluate({ gust: 40 }, r, 60).length === 0, 'rules: latched, no repeat');
+  console.assert(evaluate({ gust: 29 }, r, 120).length === 0, 'rules: 29 is inside the re-arm band');
+  console.assert(evaluate({ gust: 20 }, r, 180).length === 0, 'rules: re-arm is not a fire');
+  console.assert(evaluate({ gust: 40 }, r, 240).length === 1, 'rules: fires again after re-arm');
+  state.clear();
+  const d = [{ metric: 'temp', op: '<', value: 32, durMin: 10 }];
+  console.assert(evaluate({ temp: 30 }, d, 0).length === 0, 'rules: duration not yet met');
+  console.assert(evaluate({ temp: 30 }, d, 599).length === 0, 'rules: still short');
+  console.assert(evaluate({ temp: 30 }, d, 600).length === 1, 'rules: fires at the duration');
+  state.clear();
+  console.assert(evaluate({ temp: null }, d, 0).length === 0, 'rules: missing reading never fires');
+  state.clear();
+}

--- a/site/js/udp.js
+++ b/site/js/udp.js
@@ -56,6 +56,12 @@ async function poll() {
   // Same SI tuple the cloud websocket sends, so it rides the same event — the hero, the gauges
   // and the MQTT publisher all get a local feed without a token. Dedupe by the report's own
   // timestamp: a 3s poll sees each minute-old report about twenty times.
+  // The hub reports its own health every minute. No freshness gate: a status packet that has
+  // stopped arriving is exactly what the health card needs to show, stamp and all.
+  if (j.device_status) {
+    window.dispatchEvent(new CustomEvent('wd:device-status', { detail: j.device_status }));
+  }
+
   const o = j.obs_st;
   if (o?.obs?.[0] && now - o._at < OBS_FRESH_SEC && o.obs[0][0] !== lastObs) {
     lastObs = o.obs[0][0];

--- a/site/manifest.json
+++ b/site/manifest.json
@@ -1,0 +1,14 @@
+{
+  "name": "WeatherDesk",
+  "short_name": "WeatherDesk",
+  "description": "Self-hosted dashboard for a WeatherFlow Tempest station.",
+  "start_url": ".",
+  "scope": ".",
+  "display": "standalone",
+  "orientation": "any",
+  "background_color": "#0b0f14",
+  "theme_color": "#0b0f14",
+  "icons": [
+    { "src": "icon.svg", "sizes": "any", "type": "image/svg+xml", "purpose": "any maskable" }
+  ]
+}

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3868,7 +3868,7 @@ dependencies = [
 
 [[package]]
 name = "weatherdesk"
-version = "1.3.1"
+version = "2.0.0"
 dependencies = [
  "serde_json",
  "tauri",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weatherdesk"
-version = "1.3.1"
+version = "2.0.0"
 description = "Self-hosted WeatherFlow Tempest dashboard"
 authors = ["David May"]
 license = "MIT"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -34,10 +34,163 @@ fn now() -> u64 {
     SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or(0)
 }
 
+/// Civil date from a day number since the epoch (Howard Hinnant's algorithm). std has no
+/// calendar and this is the whole of what the log needs — a date crate for six lines would be
+/// a dependency to keep updated forever.
+#[cfg(desktop)]
+fn civil_from_days(z: i64) -> (i64, u32, u32) {
+    let z = z + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = (z - era * 146_097) as u64;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 } as u32;
+    (if m <= 2 { y + 1 } else { y }, m, d)
+}
+
+/// `YYYY-MM-DD` for an epoch second, shifted by `tz_off_min` minutes east of UTC.
+#[cfg(desktop)]
+fn ymd(epoch: i64, tz_off_min: i64) -> (i64, u32, u32) {
+    civil_from_days((epoch + tz_off_min * 60).div_euclid(86_400))
+}
+
+/// Where the raw observation log lives. One file per month keeps any single file openable in a
+/// text editor; the whole thing is ~15 MB a year and is never rotated away.
+#[cfg(desktop)]
+fn log_file(dir: &std::path::Path, epoch: i64) -> std::path::PathBuf {
+    let (y, m, _) = ymd(epoch, 0);
+    dir.join(format!("obs-{y:04}-{m:02}.jsonl"))
+}
+
+/// Append one raw `obs_st` observation tuple as a JSON line. SI throughout, exactly as the hub
+/// broadcast it — conversion is the page's job and it already does it in one place.
+#[cfg(desktop)]
+fn log_obs(dir: &std::path::Path, obs: &serde_json::Value) {
+    use std::io::Write;
+    let Some(ts) = obs.get(0).and_then(|v| v.as_i64()) else { return };
+    if std::fs::create_dir_all(dir).is_err() {
+        return;
+    }
+    let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open(log_file(dir, ts)) else {
+        return;
+    };
+    let _ = writeln!(f, "{obs}");
+}
+
+/// Every logged tuple, oldest file first. Lines that don't parse are skipped rather than
+/// fatal: a half-written last line after a power cut should cost one minute, not the archive.
+#[cfg(desktop)]
+fn read_log(dir: &std::path::Path) -> Vec<Vec<Option<f64>>> {
+    let mut files: Vec<_> = std::fs::read_dir(dir)
+        .into_iter()
+        .flatten()
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| p.extension().map(|x| x == "jsonl").unwrap_or(false))
+        .collect();
+    files.sort();
+    let mut out = Vec::new();
+    for f in files {
+        let Ok(text) = std::fs::read_to_string(&f) else { continue };
+        for line in text.lines() {
+            let Ok(v) = serde_json::from_str::<Vec<serde_json::Value>>(line) else { continue };
+            out.push(v.iter().map(|x| x.as_f64()).collect());
+        }
+    }
+    out
+}
+
+/// Per-day aggregates, SI, keyed by the viewer's local date — the browser passes its own UTC
+/// offset because the process has no notion of a timezone and "yesterday" has to mean the same
+/// day the user saw.
+#[cfg(desktop)]
+fn daily_json(dir: &std::path::Path, tz_off_min: i64) -> String {
+    // obs_st tuple indices, same map as site/js/api.js OBS
+    const TIME: usize = 0;
+    const GUST: usize = 3;
+    const TEMP: usize = 7;
+    const RAIN: usize = 12;
+    const STRIKES: usize = 15;
+    const BATT: usize = 16;
+    let get = |o: &Vec<Option<f64>>, i: usize| o.get(i).copied().flatten();
+
+    let mut days: std::collections::BTreeMap<String, [Option<f64>; 6]> = Default::default();
+    for o in read_log(dir) {
+        let Some(t) = get(&o, TIME) else { continue };
+        let (y, m, d) = ymd(t as i64, tz_off_min);
+        let row = days.entry(format!("{y:04}-{m:02}-{d:02}")).or_insert([None; 6]);
+        let lo = |a: &mut Option<f64>, v: Option<f64>| {
+            if let Some(v) = v {
+                *a = Some(a.map_or(v, |x: f64| x.min(v)));
+            }
+        };
+        let hi = |a: &mut Option<f64>, v: Option<f64>| {
+            if let Some(v) = v {
+                *a = Some(a.map_or(v, |x: f64| x.max(v)));
+            }
+        };
+        let sum = |a: &mut Option<f64>, v: Option<f64>| {
+            if let Some(v) = v {
+                *a = Some(a.unwrap_or(0.0) + v);
+            }
+        };
+        let (t_lo, t_hi, g, r, s, b) = (get(&o, TEMP), get(&o, TEMP), get(&o, GUST), get(&o, RAIN), get(&o, STRIKES), get(&o, BATT));
+        lo(&mut row[0], t_lo);
+        hi(&mut row[1], t_hi);
+        hi(&mut row[2], g);
+        sum(&mut row[3], r);
+        sum(&mut row[4], s);
+        lo(&mut row[5], b);
+    }
+    let n = |v: Option<f64>| v.map(|x| x.to_string()).unwrap_or_else(|| "null".into());
+    let rows: Vec<String> = days
+        .iter()
+        .map(|(day, r)| {
+            format!(
+                "{{\"day\":\"{day}\",\"tempMin\":{},\"tempMax\":{},\"gustMax\":{},\"rain\":{},\"strikes\":{},\"battMin\":{}}}",
+                n(r[0]), n(r[1]), n(r[2]), n(r[3]), n(r[4]), n(r[5])
+            )
+        })
+        .collect();
+    format!("[{}]", rows.join(","))
+}
+
+/// Total bytes of the log. The archive is append-only, so this is a sound cache key.
+#[cfg(desktop)]
+fn log_size(dir: &std::path::Path) -> u64 {
+    std::fs::read_dir(dir)
+        .into_iter()
+        .flatten()
+        .flatten()
+        .filter_map(|e| e.metadata().ok())
+        .map(|m| m.len())
+        .sum()
+}
+
+/// The whole log as CSV, SI, header row. Built in memory: a decade of minutes is still only
+/// tens of MB, and this is a button a user presses by hand.
+#[cfg(desktop)]
+fn history_csv(dir: &std::path::Path) -> String {
+    let mut out = String::from(
+        "time,wind_lull,wind_avg,wind_gust,wind_dir,wind_interval,pressure,temp,humidity,lux,uv,solar,rain,precip_type,strike_dist,strikes,battery,report_interval,day_rain\n",
+    );
+    for o in read_log(dir) {
+        let row: Vec<String> = (0..19)
+            .map(|i| o.get(i).copied().flatten().map(|v| v.to_string()).unwrap_or_default())
+            .collect();
+        out.push_str(&row.join(","));
+        out.push('\n');
+    }
+    out
+}
+
 /// Listen to the hub's LAN broadcasts. Everything the websocket carries, minus the round trip
 /// through WeatherFlow's cloud — and it keeps working when the internet doesn't.
 #[cfg(desktop)]
-fn listen_udp(packets: Packets) {
+fn listen_udp(packets: Packets, log_dir: Option<std::path::PathBuf>) {
     // ponytail: another Tempest app on the box owns the port first-come. Nothing to do but
     // skip; the page falls back to the websocket on its own.
     let sock = match UdpSocket::bind(("0.0.0.0", HUB_PORT)) {
@@ -48,10 +201,21 @@ fn listen_udp(packets: Packets) {
         }
     };
     let mut buf = [0u8; 2048];
+    // The hub re-broadcasts; without this the archive gets the same minute several times.
+    let mut last_logged: i64 = 0;
     loop {
         let Ok((n, _)) = sock.recv_from(&mut buf) else { continue };
         let Ok(mut v) = serde_json::from_slice::<serde_json::Value>(&buf[..n]) else { continue };
         let Some(kind) = v.get("type").and_then(|t| t.as_str()).map(String::from) else { continue };
+        if kind == "obs_st" {
+            if let (Some(dir), Some(obs)) = (log_dir.as_ref(), v.get("obs").and_then(|o| o.get(0))) {
+                let ts = obs.get(0).and_then(|t| t.as_i64()).unwrap_or(0);
+                if ts > last_logged {
+                    last_logged = ts;
+                    log_obs(dir, obs);
+                }
+            }
+        }
         // stamped on arrival so the page can tell a live packet from the last one before a
         // hub reboot
         if let Some(obj) = v.as_object_mut() {
@@ -90,6 +254,64 @@ fn cors(res: Response<std::io::Empty>) -> Response<std::io::Empty> {
     res.with_header(Header::from_bytes("Access-Control-Allow-Origin", "*").unwrap())
 }
 
+/// Strip every credential out of the settings blob for the public dashboard.
+///
+/// Deny by key name, and the keys are listed here rather than derived: a future setting that
+/// holds a secret has to be added to this list, and a test below fails loudly if the token ever
+/// survives. Anything not recognised is kept — the public page still needs the station's
+/// coordinates and units to render.
+#[cfg(desktop)]
+const SECRET_KEYS: [&str; 6] = ["token", "mqttUser", "mqttPass", "haToken", "ntfyTopic", "webhookUrl"];
+
+#[cfg(desktop)]
+fn redact(config_json: &str) -> String {
+    let Ok(mut v) = serde_json::from_str::<serde_json::Value>(config_json) else {
+        return "{}".into();
+    };
+    if let Some(s) = v.get_mut("settings").and_then(|s| s.as_object_mut()) {
+        for k in SECRET_KEYS {
+            if s.contains_key(k) {
+                s.insert(k.into(), serde_json::Value::String(String::new()));
+            }
+        }
+    }
+    v.to_string()
+}
+
+// ponytail: one check, on the only maths here that can be silently wrong — a day boundary off
+// by one puts "yesterday's high" on the wrong row and nothing else complains.
+#[cfg(all(test, desktop))]
+mod tests {
+    use super::{redact, ymd};
+
+    #[test]
+    fn day_boundaries() {
+        assert_eq!(ymd(0, 0), (1970, 1, 1));
+        assert_eq!(ymd(1_700_000_000, 0), (2023, 11, 14));
+        // 04:00 UTC is still the previous day in US Central (-300 min)
+        assert_eq!(ymd(1_700_020_800, -300), (2023, 11, 14));
+        assert_eq!(ymd(1_700_020_800, 0), (2023, 11, 15));
+        assert_eq!(ymd(951_782_400, 0), (2000, 2, 29)); // leap day
+    }
+
+    #[test]
+    fn public_config_keeps_no_secrets() {
+        let out = redact(
+            r#"{"settings":{"token":"abc123","mqttPass":"hunter2","ntfyTopic":"secret-topic",
+                "stationId":"1234","lat":33.1,"units":"imperial"}}"#,
+        );
+        for needle in ["abc123", "hunter2", "secret-topic"] {
+            assert!(!out.contains(needle), "{needle} leaked into the public config: {out}");
+        }
+        assert!(out.contains("1234") && out.contains("imperial"), "public config lost the station");
+    }
+
+    #[test]
+    fn malformed_config_is_not_served_raw() {
+        assert_eq!(redact("not json at all"), "{}");
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -110,12 +332,16 @@ pub fn run() {
                 // "/" -> index.html, percent-decoding and MIME types.
                 let packets: Packets = Arc::new(Mutex::new(HashMap::new()));
                 let listener = packets.clone();
-                std::thread::spawn(move || listen_udp(listener));
+                let log_dir = app.path().app_data_dir().map(|d| d.join("log")).ok();
+                let listen_log = log_dir.clone();
+                std::thread::spawn(move || listen_udp(listener, listen_log));
 
                 let cfg_path = app.path().app_config_dir().map(|d| d.join("config.json")).ok();
 
                 let resolver = app.asset_resolver();
                 std::thread::spawn(move || {
+                    // (tz offset, total log bytes, body) — see the /history/daily route.
+                    let mut daily_cache: Option<(i64, u64, String)> = None;
                     for mut req in server.incoming_requests() {
                         let path = req.url().split('?').next().unwrap_or("/").to_string();
                         // ponytail: a plain polled route, not SSE — this request loop is
@@ -126,6 +352,65 @@ pub fn run() {
                             let _ = req.respond(
                                 Response::from_string(body)
                                     .with_header(Header::from_bytes("Content-Type", "application/json").unwrap())
+                                    .with_header(Header::from_bytes("Access-Control-Allow-Origin", "*").unwrap()),
+                            );
+                            continue;
+                        }
+                        // A read-only dashboard for anyone on the network — the family tablet,
+                        // a guest phone, a reverse proxy to the outside world. Same config, with
+                        // every secret taken out of it, and a flag the page uses to hide the
+                        // settings drawer.
+                        if path == "/public" || path == "/config-public" {
+                            let body = std::fs::read_to_string(cfg_path.clone().unwrap_or_default())
+                                .unwrap_or_else(|_| "{}".into());
+                            let public = redact(&body);
+                            if path == "/config-public" {
+                                let _ = req.respond(
+                                    Response::from_string(public)
+                                        .with_header(Header::from_bytes("Content-Type", "application/json").unwrap())
+                                        .with_header(Header::from_bytes("Access-Control-Allow-Origin", "*").unwrap()),
+                                );
+                                continue;
+                            }
+                            let page = resolver
+                                .get("/index.html".into())
+                                .map(|a| String::from_utf8_lossy(&a.bytes).into_owned())
+                                .unwrap_or_default()
+                                .replace("<head>", "<head><script>window.__WD_PUBLIC=1</script>");
+                            let _ = req.respond(
+                                Response::from_string(page)
+                                    .with_header(Header::from_bytes("Content-Type", "text/html").unwrap()),
+                            );
+                            continue;
+                        }
+                        if path == "/history/daily" || path == "/history.csv" {
+                            let Some(dir) = log_dir.clone() else {
+                                let _ = req.respond(Response::empty(503));
+                                continue;
+                            };
+                            // `?tz=<minutes east of UTC>`; absent means UTC days.
+                            let tz = req
+                                .url()
+                                .split('?')
+                                .nth(1)
+                                .and_then(|q| q.split('&').find_map(|kv| kv.strip_prefix("tz=")))
+                                .and_then(|v| v.parse::<i64>().ok())
+                                .unwrap_or(0);
+                            let (body, mime) = if path == "/history.csv" {
+                                (history_csv(&dir), "text/csv")
+                            } else {
+                                // Re-reading a year of minutes on every Data-tab visit would
+                                // stall this loop — and it serves the page's assets too. The
+                                // log only ever grows, so its total size is the whole cache key.
+                                let size = log_size(&dir);
+                                if daily_cache.as_ref().map(|(t, s, _)| (*t, *s)) != Some((tz, size)) {
+                                    daily_cache = Some((tz, size, daily_json(&dir, tz)));
+                                }
+                                (daily_cache.as_ref().unwrap().2.clone(), "application/json")
+                            };
+                            let _ = req.respond(
+                                Response::from_string(body)
+                                    .with_header(Header::from_bytes("Content-Type", mime).unwrap())
                                     .with_header(Header::from_bytes("Access-Control-Allow-Origin", "*").unwrap()),
                             );
                             continue;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "WeatherDesk",
-  "version": "1.3.1",
+  "version": "2.0.0",
   "identifier": "io.github.davidmay87.weatherdesk",
   "build": {
     "frontendDist": "../site"


### PR DESCRIPTION
Six areas, one release. Scope came out of a 36-question interview; everything below is either arithmetic on numbers the dashboard already had or a keyless endpoint. No new dependencies, no build step, still ES2020 for the G Pad's WebView, and every new settings key is additive so an older client round-trips `/config` unharmed.

### Performance
Jobs registered with `every()` now keep their base period and can be re-paced without re-running. Eco doubles every non-exempt period, the night window (sunset+1h to sunrise−1h) triples it, and an active Severe/Extreme NWS alert puts everything back to full rate and halves obs/alerts. Eco defaults to *auto* — on when the browser reports four cores or fewer — and also stops the ticker, kills transitions and drops the seconds from the clock. NWS requests send `If-None-Match` and reuse the cached body on a 304.

### Observation log, almanac, backup
The desktop app appends every `obs_st` the hub broadcasts to `app_data_dir/log/obs-YYYY-MM.jsonl`, raw SI, deduped by report timestamp (~15 MB/yr, never rotated). New routes serve per-day aggregates (`/history/daily`, keyed by the browser's own UTC offset — the process has no timezone) and the whole archive as CSV. New almanac boards read it: all-time records, this day last year, rain by month. Nothing backfills; the panel says how far back the record actually goes. Settings export/import added, with a confirm noting the export contains the token.

### Alert rules and push
A rule is a metric, a direction, a value and a hold time; it fires once and re-arms at 90% of its threshold, same latch the gust alert already used. Nine metrics including 3h pressure change and 3h strike count. Any alert can leave the machine over ntfy, a webhook, or MQTT (reusing the existing broker connection). **Payloads carry title, body and category only — never the token, station ID or broker credentials.**

### Appearance
Light and auto themes, accent colour, text scale, compact density, oversized readings, kiosk tab cycling with night dim and an hourly burn-in nudge, keyboard shortcuts with a `?` overlay. `charts.js` reads its palette from CSS variables per draw so charts follow the theme.

### Environment and health
Golden hour and day-length change from a local NOAA solar-position calculation, moonrise/set from api.met.no (keyless, once a day), growing degree days and a watering shortfall, and a station health card off the `device_status` packet the UDP listener was already storing — battery, signal, decoded sensor faults, time since the last report, with alerts on each. Auto storm mode un-hides the radar during a warning and restores your setting afterwards.

### Sharing and setup
`/public` serves the dashboard with the drawer gone and a config the server strips every credential out of first (deny-list, with a Rust test asserting the token cannot survive). Responsive pass for phones plus a web manifest — no service worker, because the LAN origin is plain http and a cached copy of a live dashboard would be a lie. Saved stations switch from the header. First run is now a wizard that lists the stations the pasted token can actually reach.

### Deviation from the plan
No US Drought Monitor. Its county API sends no `Access-Control-Allow-Origin` (checked live), and the one CORS-enabled file it publishes is a 27 MB national GeoJSON, which a 2013 tablet will not parse. Dryness is measured from this station's own rain log instead — 30-day total and days since rain. Reasoning is in a `ponytail:` comment at the call site.

Radar warning polygons and the lightning overlay remain a Hook Echo repo follow-up; only the panel behaviour is in scope here.

### Verification
Verified against a live hub: the log writes real observations, `/history/daily` and `/history.csv` return them, `/config-public` comes back with every secret empty and the station intact, `/public` renders with the drawer hidden and no token in source. `cargo test` passes (3), `cargo tauri build` is clean at 2.0.0, and the in-page `?selftest` run produced no assertion failures.

Not verified: G Pad and old-laptop idle CPU, `cargo tauri android build` on the S24, real ntfy/webhook/MQTT delivery, and a light-theme visual sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)