### PR TITLE
fix: keep a station reporting past its first reading

### DIFF
--- a/src-tauri/src/gui.rs
+++ b/src-tauri/src/gui.rs
@@ -130,7 +130,8 @@ pub fn run() {
                     .maximized(cfg!(target_os = "linux"))
                     // the window isn't same-origin with the LAN server, so it needs the port told to it
                     .initialization_script(format!(
-                        "window.__WD_UDP='http://localhost:{port}/udp';window.__WD_SRV='http://localhost:{port}'"
+                        "window.__WD_UDP='http://localhost:{port}/udp';window.__WD_SRV='http://localhost:{port}';{}",
+                        crate::server::ver_script()
                     ));
             }
 

--- a/src-tauri/src/ingest.rs
+++ b/src-tauri/src/ingest.rs
@@ -186,6 +186,11 @@ struct Mem {
     rain: Option<f64>,
     strikes: Option<f64>,
     last_ts: Option<f64>,
+    /// When we heard the last kept report, by our clock.
+    last_wall: Option<u64>,
+    /// The payload's own stamp on that report, unclamped — a poll that returns the same
+    /// reading twice is a duplicate, not a new interval.
+    last_raw: Option<f64>,
 }
 
 /// Difference a running total against the last stored one. A drop means the console rolled its
@@ -204,9 +209,71 @@ fn delta(prev: &mut Option<f64>, cur: f64) -> f64 {
     }
 }
 
-fn mem() -> &'static Mutex<Mem> {
-    static M: OnceLock<Mutex<Mem>> = OnceLock::new();
-    M.get_or_init(|| Mutex::new(Mem::default()))
+/// Counters and throttle state, per source. One shared set used to serve every brand at once,
+/// which meant a Davis poll and an Ecowitt push starved each other, and one console's wrong
+/// clock stopped the lot.
+fn mem() -> &'static Mutex<HashMap<&'static str, Mem>> {
+    static M: OnceLock<Mutex<HashMap<&'static str, Mem>>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Is this report far enough from the last one we kept to be worth a row?
+///
+/// Gated on our own clock, not the payload's. A WeatherLink Live console set a day ahead used to
+/// park `last_ts` in the future and every later report was dropped for good — "grabs data
+/// initially then stops". The payload stamp is only used to spot a poll that returned the same
+/// reading twice.
+fn keep(now: u64, m: &Mem, raw_ts: f64) -> bool {
+    if m.last_raw == Some(raw_ts) {
+        return false;
+    }
+    m.last_wall.map(|w| now.saturating_sub(w) >= MIN_GAP).unwrap_or(true)
+}
+
+// --- Diagnostics ---
+
+/// The last thing each source did, for the drawer. Fixed phrases and status codes only — these
+/// go over HTTP to any LAN client, and the payloads they describe carry keys and passwords.
+struct Diag {
+    at: u64,
+    ok: bool,
+    what: String,
+    rows: u64,
+}
+
+fn diags() -> &'static Mutex<HashMap<&'static str, Diag>> {
+    static D: OnceLock<Mutex<HashMap<&'static str, Diag>>> = OnceLock::new();
+    D.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn note(origin: &'static str, ok: bool, what: &str, stored: bool) {
+    let Ok(mut d) = diags().lock() else { return };
+    let e = d.entry(origin).or_insert(Diag { at: 0, ok: true, what: String::new(), rows: 0 });
+    e.at = epoch();
+    e.ok = ok;
+    e.what = what.into();
+    if stored {
+        e.rows += 1;
+    }
+}
+
+/// `{"push":{"at":...,"ok":true,"what":"stored","rows":42}, ...}`
+pub fn diag_json() -> String {
+    let Ok(d) = diags().lock() else { return "{}".into() };
+    let body = d
+        .iter()
+        .map(|(k, v)| {
+            format!(
+                "\"{k}\":{{\"at\":{},\"ok\":{},\"what\":\"{}\",\"rows\":{}}}",
+                v.at,
+                v.ok,
+                v.what.replace('"', ""),
+                v.rows
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    format!("{{{body}}}")
 }
 
 // --- Publishing ---
@@ -234,8 +301,11 @@ fn n(v: Option<f64>) -> String {
 ///
 /// The counters are only advanced on a report we keep — a differenced total against a report we
 /// threw away would drop that interval's rain on the floor.
-fn take(state: &Arc<State>, f: &Fields, ts: f64, src: i64) -> bool {
+fn take(state: &Arc<State>, f: &Fields, raw_ts: f64, src: i64, origin: &'static str) -> bool {
     let at = epoch();
+    // A console clock that is out by a day would otherwise scatter rows across the archive and
+    // defeat CWOP's staleness guard. Ten minutes of slack is more than any real drift.
+    let ts = raw_ts.clamp(at as f64 - 600.0, at as f64 + 600.0);
     let wind = num(f, &["windspeedmph"]).map(|v| v * MPS_PER_MPH).or_else(|| num(f, &["wind_avg_m_s"]));
     if let (Some(sp), Some(dir)) = (wind, num(f, &["winddir", "wind_dir_deg"])) {
         publish(
@@ -245,13 +315,19 @@ fn take(state: &Arc<State>, f: &Fields, ts: f64, src: i64) -> bool {
         );
     }
 
-    let mut m = mem().lock().unwrap();
-    if m.last_ts.map(|prev| ts - prev < MIN_GAP as f64).unwrap_or(false) {
+    let mut all = mem().lock().unwrap();
+    let m = all.entry(origin).or_default();
+    if !keep(at, m, raw_ts) {
+        drop(all);
+        note(origin, true, "throttled", false);
         return false;
     }
-    let t = tuple(f, ts, &mut m);
+    let t = tuple(f, ts, m);
     m.last_ts = Some(ts);
-    drop(m);
+    m.last_wall = Some(at);
+    m.last_raw = Some(raw_ts);
+    drop(all);
+    note(origin, true, "stored", true);
 
     if let Some(conn) = state.db() {
         store::insert(&conn, &t, src);
@@ -290,6 +366,7 @@ pub fn accept(state: &Arc<State>, url: &str, body: &str) -> u16 {
         let path = url.split('?').next().unwrap_or("");
         let given = crate::server::query(url, "key").unwrap_or_default();
         if given != want && !path.ends_with(&format!("/{want}")) {
+            note("push", false, "wrong ingest key", false);
             return 401;
         }
     }
@@ -297,26 +374,32 @@ pub fn accept(state: &Arc<State>, url: &str, body: &str) -> u16 {
     // Anything with no temperature and no wind in it is not a weather report — a console
     // probing the path, or a browser that wandered in.
     if num(&f, &["tempf", "temperature_c", "temp_c", "temp"]).is_none() && num(&f, &["windspeedmph", "wind_avg_m_s"]).is_none() {
+        note("push", false, "no temperature or wind in report", false);
         return 400;
     }
     // Console clocks are wrong often enough that trusting `dateutc` would scatter rows across
     // the archive. What matters is when we heard it.
-    take(state, &f, epoch() as f64, SRC_INGEST);
+    take(state, &f, epoch() as f64, SRC_INGEST, "push");
     200
 }
 
 // --- Pollers ---
 
-fn get(url: &str) -> Option<serde_json::Value> {
-    // Status code only, never the error's Display: these URLs carry API keys in their query
-    // strings and this string goes to a log.
+fn get(url: &str, origin: &'static str) -> Option<serde_json::Value> {
+    // Status code or transport kind only, never the error's Display: these URLs carry API keys in
+    // their query strings and this string goes to a log.
     match ureq::get(url).timeout(Duration::from_secs(20)).call() {
         Ok(r) => r.into_string().ok().and_then(|b| serde_json::from_str(&b).ok()),
         Err(ureq::Error::Status(code, _)) => {
             eprintln!("weatherdesk: station poll refused ({code})");
+            note(origin, false, &format!("HTTP {code}"), false);
             None
         }
-        Err(_) => None,
+        Err(ureq::Error::Transport(t)) => {
+            eprintln!("weatherdesk: station poll failed ({:?})", t.kind());
+            note(origin, false, &format!("{:?}", t.kind()), false);
+            None
+        }
     }
 }
 
@@ -327,7 +410,7 @@ fn get(url: &str) -> Option<serde_json::Value> {
 /// 10-second poll is the same data at a resolution the gauge can't show; arm the UDP stream if
 /// somebody wants the fast needle.
 fn poll_wll(state: &Arc<State>, host: &str) {
-    let Some(v) = get(&format!("http://{host}/v1/current_conditions")) else { return };
+    let Some(v) = get(&format!("http://{host}/v1/current_conditions"), "wll") else { return };
     let Some(conds) = v.pointer("/data/conditions").and_then(|c| c.as_array()) else { return };
     let ts = v.pointer("/data/ts").and_then(|t| t.as_f64()).unwrap_or(epoch() as f64);
 
@@ -364,7 +447,7 @@ fn poll_wll(state: &Arc<State>, host: &str) {
         }
     }
     if !f.is_empty() {
-        take(state, &f, ts, SRC_INGEST);
+        take(state, &f, ts, SRC_INGEST, "wll");
     }
 }
 
@@ -384,13 +467,13 @@ fn rain_bucket_mm(c: &serde_json::Value) -> f64 {
 /// not point it away from Ambient's own servers.
 fn poll_awn(state: &Arc<State>, api_key: &str, app_key: &str) {
     let url = format!("https://rt.ambientweather.net/v1/devices?applicationKey={app_key}&apiKey={api_key}");
-    let Some(v) = get(&url) else { return };
+    let Some(v) = get(&url, "awn") else { return };
     let Some(last) = v.get(0).and_then(|d| d.get("lastData")) else { return };
     let mut f = Fields::new();
     parse_json(last, &mut f);
     // `dateutc` is milliseconds here, unlike everywhere else in this file.
     let ts = last.get("dateutc").and_then(|t| t.as_f64()).map(|ms| ms / 1000.0).unwrap_or(epoch() as f64);
-    take(state, &f, ts, SRC_CLOUD);
+    take(state, &f, ts, SRC_CLOUD, "awn");
 }
 
 /// La Crosse. Unofficial: there is no published API, and this is the app's own — a Google
@@ -424,9 +507,14 @@ fn bearer(url: &str, token: &str) -> Option<serde_json::Value> {
         Ok(r) => r.into_string().ok().and_then(|b| serde_json::from_str(&b).ok()),
         Err(ureq::Error::Status(code, _)) => {
             eprintln!("weatherdesk: La Crosse read refused ({code})");
+            note("lacrosse", false, &format!("HTTP {code}"), false);
             None
         }
-        Err(_) => None,
+        Err(ureq::Error::Transport(t)) => {
+            eprintln!("weatherdesk: La Crosse read failed ({:?})", t.kind());
+            note("lacrosse", false, &format!("{:?}", t.kind()), false);
+            None
+        }
     }
 }
 
@@ -467,7 +555,7 @@ fn poll_lacrosse(state: &Arc<State>, token: &str) {
         }
     }
     if !f.is_empty() {
-        take(state, &f, ts, SRC_CLOUD);
+        take(state, &f, ts, SRC_CLOUD, "lacrosse");
     }
 }
 
@@ -648,6 +736,36 @@ mod tests {
         assert!((rain_bucket_mm(&serde_json::json!({"rain_size": 4})) - 0.0254).abs() < 1e-9);
         // An absent field is the North American gauge, not zero millimetres a tip.
         assert!((rain_bucket_mm(&serde_json::json!({})) - 0.254).abs() < 1e-9);
+    }
+
+    /// The Davis regression: a console stamping its reports a day into the future used to freeze
+    /// the throttle forever, because the gate compared payload stamps.
+    #[test]
+    fn a_console_clock_in_the_future_cannot_stall_the_gate() {
+        let now = 1_000_000u64;
+        let ahead = now as f64 + 86_400.0;
+        let mut m = Mem::default();
+        assert!(keep(now, &m, ahead), "first report always keeps");
+        m.last_wall = Some(now);
+        m.last_raw = Some(ahead);
+        assert!(!keep(now + 10, &m, ahead + 10.0), "ten seconds later is still the same minute");
+        assert!(keep(now + MIN_GAP, &m, ahead + 60.0), "a minute of our time must let a row through");
+    }
+
+    #[test]
+    fn a_repeated_poll_result_is_not_a_new_interval() {
+        let m = Mem { last_wall: Some(0), last_raw: Some(500.0), ..Mem::default() };
+        assert!(!keep(1_000, &m, 500.0), "same payload stamp is the same reading");
+        assert!(keep(1_000, &m, 501.0));
+    }
+
+    #[test]
+    fn sources_do_not_throttle_each_other() {
+        // Two entries in the map, so a push and a poll each get their own minute.
+        let mut map: HashMap<&'static str, Mem> = HashMap::new();
+        map.insert("push", Mem { last_wall: Some(1_000), ..Mem::default() });
+        assert!(keep(1_010, map.entry("wll").or_default(), 1_010.0));
+        assert!(!keep(1_010, &map["push"], 1_010.0));
     }
 
     #[test]

--- a/src-tauri/src/server.rs
+++ b/src-tauri/src/server.rs
@@ -84,16 +84,25 @@ pub fn epoch() -> u64 {
 /// SQLite — CWOP timestamps its reports this way. Howard Hinnant's civil-from-days, because std
 /// has no calendar and a date crate for six lines would be a dependency to keep updated forever.
 pub fn utc_dhm(epoch: i64) -> (u32, u32, u32) {
+    let (_, _, d, h, mi, _) = utc_ymdhms(epoch);
+    (d, h, mi)
+}
+
+/// The same civil-from-days, with the year and month the Weather Underground protocol wants in
+/// its `dateutc` (`YYYY-MM-DD HH:MM:SS`).
+pub fn utc_ymdhms(epoch: i64) -> (i64, u32, u32, u32, u32, u32) {
     let days = epoch.div_euclid(86_400);
     let secs = epoch.rem_euclid(86_400);
     let z = days + 719_468;
     let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
     let doe = (z - era * 146_097) as u64;
     let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
+    let y = yoe as i64 + era * 400;
     let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
     let mp = (5 * doy + 2) / 153;
     let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
-    (d, (secs / 3600) as u32, ((secs % 3600) / 60) as u32)
+    let m = if mp < 10 { mp + 3 } else { mp - 9 } as u32;
+    (if m <= 2 { y + 1 } else { y }, m, d, (secs / 3600) as u32, ((secs % 3600) / 60) as u32, (secs % 60) as u32)
 }
 
 fn header(k: &str, v: &str) -> Header {
@@ -274,6 +283,26 @@ fn asset(path: &str) -> Option<(Vec<u8>, &'static str)> {
     Some((bytes, mime))
 }
 
+/// The one place the running version comes from. Injected into every page we serve, and into
+/// the desktop window separately (`gui.rs`) — that window loads the site over Tauri's asset
+/// protocol and never touches this server.
+pub fn ver_script() -> String {
+    format!("window.__WD_VER='{}'", env!("CARGO_PKG_VERSION"))
+}
+
+/// Every spelling a console might report on. Firmware varies more than the protocols do: some
+/// Weather Underground clones post to `/updateweatherstation.php` with no prefix, some to
+/// `/weatherstation/updateweatherstation.php?...`, and Ecowitt's `/data/report/` shows up with
+/// and without its trailing slash. Answering all of them is free — `ingest::accept` rejects
+/// anything that isn't a weather report, and `ingestKey` still applies.
+fn is_ingest_path(path: &str) -> bool {
+    path == "/ingest"
+        || path.starts_with("/ingest/")
+        || path.trim_end_matches('/') == "/data/report"
+        || path.starts_with("/weatherstation/")
+        || path == "/updateweatherstation.php"
+}
+
 fn handle(state: &Arc<State>, mut req: Request) {
     let url = req.url().to_string();
     let path = url.split('?').next().unwrap_or("/").to_string();
@@ -283,14 +312,10 @@ fn handle(state: &Arc<State>, mut req: Request) {
         return;
     }
 
-    // Where every other brand of station reports. `/ingest` is ours; the other three are the
-    // paths consoles default to and can't always be talked out of, so we answer on those too.
+    // Where every other brand of station reports. `/ingest` is ours; the rest are the paths
+    // consoles default to and can't always be talked out of, so we answer on those too.
     // A Weather Underground client checks the body for the literal `success`.
-    if path == "/ingest"
-        || path.starts_with("/ingest/")
-        || path == "/data/report/"
-        || path == "/weatherstation/updateweatherstation.php"
-    {
+    if is_ingest_path(&path) {
         let mut body = String::new();
         // A station report is a few hundred bytes. The cap is what stops a stray POST of
         // something else from being read into memory in full.
@@ -320,9 +345,12 @@ fn handle(state: &Arc<State>, mut req: Request) {
             let page = asset("/index.html")
                 .map(|(b, _)| String::from_utf8_lossy(&b).into_owned())
                 .unwrap_or_default()
-                .replace("<head>", "<head><script>window.__WD_PUBLIC=1</script>");
+                .replace("<head>", &format!("<head><script>window.__WD_PUBLIC=1;{}</script>", ver_script()));
             Response::from_string(page).with_header(header("Content-Type", "text/html")).boxed()
         }
+        // What each station source last did, for the drawer and for a screenshot in a bug
+        // report. Fixed phrases and status codes only, so there is nothing here to gate.
+        "/diag" => json(ingest::diag_json()),
         // The National Hurricane Center serves its storm list without CORS headers, so no page
         // can read it. One fixed URL, fetched here and handed on — not a general proxy.
         "/proxy/nhc" => {
@@ -430,6 +458,13 @@ fn handle(state: &Arc<State>, mut req: Request) {
             _ => Response::empty(405).boxed(),
         },
         _ => match asset(&path) {
+            // The page has no other way to know what it is: the site is baked in and the
+            // version lives in the binary.
+            Some((bytes, "text/html")) => {
+                let page = String::from_utf8_lossy(&bytes)
+                    .replace("<head>", &format!("<head><script>{}</script>", ver_script()));
+                Response::from_string(page).with_header(header("Content-Type", "text/html")).boxed()
+            }
             Some((bytes, mime)) => Response::from_data(bytes).with_header(header("Content-Type", mime)).boxed(),
             None => Response::empty(404).boxed(),
         },
@@ -551,6 +586,28 @@ mod tests {
         assert_eq!(utc_dhm(1_700_000_000), (14, 22, 13));
         assert_eq!(utc_dhm(0), (1, 0, 0));
         assert_eq!(utc_dhm(951_782_400), (29, 0, 0)); // leap day
+        assert_eq!(utc_ymdhms(1_700_000_000), (2023, 11, 14, 22, 13, 20));
+        assert_eq!(utc_ymdhms(0), (1970, 1, 1, 0, 0, 0));
+        assert_eq!(utc_ymdhms(951_782_400), (2000, 2, 29, 0, 0, 0));
+    }
+
+    /// Ray's Vevor 60234 reports on a path we used not to answer. Every spelling in this list
+    /// came off a real console; the negatives are the routes the app itself owns.
+    #[test]
+    fn every_console_spelling_reaches_ingest() {
+        for p in [
+            "/ingest",
+            "/ingest/pushpin",
+            "/data/report",
+            "/data/report/",
+            "/weatherstation/updateweatherstation.php",
+            "/updateweatherstation.php",
+        ] {
+            assert!(is_ingest_path(p), "{p} should reach ingest");
+        }
+        for p in ["/config", "/public", "/", "/history/daily", "/diag"] {
+            assert!(!is_ingest_path(p), "{p} must not be swallowed by ingest");
+        }
     }
 
     #[test]


### PR DESCRIPTION
First of five stacked PRs answering the 3.0.8 feedback round (Facebook group + Reddit). Merge in order: this → dashboard-ux → upload-relay → support-and-checksums → changelog.

## The bug

Jack Ahern: *"It grabs data initially then stops"* on a Davis WeatherLink Live, plus *"reporting slower than the obs interval"*.

One throttle (`MIN_GAP`, 55s) was shared by every source, and it compared the timestamp **inside the report** against the last one stored. A console whose clock runs ahead of real time parks that value in the future — and every later reading is dropped until the process restarts. The same shared gate meant a push station and a polled one starved each other.

The gate is now per source (`push` / `wll` / `awn` / `lacrosse`) and runs on our own clock. Report timestamps are clamped to now ± 10 minutes so a badly set console can't scatter rows across the archive or defeat CWOP's staleness guard either.

## Also here

- **WU-clone paths.** Ray Bonneau's Vevor 60234 couldn't connect. Those firmwares vary on the `/weatherstation/` prefix and the trailing slash of `/data/report`; all of them 404'd. `is_ingest_path()` now answers every spelling, with a test listing them.
- **`GET /diag`** — what each source last did, rows stored, how long ago. Fixed phrases and status codes only; nothing it describes is safe to print.
- **Version from the build**, injected into served pages and into the desktop window (which loads over the asset protocol and never touches this server). The page had `APP_VERSION = '2.0.1'` hardcoded while shipping 3.0.8 — George Tranos and Jeff Nordello both asked what version they were on.
- Failed polls log the failure kind instead of going silent. Kind only, never the URL — those carry API keys.

## Verified

`cargo test` (4 new: the skew regression, duplicate poll results, source isolation, path spellings). Live against a headless build: two Ecowitt posts 5s apart with `dateutc` a day ahead → one row stored **stamped now**, the repeat throttled, a third at 60s stored; mesonet-path curl returned `success`; `/diag` read `{"push":{...,"what":"stored","rows":2}}` and greps clean of `PASSKEY`; `curl :8099/ | grep __WD_VER` → `3.0.8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)