### PR TITLE
fix: show the grips in phone rearrange mode (v3.0.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Raspberry Pi, an Android APK, and the `ghcr.io/d4vid87/weatherdesk` container im
 
 ## [Unreleased]
 
+## [3.0.7] — 2026-08-20
+
+### Fixed
+
+- Rearrange mode now actually shows the grips in the Android app. The rules that reveal them were
+  scoped inside the phone media query in 3.0.6; they are keyed on the mode alone now, so nothing
+  about how a given webview reports its width can swallow them.
+
 ## [3.0.6] — 2026-08-20
 
 ### Fixed
@@ -205,7 +213,8 @@ tablet on the LAN — vanilla JS, no build step, no framework, no chart library.
 - Radar from [Hook Echo-WX](https://github.com/d4vid87/hookecho)
 - MIT license
 
-[Unreleased]: https://github.com/d4vid87/weatherdesk/compare/v3.0.6...HEAD
+[Unreleased]: https://github.com/d4vid87/weatherdesk/compare/v3.0.7...HEAD
+[3.0.7]: https://github.com/d4vid87/weatherdesk/compare/v3.0.6...v3.0.7
 [3.0.6]: https://github.com/d4vid87/weatherdesk/compare/v3.0.5...v3.0.6
 [3.0.5]: https://github.com/d4vid87/weatherdesk/compare/v3.0.4...v3.0.5
 [3.0.4]: https://github.com/d4vid87/weatherdesk/compare/v3.0.3...v3.0.4

--- a/site/index.html
+++ b/site/index.html
@@ -196,6 +196,12 @@
   /* controls that only mean something at phone width; the phone media query switches them on,
      so this has to sit above it — same specificity, and the later rule wins. */
   .phone-only { display: none; }
+  /* Rearrange mode, for a phone. Keyed on the class alone and marked !important on purpose: the
+     phone block below hides the grips, and this has to beat it wherever the two meet — the button
+     that sets the class only exists at phone width, so there is nothing else to guard against.
+     The headroom keeps the panel's own title readable under the grip while the mode is on. */
+  body.editing .grip, body.editing .grip-hide { display: flex !important; opacity: 1; }
+  body.editing [data-panel] { padding-top: 34px; }
 
   /* Fat, visible, touch-sized targets. `touch-action: none` is what lets a finger drag them
      instead of scrolling the page. */
@@ -399,10 +405,6 @@
        forced to the full column here, and its height comes back auto, so a resize handle on a
        phone would drag against a rule it cannot win. */
     .grip, .grip-hide, .rz { display: none; }
-    body.editing .grip, body.editing .grip-hide { display: flex; }
-    /* the grip sits over the panel's own title while the mode is on; a little headroom keeps the
-       title readable instead of making the user guess which panel they are holding */
-    body.editing [data-panel] { padding-top: 34px; }
     /* min-width is a resize floor, and it is 160px of content plus padding — two of them in a
        360px row is wider than the screen. Nothing resizes here, so the floor goes. */
     [data-panel] { overflow: visible; min-width: 0; }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4744,7 +4744,7 @@ dependencies = [
 
 [[package]]
 name = "weatherdesk"
-version = "3.0.6"
+version = "3.0.7"
 dependencies = [
  "include_dir",
  "rusqlite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weatherdesk"
-version = "3.0.6"
+version = "3.0.7"
 description = "Self-hosted WeatherFlow Tempest dashboard"
 authors = ["David May"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "WeatherDesk",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "identifier": "io.github.davidmay87.weatherdesk",
   "build": {
     "frontendDist": "../site"


### PR DESCRIPTION
Follow-up to #33, verified on the S24 Ultra with the shipped 3.0.6 APK: **Settings → Rearrange panels** toggles (the button flips to *Done rearranging*), the drawer closes — and no grips appear on the Desk. The panel padding the mode adds does not appear either, so the CSS is not matching in that webview even though the rest of the phone stylesheet clearly is.

The reveal rules were inside `@media (max-width: 720px)`, immediately after the rules that hide the grips. This moves them above the media query and keys them on `body.editing` alone:

```css
body.editing .grip, body.editing .grip-hide { display: flex !important; opacity: 1; }
body.editing [data-panel] { padding-top: 34px; }
```

`!important` is deliberate — it has to beat the phone block's `display: none`, and the button that sets the class only exists at phone width, so there is nothing else to guard against.

Re-checked at 360 CSS px in headless Chrome: grips hidden by default, `display: flex` after the toggle, resize handles still hidden, button label flips back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)