### PR TITLE
feat: re-upload the station to Weather Underground and PWSWeather

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -836,6 +836,13 @@
     <input id="set-cwop" placeholder="e.g. EW1234">
     <p class="muted" style="font-size:12px">Sends your readings to the Citizen Weather Observer
       Program every ten minutes, where forecast models can use them. Callsigns are public.</p>
+    <label>Weather Underground station ID</label><input id="set-wu-id" placeholder="e.g. KCTHARTF12">
+    <label>Weather Underground station key</label><input id="set-wu-key" type="password">
+    <label>PWSWeather station ID</label><input id="set-pws-id">
+    <label>PWSWeather API key</label><input id="set-pws-key" type="password">
+    <p class="muted" style="font-size:12px">Re-uploads whatever your station reports here, once a
+      minute. Consoles hold one upload address, so pointing yours at WeatherDesk takes it off
+      these networks — this puts it back.</p>
 
     <div class="row">
       <button id="btn-export">Export settings</button>

--- a/site/js/app.js
+++ b/site/js/app.js
@@ -51,6 +51,9 @@ const DEFAULTS = {
   // CWOP callsign to report to (empty = off). Not a secret: callsigns are public and the
   // network's passcode for stations like ours is the constant -1.
   cwopId: '',
+  // Relay the station on to the two networks a console usually uploads to — pointing it at this
+  // app takes it away from them, and most consoles only hold one address.
+  wuId: '', wuKey: '', pwsId: '', pwsKey: '',
   // Broker topics to read back and show on the Home card. [{ topic, label, unit }]
   mqttSubs: [],
   // --- Other brands of station. Empty means a Tempest (or nothing yet). ---

--- a/site/js/boot.js
+++ b/site/js/boot.js
@@ -137,6 +137,10 @@ function fillDrawer() {
   $('set-quiet-end').value = s.quietEnd || '';
   $('set-http-port').value = s.httpPort || '';
   $('set-cwop').value = s.cwopId || '';
+  $('set-wu-id').value = s.wuId || '';
+  $('set-wu-key').value = s.wuKey || '';
+  $('set-pws-id').value = s.pwsId || '';
+  $('set-pws-key').value = s.pwsKey || '';
   $('set-source').value = s.stationSource || '';
   $('set-wll').value = s.wllHost || '';
   $('set-awn-api').value = s.awnApiKey || '';
@@ -291,6 +295,10 @@ $('btn-save').onclick = async () => {
     quietEnd: $('set-quiet-end').value,
     httpPort: $('set-http-port').value.trim(),
     cwopId: $('set-cwop').value.trim().toUpperCase(),
+    wuId: $('set-wu-id').value.trim(),
+    wuKey: $('set-wu-key').value.trim(),
+    pwsId: $('set-pws-id').value.trim(),
+    pwsKey: $('set-pws-key').value.trim(),
     stationSource: $('set-source').value,
     wllHost: $('set-wll').value.trim(),
     awnApiKey: $('set-awn-api').value.trim(),

--- a/src-tauri/src/cwop.rs
+++ b/src-tauri/src/cwop.rs
@@ -84,16 +84,18 @@ pub fn packet(
     )
 }
 
-/// Latest reading plus the rain sums, straight out of the archive.
+/// Latest reading plus the rain sums, straight out of the archive. The tail of the vector — UV,
+/// solar and the day's rain — is only read by the upload relay; CWOP's packet stops at pressure.
 fn latest(conn: &rusqlite::Connection) -> Option<(i64, Vec<Option<f64>>, f64, f64)> {
     let row = conn
         .query_row(
-            "SELECT ts, wind_dir, wind_avg, wind_gust, temp, humidity, pressure FROM obs ORDER BY ts DESC LIMIT 1",
+            "SELECT ts, wind_dir, wind_avg, wind_gust, temp, humidity, pressure, uv, solar, day_rain \
+             FROM obs ORDER BY ts DESC LIMIT 1",
             [],
             |r| {
                 Ok((
                     r.get::<_, i64>(0)?,
-                    vec![r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?, r.get(5)?, r.get(6)?],
+                    vec![r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?, r.get(5)?, r.get(6)?, r.get(7)?, r.get(8)?, r.get(9)?],
                 ))
             },
         )
@@ -145,6 +147,81 @@ pub fn start(data_dir: std::path::PathBuf, cfg_path: std::path::PathBuf) {
     });
 }
 
+// --- Relaying to Weather Underground and PWSWeather ---
+//
+// Both speak the same protocol a station would have spoken to them directly, so this is the same
+// readings sent on a second time. It exists because pointing a console at this app takes it away
+// from wherever it used to upload — Ray's Vevor and every other clone can only be told one
+// address. Ten lines here gives them both.
+
+/// The reading as WU protocol query parameters. Imperial, because the protocol is, and a missing
+/// reading is left out entirely rather than sent as a zero — a zero is a measurement.
+fn wu_params(dateutc: &str, v: &[Option<f64>], rain_1h: f64, rain_day: Option<f64>) -> String {
+    let mut q = format!("&dateutc={}&softwaretype=WeatherDesk&action=updateraw", dateutc.replace(' ', "%20"));
+    let mut put = |k: &str, val: Option<f64>| {
+        if let Some(x) = val {
+            q.push_str(&format!("&{k}={x:.2}"));
+        }
+    };
+    put("winddir", v[0]);
+    put("windspeedmph", v[1].map(|x| x / MPS_PER_MPH));
+    put("windgustmph", v[2].map(|x| x / MPS_PER_MPH));
+    put("tempf", v[3].map(|c| c * 9.0 / 5.0 + 32.0));
+    put("humidity", v[4]);
+    // ponytail: baromin is the station's own pressure, not sea level, so it reads low at
+    // altitude — derive SLP from the configured elevation if anyone up a mountain complains.
+    put("baromin", v[5].map(|mb| mb / MB_PER_INHG));
+    put("UV", v[6]);
+    put("solarradiation", v[7]);
+    put("dailyrainin", rain_day.map(|mm| mm / 25.4));
+    put("rainin", Some(rain_1h / 25.4));
+    q
+}
+
+const MPS_PER_MPH: f64 = 0.447_04;
+const MB_PER_INHG: f64 = 33.863_9;
+
+/// A minute apart while either service has an id and a key. Same settings-per-tick habit as
+/// `start`, so filling the fields in takes effect without a restart.
+pub fn start_relay(data_dir: std::path::PathBuf, cfg_path: std::path::PathBuf) {
+    std::thread::spawn(move || loop {
+        std::thread::sleep(Duration::from_secs(60));
+        let s = |k: &str| crate::setting(&cfg_path, k).unwrap_or_default();
+        let (wu_id, wu_key, pws_id, pws_key) = (s("wuId"), s("wuKey"), s("pwsId"), s("pwsKey"));
+        let wu = !wu_id.is_empty() && !wu_key.is_empty();
+        let pws = !pws_id.is_empty() && !pws_key.is_empty();
+        if !wu && !pws {
+            continue;
+        }
+        let Ok(conn) = store::open(&store::db_path(&data_dir)) else { continue };
+        let Some((ts, v, rain_1h, _)) = latest(&conn) else { continue };
+        // Same reasoning as CWOP: a station that went offline an hour ago must not keep
+        // publishing the same temperature.
+        if (crate::server::epoch() as i64) - ts > 1800 {
+            continue;
+        }
+        let (y, mo, d, h, mi, sec) = crate::server::utc_ymdhms(ts);
+        let params = wu_params(&format!("{y:04}-{mo:02}-{d:02} {h:02}:{mi:02}:{sec:02}"), &v, rain_1h, v[8]);
+        // Status code or error kind only, never the URL or the error's Display: the password
+        // rides in the query string, which is how both of these protocols work.
+        let post = |what: &str, url: String| match ureq::get(&url).timeout(Duration::from_secs(20)).call() {
+            Ok(_) => {}
+            Err(ureq::Error::Status(code, _)) => eprintln!("weatherdesk: {what} upload refused ({code})"),
+            Err(ureq::Error::Transport(t)) => eprintln!("weatherdesk: {what} upload failed ({:?})", t.kind()),
+        };
+        if wu {
+            post("WU", format!(
+                "https://weatherstation.wunderground.com/weatherstation/updateweatherstation.php?ID={wu_id}&PASSWORD={wu_key}{params}"
+            ));
+        }
+        if pws {
+            post("PWSWeather", format!(
+                "https://pwsupdate.pwsweather.com/api/v1/submitwx?ID={pws_id}&PASSWORD={pws_key}{params}"
+            ));
+        }
+    });
+}
+
 // ponytail: one check, against a hand-worked example — every field here is fixed width, and one
 // character out of place makes the whole report silently invalid at the other end.
 #[cfg(test)]
@@ -178,5 +255,29 @@ mod tests {
         let line = packet("EW1", 0.0, 0.0, (1, 0, 0), None, None, None, None, None, None, None, None, None);
         assert!(line.contains("_.../...g...t..."), "a missing reading was reported as zero: {line}");
         assert!(!line.contains('b'), "no pressure means no pressure field: {line}");
+    }
+
+    #[test]
+    fn relay_params_are_imperial() {
+        let v = vec![
+            Some(180.0), Some(4.4704), Some(8.9408), Some(25.0), Some(55.0), Some(1013.21),
+            Some(7.0), Some(812.4), Some(2.54),
+        ];
+        let q = wu_params("2026-08-21 14:30:00", &v, 0.0, v[8]);
+        assert!(q.contains("&tempf=77.00"), "25 C should upload as 77 F: {q}");
+        assert!(q.contains("&windspeedmph=10.00") && q.contains("&windgustmph=20.00"), "{q}");
+        assert!(q.contains("&baromin=29.92"), "{q}");
+        assert!(q.contains("&dailyrainin=0.10"), "{q}");
+        assert!(q.contains("&dateutc=2026-08-21%2014:30:00"), "{q}");
+    }
+
+    #[test]
+    fn a_missing_relay_reading_is_omitted_not_zeroed() {
+        let v = vec![None, None, None, None, Some(55.0), None, None, None, None];
+        let q = wu_params("2026-08-21 14:30:00", &v, 0.0, None);
+        for absent in ["tempf", "winddir", "baromin", "solarradiation", "dailyrainin"] {
+            assert!(!q.contains(absent), "{absent} was sent without a reading behind it: {q}");
+        }
+        assert!(q.contains("&humidity=55.00"), "{q}");
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -67,6 +67,7 @@ pub fn start_services(data_dir: PathBuf, cfg_path: PathBuf) -> (std::sync::Arc<s
     std::thread::spawn(move || server::listen_udp(listener));
     server::start_backfill(state.clone());
     cwop::start(state.data_dir.clone(), state.cfg_path.clone());
+    cwop::start_relay(state.data_dir.clone(), state.cfg_path.clone());
     ingest::start_pollers(state.clone());
     let port = server::serve(state.clone(), want);
     (state, port)

--- a/src-tauri/src/server.rs
+++ b/src-tauri/src/server.rs
@@ -127,7 +127,7 @@ fn json(body: String) -> ResponseBox {
 ///
 /// `cwopId` is deliberately absent: a CWOP callsign is public by design (the network's passcode
 /// for receive-only stations is the constant -1), and redacting it would only break the badge.
-const SECRET_KEYS: [&str; 11] = [
+const SECRET_KEYS: [&str; 13] = [
     "token",
     "mqttUser",
     "mqttPass",
@@ -141,6 +141,10 @@ const SECRET_KEYS: [&str; 11] = [
     "lacrosseEmail",
     "lacrossePass",
     "ingestKey",
+    // Upload keys for the relay. The station ids are public (they name your station on both
+    // sites); the keys are what stop anyone else from posting as you.
+    "wuKey",
+    "pwsKey",
 ];
 
 fn redact(config_json: &str) -> String {
@@ -615,9 +619,10 @@ mod tests {
         let out = redact(
             r#"{"settings":{"token":"abc123","mqttPass":"hunter2","ntfyTopic":"secret-topic",
                 "awnApiKey":"awn-key","awnAppKey":"awn-app","lacrossePass":"lax-pw","ingestKey":"pushpin",
+                "wuKey":"wu-pw","pwsKey":"pws-pw",
                 "stationId":"1234","lat":33.1,"units":"imperial"}}"#,
         );
-        for needle in ["abc123", "hunter2", "secret-topic", "awn-key", "awn-app", "lax-pw", "pushpin"] {
+        for needle in ["abc123", "hunter2", "secret-topic", "awn-key", "awn-app", "lax-pw", "pushpin", "wu-pw", "pws-pw"] {
             assert!(!out.contains(needle), "{needle} leaked into the public config: {out}");
         }
         assert!(out.contains("1234") && out.contains("imperial"), "public config lost the station");


### PR DESCRIPTION
Third of five. Base is `feedback/dashboard-ux` (#41). Asked for by xmrrushx on Reddit.

A console holds one upload address, so pointing it at WeatherDesk takes it off whichever network it was on. That is a real cost to asking someone to switch, and it comes up every time.

Station ID and key for either service under Settings → This computer, and each reading is sent on once a minute. Lives in `cwop.rs`, which already owns outbound uploads — same settings-per-tick habit so filling the fields in works without a restart, same 30-minute staleness guard, no new file and no new dependency.

## Security

The upload URL carries the password (that is how both protocols work), so only a status code or an error kind is ever logged — never the URL, never the error's `Display`. `wuKey` and `pwsKey` join `SECRET_KEYS`, with the redaction test extended to catch them. The station IDs stay public: they name your station on both sites.

## Verified

- Real endpoints, invalid credentials, our exact parameter string: WU returned `unauthorized` (401), PWSWeather `{"error":{"code":"AUTH_FAILED"}}` (401) — both parsed the request and rejected only on the password, so the URL shape, `dateutc` encoding and imperial conversions are accepted.
- Through our own loop, headless with fake keys: both fired on the 60s tick and logged `WU upload refused (401)` / `PWSWeather upload refused (401)`. Log contains no password, no URL, no `https` — grep count 0.
- `cargo test`: unit conversions (25 °C → `tempf=77.00`), a missing reading omitted rather than sent as zero, `utc_ymdhms` including a leap day.

**Not verified:** an actual station page updating, which needs real credentials — there are none in this install. Worth a check with a real PWSWeather key before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)