### PR TITLE
chore: release v3.0.1

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: David May <davidmay87@gmail.com>
 pkgname=weatherdesk
-pkgver=3.0.0
+pkgver=3.0.1
 pkgrel=1
 pkgdesc="Self-hosted dashboard for a WeatherFlow Tempest station"
 arch=('x86_64' 'aarch64')

--- a/flatpak/io.github.davidmay87.weatherdesk.metainfo.xml
+++ b/flatpak/io.github.davidmay87.weatherdesk.metainfo.xml
@@ -27,6 +27,11 @@
   <url type="bugtracker">https://github.com/d4vid87/weatherdesk/issues</url>
   <content_rating type="oars-1.1"/>
   <releases>
+    <release version="3.0.1" date="2026-08-18">
+      <description>
+        <p>The embedded radar now loads from hookecho.pages.dev.</p>
+      </description>
+    </release>
     <release version="3.0.0" date="2026-08-17">
       <description>
         <p>The data release: a SQLite archive with history backfilled from WeatherFlow, live

--- a/flatpak/io.github.davidmay87.weatherdesk.yml
+++ b/flatpak/io.github.davidmay87.weatherdesk.yml
@@ -36,5 +36,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/d4vid87/weatherdesk.git
-        tag: v3.0.0
+        tag: v3.0.1
       - cargo-sources.json

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4744,7 +4744,7 @@ dependencies = [
 
 [[package]]
 name = "weatherdesk"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "include_dir",
  "rusqlite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weatherdesk"
-version = "3.0.0"
+version = "3.0.1"
 description = "Self-hosted WeatherFlow Tempest dashboard"
 authors = ["David May"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "WeatherDesk",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "identifier": "io.github.davidmay87.weatherdesk",
   "build": {
     "frontendDist": "../site"


### PR DESCRIPTION
Version bump to 3.0.1 across `Cargo.toml`, `Cargo.lock`, `tauri.conf.json`, `PKGBUILD`, the flatpak manifest tag and a metainfo release entry.

The only code change in this release is #17 — the radar embed moving to `hookecho.pages.dev`, which merged after the v3.0.0 binaries were built.

This is also the first release that exercises the updater end to end: v3.0.0 installs should see it via `latest.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)