### PR TITLE
fix: the LAN dashboard on older tablet browsers (v3.0.3)

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: David May <davidmay87@gmail.com>
 pkgname=weatherdesk
-pkgver=3.0.2
+pkgver=3.0.3
 pkgrel=1
 pkgdesc="Self-hosted dashboard for a WeatherFlow Tempest station"
 arch=('x86_64' 'aarch64')

--- a/flatpak/io.github.davidmay87.weatherdesk.metainfo.xml
+++ b/flatpak/io.github.davidmay87.weatherdesk.metainfo.xml
@@ -27,6 +27,12 @@
   <url type="bugtracker">https://github.com/d4vid87/weatherdesk/issues</url>
   <content_rating type="oars-1.1"/>
   <releases>
+    <release version="3.0.3" date="2026-08-18">
+      <description>
+        <p>Works again on older tablet browsers, and a screen that cannot reach the host no
+        longer overwrites the host's settings with its own blank ones.</p>
+      </description>
+    </release>
     <release version="3.0.2" date="2026-08-18">
       <description>
         <p>Fixes a settings-sync loop that held the dashboard at a full CPU core.</p>

--- a/flatpak/io.github.davidmay87.weatherdesk.yml
+++ b/flatpak/io.github.davidmay87.weatherdesk.yml
@@ -36,5 +36,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/d4vid87/weatherdesk.git
-        tag: v3.0.2
+        tag: v3.0.3
       - cargo-sources.json

--- a/site/js/almanac.js
+++ b/site/js/almanac.js
@@ -4,7 +4,7 @@
 // the REST history is capped and paged, and the point of the log is to keep going once it ends.
 // Nothing here backfills — the archive starts the day the app was first run, and the panel says
 // so rather than pretending the record is older than it is.
-import { settings, U, num, every } from './app.js';
+import { settings, U, num, every, expires } from './app.js';
 import { chart } from './charts.js';
 import { normals, normalFor } from './api.js';
 
@@ -32,7 +32,7 @@ async function load() {
   // The browser's own offset, because the process has no timezone and "a day" has to mean the
   // day the user lived through.
   const tz = -new Date().getTimezoneOffset();
-  const r = await fetch(`${SRV}/history/daily?tz=${tz}`, { signal: AbortSignal.timeout(10000) });
+  const r = await fetch(`${SRV}/history/daily?tz=${tz}`, { signal: expires(10000) });
   if (!r.ok) throw new Error(`${r.status}`);
   days = (await r.json()).map(toDisplay);
 }
@@ -105,7 +105,7 @@ export async function refreshAlmanac() {
 let coverage = null;
 async function loadCoverage() {
   try {
-    const r = await fetch(`${SRV}/history/coverage`, { signal: AbortSignal.timeout(5000) });
+    const r = await fetch(`${SRV}/history/coverage`, { signal: expires(5000) });
     coverage = r.ok ? await r.json() : null;
   } catch { coverage = null; }
 }

--- a/site/js/api.js
+++ b/site/js/api.js
@@ -1,5 +1,5 @@
 // All remote endpoints live here. Single choke point for token + units.
-import { settings, coords } from './app.js';
+import { settings, coords, expires } from './app.js';
 
 const SWD = 'https://swd.weatherflow.com/swd/rest';
 
@@ -38,7 +38,7 @@ async function getJSON(url, opts) {
   const hit = cacheable(url) ? etags.get(url) : null;
   try {
     r = await fetch(url, {
-      signal: AbortSignal.timeout(15000),
+      signal: expires(15000),
       ...opts,
       ...(hit ? { headers: { 'If-None-Match': hit.etag, ...(opts?.headers || {}) } } : {}),
     });

--- a/site/js/app.js
+++ b/site/js/app.js
@@ -303,6 +303,16 @@ function repace() {
   }
 }
 
+// A fetch deadline, the long way round. `AbortSignal.timeout` is Chrome 103 and Safari 16, and
+// the wall tablets this dashboard is aimed at are older than both — on one of them the missing
+// method threw before the request was made, so every timed fetch on the page died at once and
+// the screen came up as an unconfigured install. AbortController has been everywhere since 2018.
+export function expires(ms) {
+  const c = new AbortController();
+  setTimeout(() => c.abort(), ms);
+  return c.signal;
+}
+
 // Nothing here is worth a request or a repaint while the window is hidden — a wall tablet with
 // its screen off would otherwise poll every source all night. Whatever came due in the meantime
 // runs once on the way back.

--- a/site/js/boards.js
+++ b/site/js/boards.js
@@ -1,7 +1,7 @@
 // 04 Data — nine boards. Station history from observations/device, forecast
 // intelligence from open-meteo + wd.verify, official context from NWS.
 import * as api from './api.js';
-import { settings, coords, configured, U, num, every } from './app.js';
+import { settings, coords, configured, U, num, every, expires } from './app.js';
 import { chart } from './charts.js';
 import { accuracy } from './track.js';
 import { forecast as deskForecast } from './desk.js';
@@ -171,7 +171,7 @@ async function drawOfficial() {
   const fc = deskForecast();
   try {
     const p = await api.nwsPoint();
-    const nws = await (await fetch(p.properties.forecast, { signal: AbortSignal.timeout(15000) })).json();
+    const nws = await (await fetch(p.properties.forecast, { signal: expires(15000) })).json();
     const periods = nws.properties.periods.slice(0, 6);
     const tempestDaily = fc?.forecast?.daily || [];
     $('official').innerHTML = periods.map((pd, i) => {
@@ -192,7 +192,7 @@ async function drawOutlook() {
   try {
     const j = await (await fetch(`https://api.open-meteo.com/v1/forecast?latitude=${s.lat}&longitude=${s.lon}`
       + `&daily=precipitation_sum,precipitation_probability_max&forecast_days=7&timezone=auto`
-      + (imperial ? '&precipitation_unit=inch' : ''), { signal: AbortSignal.timeout(15000) })).json();
+      + (imperial ? '&precipitation_unit=inch' : ''), { signal: expires(15000) })).json();
     const data = j.daily.time.map((t, i) => ({ x: new Date(t).getTime(), y: j.daily.precipitation_sum[i] }));
     chart($('c-qpf'), [{ data, type: 'bar', color: '#4fb8ff' }], { yMin: 0, digits: 2 });
     const total = data.reduce((a, b) => a + (b.y || 0), 0);

--- a/site/js/boot.js
+++ b/site/js/boot.js
@@ -1,5 +1,5 @@
 // Wire the shell: settings drawer, diagnostics, nav, section modules.
-import { settings, saveSettings, configured, initNav, applyTabs, fullscreen, refreshAll, notify, load, store, applyEco, ecoOn, initKiosk } from './app.js';
+import { settings, saveSettings, configured, initNav, applyTabs, fullscreen, refreshAll, notify, load, store, applyEco, ecoOn, initKiosk, expires } from './app.js';
 import * as api from './api.js';
 import { initDesk, refreshDesk, refreshObs, refreshAlerts, refreshAqi } from './desk.js';
 import { initIntel, refreshModels, refreshNowcast } from './intel.js';
@@ -33,7 +33,7 @@ let rev = null;
 async function pullConfig() {
   syncing = true;
   try {
-    const r = await fetch(`${SRV}/${PUBLIC ? 'config-public' : 'config'}`, { signal: AbortSignal.timeout(2000) });
+    const r = await fetch(`${SRV}/${PUBLIC ? 'config-public' : 'config'}`, { signal: expires(2000) });
     if (!r.ok) return;
     const j = await r.json();
     if (typeof j._rev === 'number') rev = j._rev;
@@ -50,8 +50,16 @@ async function pullConfig() {
 // saw, and the server merges it and hands the result back. Whole-blob writes still work (that is
 // what a v2 client does), but tagging keeps a key only another screen knows about from being
 // dropped by this one.
+
+// A screen that has never heard back from the server has nothing to tell it. Before this, a
+// tablet whose pull failed kept its blank defaults and then pushed them — and the host's token
+// and station were gone, replaced by the empty strings of a browser that had just been opened.
+export function mayPush(pulled = rev !== null) {
+  return pulled || configured();
+}
+
 function pushConfig() {
-  if (syncing || PUBLIC) return;
+  if (syncing || PUBLIC || !mayPush()) return;
   fetch(`${SRV}/config`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
@@ -504,7 +512,7 @@ $('import-file').onchange = async (e) => {
 // button would be a second code path for something done once in a lifetime.
 $('btn-backup').onclick = async () => {
   try {
-    const r = await fetch(`${SRV}/backup.db`, { signal: AbortSignal.timeout(120000) });
+    const r = await fetch(`${SRV}/backup.db`, { signal: expires(120000) });
     if (!r.ok) throw new Error(`${r.status}`);
     download('weatherdesk.db', await r.blob());
   } catch {
@@ -536,7 +544,7 @@ $('btn-update').onclick = async () => {
 
 $('btn-csv').onclick = async () => {
   try {
-    const r = await fetch(`${SRV}/history.csv`, { signal: AbortSignal.timeout(60000) });
+    const r = await fetch(`${SRV}/history.csv`, { signal: expires(60000) });
     if (!r.ok) throw new Error(`${r.status}`);
     download('weatherdesk-history.csv', await r.blob());
   } catch {
@@ -783,6 +791,16 @@ if (location.search.includes('selftest')) {
   // (unconfigured profile returns the bare viewer URL with no #goto — nothing to assert on)
   const u2 = radarUrl(6.5);
   console.assert(!u2.includes('#goto=') || u2.endsWith(',bm:esri-streets'), 'first-load default basemap', u2);
+
+  // The push guard. A blank screen that has heard nothing from the host must stay quiet, or it
+  // overwrites what the host knew with its own empty defaults.
+  console.assert(mayPush(true), 'config: a screen that has pulled may push');
+  console.assert(mayPush(false) === configured(), 'config: without a pull, only a configured screen pushes');
+
+  // The fetch deadline every screen depends on, on the browsers that have no AbortSignal.timeout.
+  const sig = expires(50);
+  console.assert(sig.aborted === false, 'expires: not aborted yet');
+  console.assert(typeof sig.addEventListener === 'function', 'expires: returns a real signal');
 
   // The config echo, the one bug here that costs a whole CPU core rather than a wrong number.
   const held = rev;

--- a/site/js/env.js
+++ b/site/js/env.js
@@ -3,7 +3,7 @@
 // Everything here is either arithmetic on numbers the dashboard already has, or a keyless
 // endpoint. No new token, no new account: the point of these cards is that they cost nothing to
 // keep on screen all day.
-import { settings, coords, U, num, notify, every, stamp } from './app.js';
+import { settings, coords, U, num, notify, every, stamp, expires } from './app.js';
 import { forecast as deskForecast } from './desk.js';
 import { OBS } from './api.js';
 
@@ -94,7 +94,7 @@ async function loadMoon() {
   const sign = off < 0 ? '-' : '+';
   const offset = `${sign}${String(Math.floor(Math.abs(off) / 60)).padStart(2, '0')}:${String(Math.abs(off) % 60).padStart(2, '0')}`;
   const url = `https://api.met.no/weatherapi/sunrise/3.0/moon?lat=${(+c.lat).toFixed(4)}&lon=${(+c.lon).toFixed(4)}&date=${day}&offset=${encodeURIComponent(offset)}`;
-  const r = await fetch(url, { signal: AbortSignal.timeout(15000) });
+  const r = await fetch(url, { signal: expires(15000) });
   if (!r.ok) throw new Error(`${r.status}`);
   const p = (await r.json()).properties || {};
   moonTimes = {
@@ -185,7 +185,7 @@ async function loadGarden() {
   // ground. Paired with the rain that went in, it is the whole of "does the lawn need watering".
   const r = await fetch('https://api.open-meteo.com/v1/forecast'
     + `?latitude=${c.lat}&longitude=${c.lon}&daily=et0_fao_evapotranspiration,precipitation_sum`
-    + '&past_days=7&forecast_days=1&timezone=auto', { signal: AbortSignal.timeout(15000) });
+    + '&past_days=7&forecast_days=1&timezone=auto', { signal: expires(15000) });
   if (!r.ok) throw new Error(`${r.status}`);
   const j = await r.json();
   const sum = (a) => (a || []).slice(0, 7).reduce((x, y) => x + (y || 0), 0);
@@ -198,7 +198,7 @@ async function loadGarden() {
 // goes back to spring. No log (browser or Android install) simply leaves the row off.
 async function loadSeason() {
   const tz = -new Date().getTimezoneOffset();
-  const r = await fetch(`${window.__WD_SRV || ''}/history/daily?tz=${tz}`, { signal: AbortSignal.timeout(10000) });
+  const r = await fetch(`${window.__WD_SRV || ''}/history/daily?tz=${tz}`, { signal: expires(10000) });
   if (!r.ok) throw new Error(`${r.status}`);
   const days = await r.json(); // SI
   const yearStart = `${new Date().getFullYear()}-01-01`;

--- a/site/js/home.js
+++ b/site/js/home.js
@@ -8,7 +8,7 @@
 // HomeKit, Alexa and Google are reached through Home Assistant's own bridges — see README. There
 // is no native code here for them, and there shouldn't be.
 
-import { settings, every, stamp, stormMode } from './app.js';
+import { settings, every, stamp, stormMode, expires } from './app.js';
 import { OBS } from './api.js';
 import { mqtt } from './mqtt.js';
 
@@ -266,7 +266,7 @@ function initHaPanel() {
     const rows = await Promise.all(ids.map(async (id) => {
       try {
         const r = await fetch(`${url}/api/states/${encodeURIComponent(id)}`, {
-          signal: AbortSignal.timeout(15000),
+          signal: expires(15000),
           headers: { Authorization: `Bearer ${s.haToken}` },
         });
         if (!r.ok) throw new Error(`${r.status}`);

--- a/site/js/udp.js
+++ b/site/js/udp.js
@@ -2,7 +2,7 @@
 // only without the round trip and without needing the internet at all. Browsers can't hold a UDP
 // socket, so the desktop app listens and re-serves the last packet per type at /udp; a plain
 // browser install has no such route and this module switches itself off on the first miss.
-import { every, num } from './app.js';
+import { every, num, expires } from './app.js';
 import { renderRapid, onStrike } from './signals.js';
 
 // The app window runs on tauri://localhost, so it gets an absolute URL injected at build of the
@@ -24,7 +24,7 @@ async function poll() {
   if (off || streaming) return;
   let j;
   try {
-    const r = await fetch(URL, { signal: AbortSignal.timeout(3000) });
+    const r = await fetch(URL, { signal: expires(3000) });
     if (!r.ok) throw new Error(r.status);
     j = await r.json();
     misses = 0;

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4744,7 +4744,7 @@ dependencies = [
 
 [[package]]
 name = "weatherdesk"
-version = "3.0.2"
+version = "3.0.3"
 dependencies = [
  "include_dir",
  "rusqlite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weatherdesk"
-version = "3.0.2"
+version = "3.0.3"
 description = "Self-hosted WeatherFlow Tempest dashboard"
 authors = ["David May"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "WeatherDesk",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "identifier": "io.github.davidmay87.weatherdesk",
   "build": {
     "frontendDist": "../site"


### PR DESCRIPTION
Found with the G Pad on the end of an ADB cable.

## `AbortSignal.timeout` is newer than the tablets

It is Chrome 103 and Safari 16. The G Pad runs Chrome 101, where the method is undefined — so all **13** timed fetches threw before their request was ever made. The config pull was one of them, so the tablet fell back to its own empty defaults and came up showing the setup wizard beside a dashboard of dashes.

`expires()` in `app.js` does the same job with an `AbortController`, which has been everywhere since 2018.

## …and the blank screen then overwrote the host

`pushConfig` had no guard for a client that had never heard back from the host, so the tablet's empty token and station replaced the real ones in the host's `config.json`. That had already happened on this machine — the desktop app carried on from its own localStorage while the shared blob sat empty. A push now needs either a successful pull or a configured screen behind it.

## Verified on the device

- Full dashboard on the G Pad: 93°, live gauges, normals chip
- `?selftest` over the LAN with zero console errors and zero failed asserts
- Host config restored from the desktop app's localStorage

## Not fixed here

The APK needs a WebView newer than the G Pad's stock 76, which predates optional chaining — every module fails to parse and the window renders its header alone. Switching the tablet's WebView provider to its installed Chrome 101 (`cmd webviewupdate set-webview-implementation com.android.chrome`) makes the APK render; no change on this side would.

🤖 Generated with [Claude Code](https://claude.com/claude-code)