### PR TITLE
chore: point the radar embed at hookecho.pages.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ chart](docs/screenshot.png)
   forecast changes, forecast accuracy, air quality, sun & moon detail (golden hour, day-length
   change, moonrise/set), fire weather & dryness, and station health (battery, signal, sensor
   faults, time since the last report).
-- **Forecast Lab** — radar, embedded from [Hook Echo-WX](https://hookecho.netlify.app/).
+- **Forecast Lab** — radar, embedded from [Hook Echo-WX](https://hookecho.pages.dev/).
 
 The Desk radar loads itself, in Hook Echo's embedded mode: no chrome, and one frame a minute until
 you touch it. That matters because a live radar loop repaints ten times a second, and the WebKit
@@ -139,7 +139,7 @@ tablet case is the one that matters, and HTML5 drag-and-drop never fires for tou
 | The same, straight off the hub's LAN broadcast (desktop app only) | UDP `50222` |
 | Watches and warnings, gridpoint forecast | `api.weather.gov` |
 | Multi-model agreement, 15-minute nowcast, AQI | `api.open-meteo.com` |
-| Radar | [Hook Echo-WX](https://github.com/d4vid87/hookecho) at `hookecho.netlify.app` |
+| Radar | [Hook Echo-WX](https://github.com/d4vid87/hookecho) at `hookecho.pages.dev` |
 | Place search | `photon.komoot.io` |
 
 ## Smart home

--- a/site/js/boot.js
+++ b/site/js/boot.js
@@ -559,7 +559,7 @@ window.addEventListener('wd:refresh', () => {
 // Hook Echo-WX (own NEXRAD viewer) instead of the weathermap build. Deep link is
 // `#goto=SITE,lon,lat,zoom[,extras]` — note lon before lat, and unknown extras are ignored by
 // older builds, so adding to this string can never break a deployed viewer.
-const RADAR = 'https://hookecho.netlify.app/';
+const RADAR = 'https://hookecho.pages.dev/';
 
 // The NEXRAD + TDWR registry, generated from Hook Echo's own site table
 // (`cargo run -p wxdata --example sites_json`). Frozen data — a live endpoint would be coupling


### PR DESCRIPTION
Swaps the radar embed host from `hookecho.netlify.app` to `hookecho.pages.dev`.

Both hosts serve byte-identical HTML (same md5), so this is the same Hook Echo build on the Cloudflare Pages deployment.

`RADAR` in `boot.js` is the single source — `radarUrl()`, both iframes, and the `postMessage` origin check all derive from it — so the change is one constant plus the two README mentions.

Checked: `pages.dev` sends no `X-Frame-Options` or CSP `frame-ancestors`, so framing still works; `node --check` clean; the selftest builds its expected URL from `RADAR` and stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)