### PR TITLE
fix: stop the config sync answering its own broadcast (v3.0.2)

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: David May <davidmay87@gmail.com>
 pkgname=weatherdesk
-pkgver=3.0.1
+pkgver=3.0.2
 pkgrel=1
 pkgdesc="Self-hosted dashboard for a WeatherFlow Tempest station"
 arch=('x86_64' 'aarch64')

--- a/flatpak/io.github.davidmay87.weatherdesk.metainfo.xml
+++ b/flatpak/io.github.davidmay87.weatherdesk.metainfo.xml
@@ -27,6 +27,11 @@
   <url type="bugtracker">https://github.com/d4vid87/weatherdesk/issues</url>
   <content_rating type="oars-1.1"/>
   <releases>
+    <release version="3.0.2" date="2026-08-18">
+      <description>
+        <p>Fixes a settings-sync loop that held the dashboard at a full CPU core.</p>
+      </description>
+    </release>
     <release version="3.0.1" date="2026-08-18">
       <description>
         <p>The embedded radar now loads from hookecho.pages.dev.</p>

--- a/flatpak/io.github.davidmay87.weatherdesk.yml
+++ b/flatpak/io.github.davidmay87.weatherdesk.yml
@@ -36,5 +36,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/d4vid87/weatherdesk.git
-        tag: v3.0.1
+        tag: v3.0.2
       - cargo-sources.json

--- a/site/js/boot.js
+++ b/site/js/boot.js
@@ -62,11 +62,25 @@ function pushConfig() {
 }
 
 let pushTimer;
-window.addEventListener('wd:layout', () => { clearTimeout(pushTimer); pushTimer = setTimeout(pushConfig, 2000); });
+// A layout event raised while a pull is applying is the server's own layout coming back, not an
+// edit — scheduling a push for it is how this screen used to answer every broadcast with a write.
+window.addEventListener('wd:layout', () => {
+  if (syncing) return;
+  clearTimeout(pushTimer);
+  pushTimer = setTimeout(pushConfig, 2000);
+});
 
 // Someone changed a setting on another screen. Before this, a tablet kept showing yesterday's
 // units until it was reloaded by hand.
-window.addEventListener('wd:config-rev', () => pullConfig());
+//
+// Not our own write, though: the server broadcasts every revision, including the one this screen
+// just PUT. Pulling that back calls restore(), restore() dispatches wd:layout, and the debounced
+// push sends it again — a loop that bumped the revision once a second and held the webview at a
+// full core. A missing rev (older server) still pulls, as it always did.
+export function shouldPull(evRev) {
+  return typeof evRev !== 'number' || evRev !== rev;
+}
+window.addEventListener('wd:config-rev', (e) => { if (shouldPull(e.detail?.rev)) pullConfig(); });
 
 
 function fillDrawer() {
@@ -769,4 +783,12 @@ if (location.search.includes('selftest')) {
   // (unconfigured profile returns the bare viewer URL with no #goto — nothing to assert on)
   const u2 = radarUrl(6.5);
   console.assert(!u2.includes('#goto=') || u2.endsWith(',bm:esri-streets'), 'first-load default basemap', u2);
+
+  // The config echo, the one bug here that costs a whole CPU core rather than a wrong number.
+  const held = rev;
+  rev = 7;
+  console.assert(!shouldPull(7), 'config: our own revision is not pulled back');
+  console.assert(shouldPull(8), 'config: a newer revision from another screen is pulled');
+  console.assert(shouldPull(undefined), 'config: a server that sends no revision still pulls');
+  rev = held;
 }

--- a/site/js/udp.js
+++ b/site/js/udp.js
@@ -92,7 +92,13 @@ function stream() {
     streaming = true;
     apply({ [p.type]: p });
   });
-  es.addEventListener('config', () => window.dispatchEvent(new CustomEvent('wd:config-rev')));
+  // The revision rides along: a screen that already holds it is the one that just wrote it, and
+  // re-pulling its own write is how the config sync used to chase its own tail.
+  es.addEventListener('config', (e) => {
+    let d = null;
+    try { d = JSON.parse(e.data); } catch { /* older server sent no body */ }
+    window.dispatchEvent(new CustomEvent('wd:config-rev', { detail: d }));
+  });
   // EventSource reconnects by itself; the poll covers the gap until a packet proves it back.
   es.onerror = () => { streaming = false; };
 }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4744,7 +4744,7 @@ dependencies = [
 
 [[package]]
 name = "weatherdesk"
-version = "3.0.1"
+version = "3.0.2"
 dependencies = [
  "include_dir",
  "rusqlite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weatherdesk"
-version = "3.0.1"
+version = "3.0.2"
 description = "Self-hosted WeatherFlow Tempest dashboard"
 authors = ["David May"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "WeatherDesk",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "identifier": "io.github.davidmay87.weatherdesk",
   "build": {
     "frontendDist": "../site"


### PR DESCRIPTION
## The bug

An idle v3 dashboard held a full CPU core. Measured, blank-ish page, same machine:

| build | web process CPU |
|---|---|
| v2.0.1 | 3% |
| v3.0.0 | 90% |
| v3.0.1 | 87–99% |
| this branch | 3% |

Bisected to `initUdp()`, and inside it to `stream()` — the SSE client, new in v3.

## Why

Every settings write is broadcast to SSE clients as `{"rev":N}`, including back to the screen that wrote it. That screen pulled the revision, applied it, and `restore()` raised `wd:layout`, which is the debounced push — so it wrote again, which broadcast again. `_rev` in `config.json` climbed roughly once a second forever (146 revisions inside the first minute of a fresh start), and each turn of the loop re-rendered enough of the page to cost the core.

## The fix

Two guards, because they fail differently:

- A `wd:layout` raised while a pull is applying is not an edit, so it never schedules a push. This is the one that breaks the cycle — the rev guard alone loses the race when the broadcast lands before the PUT response does.
- A broadcast carrying the revision this screen already holds is its own write coming back, so it isn't pulled at all. `udp.js` now passes the event body through instead of discarding it.

## Verified

- Web process CPU 87% → 3%
- `_rev` stable across a 30s idle run (was +1/s)
- A foreign `PUT /config` still lands: rev bumps once, value persists, no echo
- `?selftest` through Chrome DevTools Protocol: 0 failed asserts, 0 console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)