### PR TITLE
chore: publish checksums, and ask bug reports the right questions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,46 @@
+name: Bug report
+description: Something in WeatherDesk isn't working
+labels: [bug]
+body:
+  - type: input
+    id: version
+    attributes:
+      label: WeatherDesk version
+      description: Settings → beside "Check for updates".
+      placeholder: "3.0.8"
+    validations:
+      required: true
+  - type: dropdown
+    id: install
+    attributes:
+      label: How is it installed?
+      options:
+        - Windows (.msi)
+        - macOS (.dmg)
+        - Linux (.deb / .AppImage)
+        - Raspberry Pi
+        - Docker / headless
+        - Android (.apk)
+        - A browser pointed at another machine
+    validations:
+      required: true
+  - type: input
+    id: station
+    attributes:
+      label: Which weather station?
+      description: Brand and model, or "none — location only".
+      placeholder: "Ambient WS-2902B"
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened?
+      description: What you expected, what you got, and what you had just done.
+    validations:
+      required: true
+  - type: textarea
+    id: diag
+    attributes:
+      label: Station reporting
+      description: >
+        If this is about a station that isn't reporting, paste or screenshot the
+        "Station reporting" lines from Settings — they say what arrived and when.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Setup help
+    url: https://github.com/d4vid87/weatherdesk#other-weather-stations
+    about: Per-brand station setup, Docker, and the read-only dashboard — also in the app under Settings → Help.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,6 +144,33 @@ jobs:
             "https://uploads.github.com/repos/${{ github.repository }}/releases/${{ needs.create-release.outputs.release_id }}/assets?name=WeatherDesk_${{ github.ref_name }}.apk" \
             --input "$apk"
 
+  # Windows Defender false-positives new unsigned installers, and the only honest answer to "is
+  # this safe?" is a checksum published beside the download. Runs after every build job so the
+  # list covers all of them.
+  #
+  # Manual step for each Windows release, and the reason we don't buy a certificate: submit the
+  # .msi at microsoft.com/wdsi/filesubmission as "Software developer" → "Incorrectly detected as
+  # malware". Turnaround is usually a day, and it clears the detection for everyone.
+  checksums:
+    needs: [create-release, build]
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_ID: ${{ needs.create-release.outputs.release_id }}
+        run: |
+          mkdir assets && cd assets
+          # The release is still a draft, so its assets are fetched by id rather than by tag.
+          gh api --paginate "repos/${{ github.repository }}/releases/$RELEASE_ID/assets" \
+            -q '.[] | "\(.id) \(.name)"' | while read -r id name; do
+            gh api -H 'Accept: application/octet-stream' \
+              "repos/${{ github.repository }}/releases/assets/$id" > "$name"
+          done
+          sha256sum ./* > ../SHA256SUMS.txt
+          gh api --method POST -H "Content-Type: text/plain" \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/$RELEASE_ID/assets?name=SHA256SUMS.txt" \
+            --input ../SHA256SUMS.txt
+
   # The headless image, for a house whose always-on machine has no desktop. Two native runners
   # rather than qemu: an emulated arm64 Rust build takes the better part of an hour.
   docker:

--- a/README.md
+++ b/README.md
@@ -176,9 +176,13 @@ slower. Nothing else to fill in here.
 then the awnet app → *Custom server*, same address and path. Ambient's consoles speak their own
 query-string format; the server recognises it.
 
-**Weather Underground protocol.** Many other consoles can only be told a WU server. Point them at
-the app's IP and port and leave the path alone — `/weatherstation/updateweatherstation.php` is
-answered too, with the `success` body those clients look for.
+**Weather Underground protocol.** Many other consoles can only be told a WU server — Vevor,
+Sainlogic, Fine Offset and most of the rest. Point them at the app's IP and port and leave the path
+alone; every spelling those firmwares use is answered (`/weatherstation/updateweatherstation.php`,
+the bare `/updateweatherstation.php`, `/data/report`), with the `success` body they look for. Two
+things catch people out: the console must be allowed plain **HTTP**, not HTTPS, and it must accept
+a port other than 80. Firmware that insists on either needs a router rule forwarding port 80 to
+8088 on this machine.
 
 **Davis — Vantage Pro2, Vantage Pro2 Plus, Vantage Vue.** Needs a WeatherLink Live (or a Console
 6313) on the network. Put its IP in *WeatherLink Live address*; the app polls its local API every
@@ -309,6 +313,10 @@ forecasts, the 10-day list, history charts, model agreement, alerts. The pressur
 
 - **Windows** — run the `.msi`. The app is unsigned, so SmartScreen shows a warning: **More info →
   Run anyway**. Allow the Windows Firewall prompt on first launch, or the tablet can't connect.
+  Defender occasionally quarantines a new unsigned installer outright — a false positive, reported
+  to Microsoft for each release. Windows Security → Protection history → the item → **Restore**,
+  then **Allow on device**. Every release ships a `SHA256SUMS.txt` to check the download against
+  first: `certutil -hashfile WeatherDesk_*.msi SHA256`.
 - **macOS** — open the `.dmg`, drag WeatherDesk to Applications. Unsigned, so on first launch macOS
   refuses it: **System Settings → Privacy & Security → Open Anyway**, or in a terminal
   `xattr -dr com.apple.quarantine /Applications/WeatherDesk.app`.
@@ -410,8 +418,17 @@ reaches the others without a reload. A browser that can't reach the stream falls
 exactly as before.
 
 **Updates.** `Settings → Check for updates` downloads and installs a signed release in place on
-Windows, macOS and Linux packages. Flatpak installs update through Flatpak, and Android stays a
-sideload.
+Windows, macOS and Linux packages. The version you are running is printed beside that button.
+Flatpak installs update through Flatpak, and Android stays a sideload. Builds older than the
+updater have to be reinstalled once from the releases page; settings and history survive.
+
+**Re-uploading to Weather Underground or PWSWeather.** Most consoles hold one upload address, so
+pointing yours at WeatherDesk takes it off whichever network it was on. Put the station ID and key
+for either service under `Settings → This computer` and the app re-sends each reading once a
+minute.
+
+**Panels.** The × beside a panel's grip hides it; `Settings → Hidden panels` lists what is hidden
+and puts it back. `Reset panel layout` restores everything at once.
 
 ### Docker / no desktop at all
 


### PR DESCRIPTION
Fourth of five. Base is `feedback/upload-relay` (#42).

Jeff Kunnath: *"keeps getting quarantined by Microsoft Defender for a Trojan… Is this on the up and up?"* The only honest answer is a checksum published beside the download.

- **`SHA256SUMS.txt` on every release**, built from the release's own assets after all build jobs finish (the release is still a draft at that point, so assets are fetched by id, not tag).
- The submission that actually clears the detection — microsoft.com/wdsi/filesubmission, per Windows release — is written down beside the job that produces the installer instead of living in somebody's head. Free route, deliberately: no certificate purchase.
- **Issue template** asking for version, install type and station brand up front. All three were a round trip before, and the version was unanswerable until #40 put it on screen.
- **README**: the WU-clone paths and the two things that catch those consoles out (plain HTTP, and a port other than 80 — Ray Bonneau's Vevor); restoring a hidden panel; the version display; the relay; Defender's quarantine with the restore steps and `certutil` verification.

`release.yml` and both templates parse as YAML. The workflow itself only runs on a tag, so it is untested beyond that — worth watching on the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)