### PR TITLE
fix: move a group of panels, and move any panel anywhere (v3.0.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ Raspberry Pi, an Android APK, and the `ghcr.io/d4vid87/weatherdesk` container im
 
 ## [Unreleased]
 
+## [3.0.8] — 2026-08-20
+
+### Fixed
+
+- **A group of panels can be moved as a group.** The gauges block, the day cards and the Desk grid
+  are panels in their own right, but their drag grip sat at the top right — exactly where the last
+  panel in the group's first row puts its own, which covered it. A group's grip and × now sit at
+  the top left, where nothing else lands.
+- **Any panel can be dragged to any part of the Desk, including the top.** A panel used to be
+  trapped in the container it started in, so a card in the Desk grid could be reordered among its
+  neighbours but could never be lifted above the gauges or up beside the hero. A drag now lands in
+  whichever container the pointer is over, innermost first, and the new home is saved with the
+  layout. Dropping a panel into a different grid clears a width that was measured against the old
+  one.
+
 ## [3.0.7] — 2026-08-20
 
 ### Fixed
@@ -213,7 +228,8 @@ tablet on the LAN — vanilla JS, no build step, no framework, no chart library.
 - Radar from [Hook Echo-WX](https://github.com/d4vid87/hookecho)
 - MIT license
 
-[Unreleased]: https://github.com/d4vid87/weatherdesk/compare/v3.0.7...HEAD
+[Unreleased]: https://github.com/d4vid87/weatherdesk/compare/v3.0.8...HEAD
+[3.0.8]: https://github.com/d4vid87/weatherdesk/compare/v3.0.7...v3.0.8
 [3.0.7]: https://github.com/d4vid87/weatherdesk/compare/v3.0.6...v3.0.7
 [3.0.6]: https://github.com/d4vid87/weatherdesk/compare/v3.0.5...v3.0.6
 [3.0.5]: https://github.com/d4vid87/weatherdesk/compare/v3.0.4...v3.0.5

--- a/site/index.html
+++ b/site/index.html
@@ -192,6 +192,11 @@
   .grip:active { cursor: grabbing; }
   /* Hide sits beside the grip and inherits its show/hide rules, including the locked-layout one. */
   .grip-hide { right: 40px; cursor: pointer; font-size: 18px; padding: 0; }
+  /* A group's own furniture goes top left. Top right is where the last panel in the group's first
+     row puts its grip, and the child's sits above the group's — which is why a group could only be
+     taken apart panel by panel and never moved as a unit. */
+  .grip-group { left: 5px; right: auto; }
+  .grip-hide.grip-group { left: 40px; right: auto; }
   .panel-hidden { display: none; }
   /* controls that only mean something at phone width; the phone media query switches them on,
      so this has to sit above it — same specificity, and the later rule wins. */

--- a/site/js/layout.js
+++ b/site/js/layout.js
@@ -79,12 +79,17 @@ export function applyPlacement() {
     const id = el.dataset.panel;
     if (!home.has(id)) home.set(id, el.parentElement);
     const want = state[id]?.tab;
-    const target = want && want !== 'desk' ? $(TABS[want]) : home.get(id);
+    const target = want && want !== 'desk'
+      ? $(TABS[want])
+      : ($(state[id]?.box) || home.get(id));
     if (target && el.parentElement !== target) target.appendChild(el);
   }
 }
 
 export function setTab(id, tab) {
+  // A tab move overrides a container move: the panel is going to that tab's grid, and coming back
+  // sends it to its markup home rather than to whichever Desk container it was last dropped in.
+  delete entry(id).box;
   if (tab === 'desk') delete entry(id).tab;
   else entry(id).tab = tab;
   save();
@@ -182,6 +187,32 @@ function insertPoint(container, x, y) {
   return after ? best.nextElementSibling : best;
 }
 
+// Which container a drop lands in. Panels used to be trapped in the container they were wired in
+// — a card in the Desk grid could reorder among its neighbours but could never be lifted above the
+// gauges or up next to the hero, because both the closure and `insertPoint` only ever saw one
+// container's children. Every wired container is a candidate on every pointermove instead.
+//
+// Deepest-first: the containers nest (the gauges block is itself a panel sitting in the stack), so
+// a pointer inside the gauges is inside the stack too, and the innermost hit is the one the user is
+// actually pointing at. Pointing at a panel that is not a container (the hero) finds the stack,
+// which is how a panel reaches the top of the Desk.
+function containerAt(x, y) {
+  let best = null, bestDepth = -1;
+  for (const c of CONTAINERS.map($)) {
+    // A container on a hidden tab measures 0x0; dragging on the Data tab must not fling the panel
+    // into an invisible Desk container.
+    if (!c || !c.offsetWidth || !c.offsetHeight) continue;
+    // Dropping a group inside itself would detach the very node being dragged.
+    if (dragged && dragged.contains(c)) continue;
+    const r = c.getBoundingClientRect();
+    if (x < r.left || x > r.right || y < r.top || y > r.bottom) continue;
+    let depth = 0;
+    for (let n = c.parentElement; n; n = n.parentElement) depth++;
+    if (depth > bestDepth) { bestDepth = depth; best = c; }
+  }
+  return best;
+}
+
 // One handle per edge the panel can grow along. `e` widens, `s` heightens, `se` does both.
 // Pointer capture means the drag survives the pointer leaving the handle — without it, a fast
 // drag detaches after a few pixels, which is most of what made the old corner feel broken.
@@ -242,18 +273,30 @@ function wire(container) {
     applySaved(el);
     if (el.querySelector(':scope > .grip')) return;
 
+    // A panel that holds other panels (the gauges block, the Desk grid, the day cards) is dragged
+    // as a unit by its own grip — but that grip sat at the top right, exactly where the last panel
+    // in the group's first row puts its own, and the child's won every time. The group's furniture
+    // goes on the left instead, where nothing else lands.
+    const group = !!el.querySelector('[data-panel]');
+
     const grip = document.createElement('div');
-    grip.className = 'grip';
-    grip.title = 'Drag to move · edges to resize · double-click to reset this panel';
+    grip.className = group ? 'grip grip-group' : 'grip';
+    grip.title = group
+      ? 'Drag to move this whole group · edges to resize'
+      : 'Drag to move · edges to resize · double-click to reset this panel';
     grip.innerHTML = '<span>⠿</span>';
 
     // Pointer events rather than HTML5 drag-and-drop: DnD never fires for touch, and this
     // dashboard's home is a tablet. Only the grip starts a move — dragging from the panel body
     // would fight text selection and the radar iframe.
-    let ph = null, offX = 0, offY = 0;
+    // `from` is read at pointerdown, not closed over: a panel keeps its handlers when it moves to
+    // another container, so the container it was wired in goes stale after the first cross-container
+    // drop.
+    let ph = null, offX = 0, offY = 0, from = null;
 
     grip.addEventListener('pointerdown', (e) => {
       e.preventDefault();
+      from = el.parentElement;
       const r = el.getBoundingClientRect();
       offX = e.clientX - r.left;
       offY = e.clientY - r.top;
@@ -265,7 +308,7 @@ function wire(container) {
       ph.className = 'ph';
       ph.style.height = `${el.offsetHeight}px`;
       ph.style.gridColumn = getComputedStyle(el).gridColumn;
-      container.insertBefore(ph, el);
+      from.insertBefore(ph, el);
 
       // The dragged panel is `position: fixed`, so its left/top are layout pixels while the rect
       // it came from is painted ones.
@@ -284,8 +327,10 @@ function wire(container) {
       const k = zoom();
       el.style.left = `${(e.clientX - offX) / k}px`;
       el.style.top = `${(e.clientY - offY) / k}px`;
-      const before = insertPoint(container, e.clientX, e.clientY);
-      if (before !== ph) container.insertBefore(ph, before);
+      const box = containerAt(e.clientX, e.clientY) || ph.parentElement;
+      if (box !== ph.parentElement) ph.style.gridColumn = ''; // the old span means nothing in a new grid
+      const before = insertPoint(box, e.clientX, e.clientY);
+      if (before !== ph || box !== ph.parentElement) box.insertBefore(ph, before);
     });
 
     const drop = (e) => {
@@ -293,14 +338,24 @@ function wire(container) {
       grip.releasePointerCapture(e.pointerId);
       el.classList.remove('dragging');
       document.body.classList.remove('resizing');
-      container.insertBefore(el, ph);
+      const to = ph.parentElement;
+      to.insertBefore(el, ph);
       ph.remove();
       ph = null;
       // Restore whatever the panel's own rules say; a saved size is reapplied on top.
       el.style.left = el.style.top = el.style.width = el.style.height = '';
+      if (to !== from) {
+        const s = entry(el.dataset.panel);
+        // A width is a column span, and a span drawn against a 12-column Desk grid overflows a
+        // two-column gauge block. The panel goes back to its natural size in its new home.
+        delete s.w;
+        setWidth(el, null);
+        if (to === home.get(el.dataset.panel)) delete s.box; else s.box = to.id;
+      }
       applySaved(el);
       dragged = null;
-      recordOrder(container);
+      if (to !== from) recordOrder(from);
+      recordOrder(to);
     };
     grip.addEventListener('pointerup', drop);
     grip.addEventListener('pointercancel', drop);
@@ -317,7 +372,7 @@ function wire(container) {
     // Hide sits on the grip rather than in a drawer checklist: 29 panels make an unreadable list,
     // and `.layout-locked .grip` already puts it out of reach when the layout is locked.
     const hide = document.createElement('button');
-    hide.className = 'grip grip-hide';
+    hide.className = group ? 'grip grip-hide grip-group' : 'grip grip-hide';
     hide.textContent = '×';
     hide.title = 'Hide this panel — restore it under Settings';
     hide.onclick = () => {
@@ -414,6 +469,20 @@ if (location.search.includes('selftest')) {
   console.assert(tabOf('anything') === 'desk', 'layout: a panel with no tab lives on the Desk');
   state = { hero: { tab: 'data' } };
   console.assert(tabOf('hero') === 'data', 'layout: the catalog records the tab');
+
+  // Cross-container drops, against the real Desk: the gauges block is inside the stack, so a
+  // pointer in the gauges must find the gauges (the inner one), while a pointer over a panel that
+  // is not a container must find the stack — that is the path a card takes to the top of the Desk.
+  const gaugesBox = $('gauges'), stackBox = $('desk-stack'), heroBox = $('hero');
+  if (gaugesBox?.offsetWidth && stackBox?.offsetWidth && heroBox?.offsetWidth) {
+    const mid = (el) => { const r = el.getBoundingClientRect(); return [r.left + r.width / 2, r.top + r.height / 2]; };
+    console.assert(containerAt(...mid(gaugesBox)) === gaugesBox, 'layout: the innermost container wins');
+    console.assert(containerAt(...mid(heroBox)) === stackBox, 'layout: a plain panel drops into its stack');
+    // A group cannot be dropped inside itself.
+    dragged = gaugesBox;
+    console.assert(containerAt(...mid(gaugesBox)) === stackBox, 'layout: a group skips its own inside');
+    dragged = null;
+  }
 
   // Painted pixels against layout pixels — the assumption the whole resize path now rests on.
   // Under `html { zoom }` a rect is scaled and `offsetHeight` is not, and reading the wrong one

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4744,7 +4744,7 @@ dependencies = [
 
 [[package]]
 name = "weatherdesk"
-version = "3.0.7"
+version = "3.0.8"
 dependencies = [
  "include_dir",
  "rusqlite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weatherdesk"
-version = "3.0.7"
+version = "3.0.8"
 description = "Self-hosted WeatherFlow Tempest dashboard"
 authors = ["David May"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "WeatherDesk",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "identifier": "io.github.davidmay87.weatherdesk",
   "build": {
     "frontendDist": "../site"


### PR DESCRIPTION
Reported by Mark 'Howie' Howerton: *"how do you move a group of panels? I can't move the collective group but rather each independently. Plus, I can't move any of the panels up to the top - above a group of other panels."*

Two separate bugs.

**The group grip was covered.** `#gauges`, `#daycards` and `#desk-grid` are panels in their own right and already had a grip for dragging the whole group — at `top: 5px; right: 5px`, which is exactly where the last panel in the group's first row puts its own grip. Same `z-index`, child later in the DOM, child wins. A group's grip and × now sit at the top left.

**A drag was confined to one container.** `wire(container)` closed over the container and `insertPoint()` only searched its children, so a card in the Desk grid could be reordered among its neighbours and nothing else. `containerAt()` picks the innermost wired container under the pointer on each `pointermove`, so a panel can be dropped into the stack (above the hero), into the gauges, into the day cards, or into the Desk grid. The container is saved next to the order, `applyPlacement()` honours it, and a group cannot be dropped inside itself.

A cross-container drop clears a saved width: a width is a column span, and a span drawn against the 12-column Desk grid overflows a two-column gauge block.

### Verification

Headless Chrome against the real page, synthetic pointer drags:

```
PASS gauges group has its own grip
PASS group grip sits left, clear of the child grips
PASS child grips unchanged
PASS card lifted out of desk-grid into the stack
PASS the new container is saved
PASS it landed above the hero
PASS the group moved as a unit
PASS all 8 gauges came with it
PASS the move survives a restore
PASS a tab move still wins
PASS coming back from a tab lands home
PASS reset puts everything home
```

`?selftest` gains three asserts for `containerAt` (innermost wins, a plain panel drops into its stack, a group skips its own inside) and reports clean. `cargo build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)