### PR TITLE
fix: rearranging panels on a phone (v3.0.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Raspberry Pi, an Android APK, and the `ghcr.io/d4vid87/weatherdesk` container im
 
 ## [Unreleased]
 
+## [3.0.6] — 2026-08-20
+
+### Fixed
+
+- **Panels can be rearranged on a phone again.** At phone width the grips and the × were hidden
+  outright, which left the Android app on a handset with no way to move or hide a panel at all.
+  Settings → **Rearrange panels** now turns them on for that device until the app is closed.
+  Resizing stays off there: a phone gives every panel the full width and its natural height, so a
+  resize handle would drag against a rule it cannot win.
+
 ### Documentation
 
 - New hero GIF walking through first-run setup, the Desk, warnings and radar, and the intro no
@@ -195,7 +205,8 @@ tablet on the LAN — vanilla JS, no build step, no framework, no chart library.
 - Radar from [Hook Echo-WX](https://github.com/d4vid87/hookecho)
 - MIT license
 
-[Unreleased]: https://github.com/d4vid87/weatherdesk/compare/v3.0.5...HEAD
+[Unreleased]: https://github.com/d4vid87/weatherdesk/compare/v3.0.6...HEAD
+[3.0.6]: https://github.com/d4vid87/weatherdesk/compare/v3.0.5...v3.0.6
 [3.0.5]: https://github.com/d4vid87/weatherdesk/compare/v3.0.4...v3.0.5
 [3.0.4]: https://github.com/d4vid87/weatherdesk/compare/v3.0.3...v3.0.4
 [3.0.3]: https://github.com/d4vid87/weatherdesk/compare/v3.0.2...v3.0.3

--- a/README.md
+++ b/README.md
@@ -138,6 +138,13 @@ every grip and handle, so a mounted tablet can't be rearranged by a passing slee
 Both gestures are pointer events, so they work the same with a mouse, a pen or a finger — the
 tablet case is the one that matters, and HTML5 drag-and-drop never fires for touch.
 
+On a phone-sized screen — the Android app on a handset, or a phone browser — the grips are off
+until you ask for them: left on, they sit over the panel titles and swallow taps meant for the
+panel underneath. Settings → **Rearrange panels** turns them on, and the button turns them off
+again. Moving and hiding work there; resizing does not, because a phone gives every panel the full
+width and its natural height anyway. That mode is per-device and lasts until the app is closed —
+the layout it writes is the shared one, so a panel moved on the phone moves on the wall tablet too.
+
 ## Data sources
 
 | Feature | Endpoint |

--- a/site/index.html
+++ b/site/index.html
@@ -193,6 +193,9 @@
   /* Hide sits beside the grip and inherits its show/hide rules, including the locked-layout one. */
   .grip-hide { right: 40px; cursor: pointer; font-size: 18px; padding: 0; }
   .panel-hidden { display: none; }
+  /* controls that only mean something at phone width; the phone media query switches them on,
+     so this has to sit above it — same specificity, and the later rule wins. */
+  .phone-only { display: none; }
 
   /* Fat, visible, touch-sized targets. `touch-action: none` is what lets a finger drag them
      instead of scrolling the page. */
@@ -388,11 +391,18 @@
     .tab { padding: 8px 12px; white-space: nowrap; }
     /* thumbs, not mouse pointers */
     .iconbtn, button { min-height: 40px; }
+    .phone-only { display: inline-flex; }
     #drawer { width: 100%; }
-    /* A phone is where the dashboard is read, not where it is rearranged: the grips and resize
-       handles only covered the panel titles and swallowed taps. Layout editing stays on the
-       desktop, and a panel that cannot be resized has nothing to clip. */
+    /* A phone is where the dashboard is read, not where it is rearranged: left on, the grips and
+       resize handles cover the panel titles and swallow taps. So they are off until Settings →
+       Rearrange panels asks for them, and then only the grip and the × — the width of a panel is
+       forced to the full column here, and its height comes back auto, so a resize handle on a
+       phone would drag against a rule it cannot win. */
     .grip, .grip-hide, .rz { display: none; }
+    body.editing .grip, body.editing .grip-hide { display: flex; }
+    /* the grip sits over the panel's own title while the mode is on; a little headroom keeps the
+       title readable instead of making the user guess which panel they are holding */
+    body.editing [data-panel] { padding-top: 34px; }
     /* min-width is a resize floor, and it is 160px of content plus padding — two of them in a
        360px row is wider than the screen. Nothing resizes here, so the floor goes. */
     [data-panel] { overflow: visible; min-width: 0; }
@@ -831,6 +841,10 @@
     </div>
     <div class="row">
       <button id="btn-layout-reset">Reset panel layout</button>
+      <!-- Phone-only: on anything wider the grips are always there, so the button would toggle
+           nothing. It is per-device, not a setting — the config server syncs one layout to the
+           whole house, and "I am rearranging right now" is not something to sync. -->
+      <button id="btn-edit" class="phone-only">Rearrange panels</button>
     </div>
     <div class="row">
       <input id="layout-name" placeholder="layout name (e.g. tablet)">
@@ -845,7 +859,9 @@
     <div class="muted" style="font-size:12px;margin-top:6px">
       Hover a panel for its grip: drag the grip to move it, drag the bottom-right corner to resize,
       double-click the grip to restore that panel's size. The × beside the grip hides a panel;
-      hidden panels come back from the list above.
+      hidden panels come back from the list above. On a phone the grips would sit over the panel
+      titles, so they wait for <b>Rearrange panels</b> above — move and hide only, since a phone
+      gives every panel the full width anyway.
     </div>
 
     <h2 style="font-size:13px;margin-top:18px">Tabs</h2>

--- a/site/js/boot.js
+++ b/site/js/boot.js
@@ -523,6 +523,25 @@ function applyLock() {
 
 $('btn-lock').onclick = () => { saveSettings({ layoutLocked: !settings().layoutLocked }); applyLock(); };
 
+// Phone rearrange mode. At phone width the grips and the × are hidden, because left on they cover
+// the panel titles and eat taps meant for the panel — so the Android app and a phone browser had
+// no way to move or hide a panel at all. This turns them on for one device: the layout itself is
+// synced house-wide, but "I am rearranging right now" is not, and it should not survive being
+// picked up tomorrow either, which is why it is sessionStorage.
+const editing = () => sessionStorage.getItem('wd.edit') === '1';
+function applyEdit() {
+  document.body.classList.toggle('editing', editing());
+  $('btn-edit').textContent = editing() ? 'Done rearranging' : 'Rearrange panels';
+}
+$('btn-edit').onclick = () => {
+  sessionStorage.setItem('wd.edit', editing() ? '0' : '1');
+  applyEdit();
+  // The grips are in the panels behind the drawer, so leaving it open would hide the thing the
+  // button just turned on.
+  if (editing()) { openDrawer(false); loadDeskRadar(); }
+};
+applyEdit();
+
 const layouts = () => load('wd.layouts', {});
 
 function renderLayouts() {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4744,7 +4744,7 @@ dependencies = [
 
 [[package]]
 name = "weatherdesk"
-version = "3.0.5"
+version = "3.0.6"
 dependencies = [
  "include_dir",
  "rusqlite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weatherdesk"
-version = "3.0.5"
+version = "3.0.6"
 description = "Self-hosted WeatherFlow Tempest dashboard"
 authors = ["David May"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "WeatherDesk",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "identifier": "io.github.davidmay87.weatherdesk",
   "build": {
     "frontendDist": "../site"


### PR DESCRIPTION
## The bug

At phone width (`max-width: 720px`) `.grip, .grip-hide, .rz` are `display: none`. The Android app on an S24 Ultra lays out at 360 CSS px, so it landed in that rule: no grip, no ×, no way to move or hide a panel at all.

That rule went in with #23 for a real reason — left on, the grips sit over the panel titles and swallow taps meant for the panel underneath.

## The fix

The grips come back behind a per-device toggle: **Settings → Rearrange panels**. It lives in `sessionStorage`, not in settings: the layout blob is synced to every screen in the house, but "I am rearranging right now" is not, and it should not survive the app being closed either. Turning it on closes the drawer, since the grips are behind it.

Resize handles stay hidden on a phone. The phone stylesheet forces every panel to the full column and its natural height, so a resize handle there would drag against a rule it cannot win.

## Verified on device

Over adb on an S24 Ultra (Chrome, real `input swipe`, page driven through CDP):

```
width        360
grip hidden  none          <- default
btn visible  flex
body class   ticker-live editing
grip shown   flex
rz hidden    none          <- resize stays off
order before ["hero","ticker","ha"]
order after  ["ticker","ha","radar"]
REORDERED    True
```

Hiding a panel with the × works in the same mode, and toggling the mode off hides the grips again.

Also in here: version to 3.0.6, a CHANGELOG entry, and the README paragraph on Moving things around.

🤖 Generated with [Claude Code](https://claude.com/claude-code)