### PR TITLE
fix: stop forecast-change notifications repeating

### DIFF
--- a/site/js/app.js
+++ b/site/js/app.js
@@ -159,6 +159,15 @@ export function notify({ id, category = 'info', title, body }) {
   el.querySelector('.notif-body').textContent = body || '';
   el.querySelector('.notif-x').onclick = () => el.remove();
   wrap.prepend(el);
+  // A dashboard is left running for days, and nothing here ever took a banner down: an overnight
+  // run of forecast changes buried the screen. Severe alerts stay until dismissed by hand.
+  if (category !== 'severe') setTimeout(() => el.remove(), 30000);
+  // Cap the stack too — the oldest goes first, but never a severe one over a routine one.
+  while (wrap.children.length > 4) {
+    const drop = [...wrap.children].reverse().find((n) => !n.classList.contains('notif-severe'));
+    if (!drop) break;
+    drop.remove();
+  }
   if (quiet) return;
   chime();
   speak(entry);

--- a/site/js/intel.js
+++ b/site/js/intel.js
@@ -145,8 +145,11 @@ export function renderTrack() {
           + ch.items.map((i) => `<div><b>${i.day}</b> ${i.text}</div>`).join('')
         : `<div class="muted">Steady — no notable change vs ${ch.age}h ago.</div>`);
 
+  // The diff reruns on every forecast fetch and the numbers wander by a degree between them, so
+  // an id carrying the text announced the same change again and again — ten banners for one day.
+  // One notification per day per comparison snapshot; the panel above still shows the live text.
   ch.items.forEach((i) => notify({
-    id: `chg-${i.day}-${i.text}`, category: 'changes',
+    id: `chg-${i.key}-${ch.base}`, category: 'changes',
     title: `Forecast change · ${i.day}`, body: i.text,
   }));
 

--- a/site/js/track.js
+++ b/site/js/track.js
@@ -50,9 +50,11 @@ export function changes(fc) {
     if (Math.abs(d.lo - o.lo) >= 3) bits.push(`lo ${num(o.lo)}→${num(d.lo)}${U.temp()}`);
     if (Math.abs((d.pop || 0) - (o.pop || 0)) >= 20) bits.push(`rain ${num(o.pop)}%→${num(d.pop)}%`);
     if (d.cond !== o.cond) bits.push(`${o.cond}→${d.cond}`);
-    if (bits.length) items.push({ day: d.label, text: bits.join(', ') });
+    // key is the calendar day, not the weekday label: 'Wed' comes round again every week, and a
+    // notification id built from the label would collide with last week's.
+    if (bits.length) items.push({ key: d.key, day: d.label, text: bits.join(', ') });
   }
-  return { age: Math.round((Date.now() - old.t) / H), items };
+  return { age: Math.round((Date.now() - old.t) / H), base: old.t, items };
 }
 
 // --- verification: record what was forecast for a future hour, score it when that hour arrives ---


### PR DESCRIPTION
Ten banners covering the whole dashboard, several of them the same day announced twice with slightly different numbers.

## Cause

`intel.js` built the notification id from the change **text**:

```js
id: `chg-${i.day}-${i.text}`
```

The forecast-change diff reruns on every forecast fetch, and the numbers it reports wander by a degree between fetches. Every wander was a new id, so the same day was announced again and again. Two things made it worse:

- Nothing ever removed a banner. A dashboard left running overnight buried itself.
- `Wed` as an id part comes round again every week and collides with last week's.

## Fix

| File | Change |
|---|---|
| `track.js` | `changes()` returns each item's calendar-day `key` and the compared snapshot's `base` timestamp |
| `intel.js` | id is `chg-<date>-<snapshot ts>` — one notification per day per comparison window. The panel still shows the live text |
| `app.js` | banners auto-dismiss after 30s, stack capped at four. Severe alerts stay until dismissed by hand and are never the one evicted by the cap |

## Verification

Headless Chrome against the working tree:

- Two diffs with drifting values (`hi 100→106°F` vs `hi 100→107°F`) produce the identical id `chg-Thu Aug 20 2026-1787060557188` — previously two different ids, two notifications.
- Firing nine notifications leaves four banners, the severe one survives the cap, and a repeated id is ignored (no duplicate banner).
- After 31s only the severe banner remains.
- `?selftest` green, `FAILS: []`.

Branched off `main`, independent of #23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)