### PR TITLE
feat: say what is actually missing, and answer the questions people ask

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -605,6 +605,7 @@
       <div class="gauge" data-panel="g-uv"><h3>UV / solar</h3><div id="g-uv"></div></div>
       <div class="gauge" data-panel="g-ltg"><h3>Lightning</h3><div id="g-ltg"></div></div>
       <div class="gauge" data-panel="g-wet"><h3>Wet bulb</h3><div id="g-wet"></div></div>
+      <div class="gauge" data-panel="g-wbgt"><h3 title="Estimated from temperature, humidity and solar — not a measured WBGT">WBGT</h3><div id="g-wbgt"></div></div>
     </div>
 
     <div class="grid" id="desk-grid" data-panel="desk-grid">
@@ -687,8 +688,9 @@
       <div class="card" style="grid-column: span 2">
         <h2>Nearby stations</h2>
         <div class="row" style="margin:0 0 8px">
-          <input id="add-station-id" placeholder="public station ID (tempestwx.com/map)" inputmode="numeric">
+          <input id="add-station-id" placeholder="public station ID, or an airport code like KBDL">
           <button id="btn-add-station" style="flex:0 0 auto">Add</button>
+          <button id="btn-nearby-reset" style="flex:0 0 auto">Reset dismissed</button>
         </div>
         <div id="signals-table"></div>
       </div>
@@ -776,6 +778,8 @@
     </div>
     <label>Ingest key (optional — pins the upload path)</label>
     <input id="set-ingest-key" type="password" placeholder="blank = any device on the LAN">
+    <label>Station reporting</label>
+    <div id="ingest-diag" class="muted" style="font-size:12px"></div>
     <label>Units</label>
     <select id="set-units"><option value="imperial">Imperial</option><option value="metric">Metric</option></select>
     <label>Obs refresh (seconds)</label><input id="set-refresh" type="number" min="10" step="10">
@@ -839,6 +843,7 @@
       <button id="btn-csv">History CSV</button>
       <button id="btn-backup">Backup archive</button>
       <button id="btn-update">Check for updates</button>
+      <span id="app-version" class="muted" style="font-size:12px;align-self:center"></span>
     </div>
     <input id="import-file" type="file" accept="application/json,.json" hidden>
     <div class="row">
@@ -858,6 +863,8 @@
       <button id="btn-layout-save" style="flex:0 0 auto">Save layout</button>
     </div>
     <div id="layout-list"></div>
+    <h2 style="font-size:13px;margin-top:18px">Hidden panels</h2>
+    <p class="muted" style="font-size:12px">Closed a panel with its ×? Click it here to put it back.</p>
     <div id="hidden-list"></div>
     <h2 style="font-size:13px;margin-top:18px">Panel catalog</h2>
     <p class="muted" style="font-size:12px">Move any Desk panel to another tab. It keeps working
@@ -948,6 +955,76 @@
     <label>Home Assistant URL</label><input id="set-ha-url" placeholder="http://homeassistant.local:8123">
     <label>Home Assistant token</label><input id="set-ha-token" type="password" placeholder="long-lived access token">
     <label>Entities to show</label><input id="set-ha-entities" placeholder="light.porch, sensor.attic_temp">
+
+    <!-- Help. Plain <details> and no script: this is the manual people asked for, and it has to
+         still be readable on an install whose JavaScript is having a bad day. Keep in step with
+         the "Other weather stations" section of the README. -->
+    <h2 style="font-size:13px;margin-top:18px">Help</h2>
+    <details><summary>Set up my station</summary>
+      <div class="muted" style="font-size:12px">
+        <p>Pick your brand above under <b>Another brand of station</b>, then set the location
+          (Places, below). No Tempest and no account of any kind is needed.</p>
+        <p><b>Tempest.</b> tempestwx.com → Settings → Data Authorizations → create a personal use
+          token. The station ID is the number in your tempestwx.com station URL.</p>
+        <p><b>Ecowitt</b> (Wittboy, GW1100/1200/2000/3000). WSView Plus → your gateway →
+          <i>Customized</i> upload. Protocol Ecowitt, server this computer's IP, path
+          <code>/ingest</code>, port <code>8088</code>, interval 16 s or slower.</p>
+        <p><b>Ambient Weather</b> (WS-2902, WS-4000, WS-2000, WS-5000). Console firmware 4.2.8 or
+          newer, then the awnet app → <i>Custom server</i>, same address and path.</p>
+        <p><b>Weather Underground clones</b> (Vevor, Sainlogic, Fine Offset and friends). Point the
+          console's WU server at this computer's IP and port and leave the path alone. Two things
+          catch people out: the console must be allowed plain <b>HTTP</b>, not HTTPS, and it must
+          accept a port other than 80. Firmware that insists on HTTPS or port 80 needs a router
+          rule forwarding port 80 to 8088 on this machine.</p>
+        <p><b>Davis</b> (Vantage Pro2, Vantage Vue). Needs a WeatherLink Live or Console 6313 on
+          the network; put its IP in <i>WeatherLink Live address</i>. No cloud, no key.</p>
+        <p><b>KestrelMet 6000</b>, or an Ambient console you would rather leave on Ambient's
+          servers: both keys from ambientweather.net → My devices → API keys.</p>
+        <p><b>La Crosse.</b> Account email and password. Unofficial — it reads the API their app
+          uses and can stop working without notice.</p>
+        <p><b>AcuRite Iris</b> and anything else: an RTL-SDR dongle and
+          <code>rtl_433 -C si -F json</code> piped to <code>/ingest</code> — see the README.</p>
+        <p>Whatever the brand, <b>Station reporting</b> above shows what has arrived and when.</p>
+      </div>
+    </details>
+    <details><summary>What version am I on, and how do I update?</summary>
+      <div class="muted" style="font-size:12px">The version is beside <b>Check for updates</b>
+        above, which downloads and installs the latest release. Older builds that predate the
+        updater have to be reinstalled once from
+        <a href="https://github.com/d4vid87/weatherdesk/releases">the releases page</a>; settings
+        and history survive.</div>
+    </details>
+    <details><summary>I closed a panel and can't get it back</summary>
+      <div class="muted" style="font-size:12px">The <b>Hidden panels</b> list above — click the
+        panel's name to restore it. <b>Reset panel layout</b> puts everything back at once.</div>
+    </details>
+    <details><summary>Where do the forecasts come from?</summary>
+      <div class="muted" style="font-size:12px">A Tempest station gets WeatherFlow's own forecast.
+        Everything else gets open-meteo, which is free and worldwide — Brazil, Europe, anywhere.
+        Watches and warnings come from the NWS and so are US-only.</div>
+    </details>
+    <details><summary>Can I see this on an iPad, a phone or another computer?</summary>
+      <div class="muted" style="font-size:12px">Yes — open the address in this window's title bar
+        in any browser on the same network. Add <code>/public</code> to the end for a read-only
+        version with no settings drawer, which is the one to leave on a wall tablet.</div>
+    </details>
+    <details><summary>Docker / Raspberry Pi</summary>
+      <div class="muted" style="font-size:12px"><code>ghcr.io/d4vid87/weatherdesk:latest</code>,
+        run with <code>--network host</code> and a volume on <code>/data</code>. There is a
+        compose file in the repo. Headless: no window, same LAN dashboard.</div>
+    </details>
+    <details><summary>Windows Defender quarantined the installer</summary>
+      <div class="muted" style="font-size:12px">A false positive, and a common one for new
+        unsigned installers. Windows Security → Protection history → the item → Restore, then
+        Allow on device. Every release also ships a <code>SHA256SUMS.txt</code> you can check the
+        download against, and each Windows build is reported to Microsoft as a false detection.</div>
+    </details>
+    <details><summary>Something is wrong — where do I report it?</summary>
+      <div class="muted" style="font-size:12px">
+        <a href="https://github.com/d4vid87/weatherdesk/issues">github.com/d4vid87/weatherdesk/issues</a>.
+        For anything about a station not reporting, a screenshot of <b>Station reporting</b> above
+        answers most of the questions first.</div>
+    </details>
 
     <div id="diag" style="margin-top:12px"></div>
     <p class="muted" style="font-size:12px">Token: tempestwx.com → Settings → Data Authorizations → create personal use token.

--- a/site/js/app.js
+++ b/site/js/app.js
@@ -100,6 +100,10 @@ export const configured = () => !!(_settings.token && _settings.stationId);
 // still gates everything that talks to WeatherFlow; this gates what any station can drive.
 export const hasSource = () => configured() || !!(_settings.stationSource && _settings.lat != null);
 
+// Forecasts only need a point on the earth: open-meteo and the NWS are free and worldwide. An
+// install with no station at all still gets a ten-day and a story out of a saved place.
+export const hasLocation = () => coords().lat != null;
+
 // Coordinates the non-Tempest panels point at: the active saved place, else the station.
 export function coords() {
   const p = _settings.places.find((x) => x.id === _settings.activePlace);

--- a/site/js/boot.js
+++ b/site/js/boot.js
@@ -1,5 +1,5 @@
 // Wire the shell: settings drawer, diagnostics, nav, section modules.
-import { settings, saveSettings, configured, hasSource, initNav, applyTabs, fullscreen, refreshAll, notify, load, store, applyEco, ecoOn, initKiosk, expires } from './app.js';
+import { settings, saveSettings, configured, hasSource, hasLocation, initNav, applyTabs, fullscreen, refreshAll, notify, load, store, applyEco, ecoOn, initKiosk, expires } from './app.js';
 import * as api from './api.js';
 import { initDesk, refreshDesk, refreshObs, refreshAlerts, refreshAqi } from './desk.js';
 import { initIntel, refreshModels, refreshNowcast } from './intel.js';
@@ -163,23 +163,48 @@ function fillDrawer() {
   renderCatalog();
   renderStations();
   fillSites();
+  $('app-version').textContent = APP_VERSION ? `v${APP_VERSION}` : '';
+  renderDiag();
 }
 
-// Panels are hidden from their own grip; this is the only way back, so it lists them by id —
-// short enough to recognise, and no second name to keep in sync with the markup.
+// What each station source last did. A snapshot each time the drawer opens is enough — this is
+// read by someone who is already looking at it, or screenshotting it into a bug report.
+function renderDiag() {
+  const el = $('ingest-diag');
+  if (!el) return;
+  fetch(`${SRV}/diag`)
+    .then((r) => r.json())
+    .then((d) => {
+      const rows = Object.entries(d).map(([src, v]) => {
+        const ago = Math.max(0, Math.round(Date.now() / 1000 - v.at));
+        return `<div>${src} · ${v.rows} rows · ${v.ok ? '' : 'error: '}${v.what} · ${ago}s ago</div>`;
+      });
+      el.innerHTML = rows.join('') || 'No station has reported here yet.';
+    })
+    .catch(() => { el.innerHTML = ''; });
+}
+
+// A panel's own heading, so the lists read the way the page does. Falls back to the id for a
+// panel that has no heading — better than a blank button.
+function panelTitle(id) {
+  const el = document.querySelector(`[data-panel="${id}"]`);
+  return el?.querySelector('h1,h2,h3')?.textContent.trim() || id;
+}
+
+// Panels are hidden from their own grip, and this is the only way back — people who close one by
+// accident have to be able to find it, so it lives under its own heading and names the panel.
 function renderHiddenPanels() {
   const ids = hiddenPanels();
   $('hidden-list').innerHTML = ids.length
     ? ids.map((id, i) => `<button class="place-hit" data-hidden="${i}" style="flex:0 0 auto"></button>`).join('')
     : '<div class="muted" style="font-size:12px">No hidden panels</div>';
   $('hidden-list').querySelectorAll('[data-hidden]').forEach((b) => {
-    b.textContent = `${ids[+b.dataset.hidden]} ×`;
+    b.textContent = `${panelTitle(ids[+b.dataset.hidden])} ×`;
     b.onclick = () => { unhide(ids[+b.dataset.hidden]); renderHiddenPanels(); };
   });
 }
 
-// One row per panel: its id (short enough to recognise, and no second name to keep in step with
-// the markup) and the tab it lives on.
+// One row per panel: its heading and the tab it lives on.
 function renderCatalog() {
   const el = $('panel-catalog');
   if (!el) return;
@@ -188,7 +213,7 @@ function renderCatalog() {
       <span class="place-hit" style="flex:1" data-name="${id}"></span>
       <select data-panel-tab="${id}" style="flex:0 0 110px">${opts}</select>
     </div>`).join('');
-  el.querySelectorAll('[data-name]').forEach((s) => { s.textContent = s.dataset.name; });
+  el.querySelectorAll('[data-name]').forEach((s) => { s.textContent = panelTitle(s.dataset.name); });
   el.querySelectorAll('[data-panel-tab]').forEach((sel) => {
     sel.value = tabOf(sel.dataset.panelTab);
     sel.onchange = () => setTab(sel.dataset.panelTab, sel.value);
@@ -446,8 +471,11 @@ $('btn-wiz-demo').onclick = () => {
 // --- what's new ---
 //
 // A dashboard that gains a feature nobody notices has not gained a feature.
-const APP_VERSION = '2.0.1';
+// The binary injects this (`server::ver_script`, and `gui.rs` for the desktop window) so there is
+// one version in the build, not a literal here that goes stale the first release nobody edits it.
+const APP_VERSION = window.__WD_VER || '';
 function changelog() {
+  if (!APP_VERSION) return; // served from a static host: no version to be honest about
   // Raw string, not store(): this is compared to a literal, and a JSON-quoted one never matches.
   const seen = localStorage.getItem('wd.lastVersion');
   if (seen === APP_VERSION) return;
@@ -869,9 +897,16 @@ if (!hasSource() && !PUBLIC) {
   // UDP-only mode: a desktop install with a hub on the LAN has real local data with no token at
   // all, so the modules start either way. Every refresh job early-returns without a token, so an
   // unconfigured init is a handful of no-ops.
-  for (const id of ['tenday', 'alerts', 'story', 'agree-verdict', 'changes', 'verify']) {
-    const el = $(id);
-    if (el) el.innerHTML = '<div class="muted">Needs a Tempest token — open ⚙ Settings</div>';
+  // Only blank them when there is nowhere to point a forecast at. A Tempest token is one way in,
+  // not the only one — saying otherwise sent people off to open accounts they never needed.
+  if (!hasLocation()) {
+    const body = settings().stationSource
+      ? 'Needs a station location — open ⚙ Settings and search a city under Places'
+      : 'Needs a station — open ⚙ Settings';
+    for (const id of ['tenday', 'alerts', 'story', 'agree-verdict', 'changes', 'verify']) {
+      const el = $(id);
+      if (el) el.innerHTML = `<div class="muted">${body}</div>`;
+    }
   }
 }
 // lat/lon must land before the open-meteo/NWS jobs start (resolves immediately when unconfigured)

--- a/site/js/desk.js
+++ b/site/js/desk.js
@@ -1,6 +1,6 @@
 // 01 Desk — current conditions, near-term forecast, alerts, AQI.
 import * as api from './api.js';
-import { settings, coords, configured, hasSource, U, num, timeStr, dayStr, notify, every, stamp, store, load, setStorm } from './app.js';
+import { settings, coords, configured, hasSource, hasLocation, U, num, timeStr, dayStr, notify, every, stamp, store, load, setStorm } from './app.js';
 
 // Last-good copies of the two payloads the Desk can't render without. An outage that spans a
 // reload would otherwise leave the whole page at `--`; in-session failures already keep the DOM.
@@ -38,8 +38,9 @@ export const icon = (k) => ICON[k] || '·';
 
 export async function refreshDesk() {
   // Not `configured()`: an Ecowitt or a Davis has no Tempest forecast, and `api.betterForecast`
-  // hands those installs the open-meteo payload in the same shape.
-  if (!hasSource()) return;
+  // hands those installs the open-meteo payload in the same shape — which needs a location and
+  // nothing else, so an install with only a saved place gets a forecast too.
+  if (!hasSource() && !hasLocation()) return;
   let res;
   try {
     res = await cached('wd.cache.fc', api.betterForecast);

--- a/site/js/pro.js
+++ b/site/js/pro.js
@@ -342,6 +342,13 @@ function renderGauges(fc) {
   const wb = c.wet_bulb_temperature;
   $('g-wet').innerHTML = gauge(icon.thermometer((wb - (metric ? 0 : 32)) / (metric ? 35 : 60)),
     `<b>${num(wb)}°</b><span>Air ${num(c.air_temperature)}°</span>`);
+
+  const taC = metric ? c.air_temperature : (c.air_temperature - 32) / 1.8;
+  const windMps = c.wind_avg / (metric ? 3.6 : 2.23694);
+  const wbgt = wbgtC(taC, c.relative_humidity, c.solar_radiation || 0, windMps);
+  const shown = wbgt == null ? null : metric ? wbgt : wbgt * 1.8 + 32;
+  $('g-wbgt').innerHTML = gauge(icon.thermometer(((shown ?? 0) - (metric ? 0 : 32)) / (metric ? 35 : 60)),
+    `<b>${shown == null ? '--' : num(shown)}°</b><span>${shown == null ? 'no humidity' : `estimated · ${wbgtWord(metric ? shown * 1.8 + 32 : shown)}`}</span>`);
 }
 
 const uvWord = (v) => (v >= 11 ? 'Extreme' : v >= 8 ? 'Very high' : v >= 6 ? 'High' : v >= 3 ? 'Moderate' : 'Low');
@@ -412,6 +419,36 @@ function dewPointC(c, rh) {
   const g = (17.625 * c) / (243.04 + c) + Math.log(rh / 100);
   return (243.04 * g) / (17.625 - g);
 }
+
+// Wet-bulb temperature from air temperature and humidity, Stull (2011). Within a few tenths of
+// a degree over the range a weather station sees.
+function wetBulbC(c, rh) {
+  if (c == null || !(rh > 0)) return null;
+  return c * Math.atan(0.151977 * Math.sqrt(rh + 8.313659))
+    + Math.atan(c + rh) - Math.atan(rh - 1.676331)
+    + 0.00391838 * rh ** 1.5 * Math.atan(0.023101 * rh) - 4.686035;
+}
+
+// Wet Bulb Globe Temperature — the heat-stress number the military, athletics and OSHA use,
+// because it accounts for sun and wind where the heat index doesn't.
+//
+// ponytail: an estimate, because the real instrument is a 15 cm black globe nobody has in their
+// garden. The ISO weighting is exact; what is estimated is the globe temperature, from solar and
+// wind (Hunter & Minyard) — sun heats the globe, wind carries it away, which is the whole reason
+// WBGT says something the heat index doesn't. Out of the sun the globe reads air temperature and
+// the weighting collapses to the indoor form. Swap in Liljegren if somebody turns up with a real
+// globe to compare against.
+export function wbgtC(taC, rh, solar = 0, windMps = 1) {
+  if (taC == null || !(rh > 0)) return null;
+  const tw = wetBulbC(taC, rh);
+  if (tw == null) return null;
+  if (!(solar >= 100)) return 0.7 * tw + 0.3 * taC;
+  const tg = taC + 0.021 * solar - 0.42 * Math.max(windMps, 0) + 3.6;
+  return 0.7 * tw + 0.2 * tg + 0.1 * taC;
+}
+
+// The NWS flag categories, in °F.
+const wbgtWord = (f) => (f >= 90 ? 'Extreme' : f >= 88 ? 'Very high' : f >= 85 ? 'High' : f >= 80 ? 'Moderate' : 'Low');
 
 function renderLocal(o) {
   const metric = settings().units === 'metric';
@@ -490,4 +527,10 @@ if (location.search.includes('selftest')) {
   console.assert(Math.abs(dewPointC(20, 100) - 20) < 0.1, 'pro: saturated air dews at the air temperature');
   console.assert(Math.abs(dewPointC(20, 50) - 9.3) < 0.3, 'pro: 20°C at 50% dews near 9.3°C');
   console.assert(dewPointC(20, 0) === null, 'pro: no humidity, no dew point');
+  console.assert(Math.abs(wetBulbC(20, 50) - 13.7) < 0.5, 'pro: 20°C at 50% wet-bulbs near 13.7°C');
+  const sun = wbgtC(35, 50, 800, 1);
+  console.assert(sun > 31 && sun < 35, 'pro: 35°C/50% in full sun is an extreme WBGT', sun);
+  console.assert(wbgtC(35, 50, 0, 1) < sun, 'pro: shade must read cooler than sun');
+  console.assert(wbgtC(35, 50, 800, 8) < sun, 'pro: wind must carry heat off the globe');
+  console.assert(wbgtC(20, 0, 500, 1) === null, 'pro: no humidity, no WBGT');
 }

--- a/site/js/signals.js
+++ b/site/js/signals.js
@@ -20,9 +20,12 @@ const MPS = { imperial: 2.23694, metric: 3.6 }; // rapid_wind is always m/s
 async function scanNearby() {
   const s = settings();
   const r = s.nearbyRadius;
+  // An airport typed in by hand is not something a scan gets to take away — radius 0 is the
+  // default, so a wholesale clear used to lose it on the next save.
+  const manual = s.nearbyMetar.filter((m) => m.manual);
   if (!r || s.lat == null) {
-    if (s.nearbyMetar.length) {
-      saveSettings({ nearbyMetar: [] });
+    if (s.nearbyMetar.length !== manual.length) {
+      saveSettings({ nearbyMetar: manual });
       refreshSignals();
     }
     return;
@@ -36,9 +39,9 @@ async function scanNearby() {
     // same air mass, half an hour late.
     const metar = (list.features || [])
       .map((f) => ({ id: f.properties.stationIdentifier, name: f.properties.name, c: f.geometry.coordinates }))
-      .filter((x) => !s.nearbyExclude.includes(x.id) && near(x.c[1], x.c[0]))
+      .filter((x) => !s.nearbyExclude.includes(x.id) && !manual.some((m) => m.id === x.id) && near(x.c[1], x.c[0]))
       .slice(0, 3);
-    saveSettings({ nearbyMetar: metar.map(({ id, name }) => ({ id, name })) });
+    saveSettings({ nearbyMetar: [...manual, ...metar.map(({ id, name }) => ({ id, name }))] });
   } catch (e) { console.warn('nearby METAR scan:', e.message); }
   refreshSignals();
 }
@@ -235,14 +238,34 @@ export function initSignals() {
   renderStrikes();
   renderNotifLog();
   $('btn-add-station').onclick = () => {
+    const raw = $('add-station-id').value.trim();
+    // An airport code, for the parts of the country the radius scan reaches past — the NWS
+    // station list is nearest-first and capped, so a neighbouring state's airport never appears
+    // on its own. `api.metarObs()` reads any ICAO the NWS publishes.
+    const icao = (raw.toUpperCase().match(/^[A-Z]{4}$/) || [])[0];
+    if (icao) {
+      const s = settings();
+      saveSettings({
+        nearbyMetar: [...s.nearbyMetar.filter((m) => m.id !== icao), { id: icao, name: icao, manual: true }],
+        nearbyExclude: s.nearbyExclude.filter((x) => x !== icao),
+      });
+      $('add-station-id').value = '';
+      refreshSignals();
+      return;
+    }
     // Pasting the map/station URL is what people actually have in hand. Station ids run 4+
     // digits, so the first such run is the id in every form of the link.
-    const id = ($('add-station-id').value.match(/\d{4,}/) || [])[0];
+    const id = (raw.match(/\d{4,}/) || [])[0];
     if (!id) return;
     const list = settings().nearbyStations;
     if (!list.includes(id)) saveSettings({ nearbyStations: [...list, id] });
     $('add-station-id').value = '';
     refreshSignals();
+  };
+  // The × on a row is remembered forever, which is right until somebody wants one back.
+  $('btn-nearby-reset').onclick = () => {
+    saveSettings({ nearbyExclude: [] });
+    scanNearby();
   };
   // connectWs() self-guards on the token, so a non-Tempest station gets the neighbour scan and
   // the comparison rows without one.


### PR DESCRIPTION
Second of five. Base is `feedback/ingest-reliability` (#40).

Every item here is somebody having had to ask.

- **"Needs a Tempest token" was a lie.** Rob N Tammy Carrigan-Cole and Javier Baez both read that placeholder and concluded they needed a Tempest account. Panels that only need a location now say so, and an install with just a saved place gets its forecast, ten-day and story — open-meteo needs a point on the earth and nothing else. (Also fixes a latent bug: the wizard's placeholder-clear checked for `'Needs a station'`, which the old copy never matched.)
- **Hidden panels are findable.** Mark Howerton closed a panel and couldn't get it back. The restore list shipped — unlabelled, below the saved layouts, showing raw ids like `tenday ×`. It now has its own heading and uses the names the page shows.
- **Version on screen** beside Check for updates, and **Station reporting**, which renders `/diag` from #40 — the answer to "is my console getting through?" without a log file, and the thing to screenshot into a bug report.
- **Airports by code.** David Kaplan: no CT airports, KBDL missing. The NWS station list is nearest-first and capped at 3, so a neighbouring state's airport never appears. Type `KBDL` and it's added, flagged `manual` so later scans don't wipe it. **Reset dismissed** brings back one closed with its ×.
- **WBGT gauge** (Mark Howerton asked where it was). Heat stress including sun and wind, which the heat index ignores. ISO weighting with a wind-corrected globe estimate — labelled as an estimate, because the real instrument is a black globe on a stand.
- **Help section** in Settings: per-brand setup, version/updates, restoring a panel, where forecasts come from (Brazil — Douglas Castro), reading it on an iPad (James Haviland), Docker (Heath Warren), Defender (Jeff Kunnath), and where to file issues. Plain `<details>`, no script. This is the manual poppi_r6daddy and TXCEPE asked for.

## Verified

`node --check` on every module. WBGT values sanity-checked across conditions: 35 °C / 50 % / 800 W/m² at 1 m/s → 33.1 °C (91.6 °F, Extreme); same in shade → 29.1 °C; same in 8 m/s wind → 32.5 °C. `?selftest` asserts added for all three relationships.

Note: I dropped the Bureau of Meteorology formula the plan called for — it ignores wind, which we measure, and returned 34.8 °C where the reference value is ~31–33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)