### PR TITLE
chore: put the changelog in the release body and updater notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,21 +16,29 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       release_id: ${{ steps.create.outputs.id }}
+      notes: ${{ steps.create.outputs.notes }}
     steps:
       - uses: actions/checkout@v4
       - id: create
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # The tag's section of the changelog becomes the release body and, via the
+          # notes output, the updater feed's notes — otherwise latest.json ships "".
+          v=${GITHUB_REF_NAME#v}
+          notes=$(awk -v v="$v" '/^## \[/{f=($2=="["v"]")} f' CHANGELOG.md | tail -n +2)
+          body="Download the installer for your OS below. See the README for first-run notes (the apps are unsigned).
+
+          $notes"
           # Create it through the API so the new release's id comes straight back —
           # a draft has no git tag yet, so it can't be looked up by tag afterwards.
           id=$(gh api repos/${{ github.repository }}/releases \
             -f tag_name='${{ github.ref_name }}' \
             -f name='WeatherDesk ${{ github.ref_name }}' \
-            -f body='Download the installer for your OS below. See the README for first-run notes (the apps are unsigned).' \
+            -f body="$body" \
             -F draft=true -q .id)
           test -n "$id"
-          echo "id=$id" >> "$GITHUB_OUTPUT"
+          { echo "id=$id"; echo 'notes<<WD_EOF'; echo "$notes"; echo WD_EOF; } >> "$GITHUB_OUTPUT"
 
   build:
     needs: create-release
@@ -110,6 +118,8 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           releaseId: ${{ needs.create-release.outputs.release_id }}
+          # Only this input — not the release's own body — feeds latest.json's notes.
+          releaseBody: ${{ needs.create-release.outputs.notes }}
           args: ${{ matrix.args }}
           includeUpdaterJson: true
 

--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ The same binary runs with no window and no Tauri in it:
 
 ```sh
 docker run -d --name weatherdesk --restart unless-stopped \
-  --network host -v ./data:/data ghcr.io/d4vid87/weatherdesk:latest
+  --network host -v "$PWD/data:/data" ghcr.io/d4vid87/weatherdesk:latest
 ```
 
 or the `docker-compose.yml` in this repo. Then open `http://<host>:8088`.


### PR DESCRIPTION
The create-release job extracts the tag's CHANGELOG.md section and uses it as the draft release's body, and passes it to tauri-action's `releaseBody` input — the only thing that feeds `latest.json`'s `notes`, which have shipped empty since updater support landed (v3.0.8's feed has `"notes": ""`). Publishing a release no longer needs the changelog pasted in by hand.

Also quotes the README Docker one-liner's bind mount as `"$PWD/data"`; the relative `./data` form fails on older Docker CLIs.

Verified: YAML parses; the exact shell block was dry-run locally against CHANGELOG.md with `GITHUB_REF_NAME=v3.0.8` — body carries the 3.0.8 section, stops before 3.0.7, and the multi-line `GITHUB_OUTPUT` heredoc round-trips. End-to-end proof lands with the next tagged release.