### PR TITLE
feat: the Android app holds the screen awake (v3.0.4)

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: David May <davidmay87@gmail.com>
 pkgname=weatherdesk
-pkgver=3.0.3
+pkgver=3.0.4
 pkgrel=1
 pkgdesc="Self-hosted dashboard for a WeatherFlow Tempest station"
 arch=('x86_64' 'aarch64')

--- a/flatpak/io.github.davidmay87.weatherdesk.metainfo.xml
+++ b/flatpak/io.github.davidmay87.weatherdesk.metainfo.xml
@@ -27,6 +27,11 @@
   <url type="bugtracker">https://github.com/d4vid87/weatherdesk/issues</url>
   <content_rating type="oars-1.1"/>
   <releases>
+    <release version="3.0.4" date="2026-08-18">
+      <description>
+        <p>The Android app holds the screen awake while it is open.</p>
+      </description>
+    </release>
     <release version="3.0.3" date="2026-08-18">
       <description>
         <p>Works again on older tablet browsers, and a screen that cannot reach the host no

--- a/flatpak/io.github.davidmay87.weatherdesk.yml
+++ b/flatpak/io.github.davidmay87.weatherdesk.yml
@@ -36,5 +36,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/d4vid87/weatherdesk.git
-        tag: v3.0.3
+        tag: v3.0.4
       - cargo-sources.json

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4744,7 +4744,7 @@ dependencies = [
 
 [[package]]
 name = "weatherdesk"
-version = "3.0.3"
+version = "3.0.4"
 dependencies = [
  "include_dir",
  "rusqlite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weatherdesk"
-version = "3.0.3"
+version = "3.0.4"
 description = "Self-hosted WeatherFlow Tempest dashboard"
 authors = ["David May"]
 license = "MIT"

--- a/src-tauri/gen/android/app/src/main/java/io/github/davidmay87/weatherdesk/MainActivity.kt
+++ b/src-tauri/gen/android/app/src/main/java/io/github/davidmay87/weatherdesk/MainActivity.kt
@@ -1,11 +1,16 @@
 package io.github.davidmay87.weatherdesk
 
 import android.os.Bundle
+import android.view.WindowManager
 import androidx.activity.enableEdgeToEdge
 
 class MainActivity : TauriActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     enableEdgeToEdge()
+    // This app is a wall clock as much as a dashboard: a screen that sleeps after a minute is
+    // no use on a shelf. The flag is scoped to this window, so it lapses the moment the app is
+    // backgrounded — no wake lock to leak and no permission to ask for.
+    window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
     super.onCreate(savedInstanceState)
   }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "WeatherDesk",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "identifier": "io.github.davidmay87.weatherdesk",
   "build": {
     "frontendDist": "../site"


### PR DESCRIPTION
A wall tablet that blanks after a minute is a blank tablet.

`FLAG_KEEP_SCREEN_ON` on the activity's window, set in `MainActivity.onCreate`. It is the platform's own answer and it is scoped to this window: the flag lapses when the app is backgrounded, so there is no wake lock to release, nothing to leak, and no permission to declare in the manifest.

CI builds the checked-in `gen/android` project rather than re-running `android init`, so the Kotlin change ships with the APK.

Desktop is unaffected. A dashboard open in a tablet's *browser* still sleeps on the system timeout — that case wants the Screen Wake Lock API, and isn't in this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)