### PR TITLE
feat: the rest of the 3.0.8 feedback round (#41–#44 re-targeted at main)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,46 @@
+name: Bug report
+description: Something in WeatherDesk isn't working
+labels: [bug]
+body:
+  - type: input
+    id: version
+    attributes:
+      label: WeatherDesk version
+      description: Settings → beside "Check for updates".
+      placeholder: "3.0.8"
+    validations:
+      required: true
+  - type: dropdown
+    id: install
+    attributes:
+      label: How is it installed?
+      options:
+        - Windows (.msi)
+        - macOS (.dmg)
+        - Linux (.deb / .AppImage)
+        - Raspberry Pi
+        - Docker / headless
+        - Android (.apk)
+        - A browser pointed at another machine
+    validations:
+      required: true
+  - type: input
+    id: station
+    attributes:
+      label: Which weather station?
+      description: Brand and model, or "none — location only".
+      placeholder: "Ambient WS-2902B"
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened?
+      description: What you expected, what you got, and what you had just done.
+    validations:
+      required: true
+  - type: textarea
+    id: diag
+    attributes:
+      label: Station reporting
+      description: >
+        If this is about a station that isn't reporting, paste or screenshot the
+        "Station reporting" lines from Settings — they say what arrived and when.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Setup help
+    url: https://github.com/d4vid87/weatherdesk#other-weather-stations
+    about: Per-brand station setup, Docker, and the read-only dashboard — also in the app under Settings → Help.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,6 +144,33 @@ jobs:
             "https://uploads.github.com/repos/${{ github.repository }}/releases/${{ needs.create-release.outputs.release_id }}/assets?name=WeatherDesk_${{ github.ref_name }}.apk" \
             --input "$apk"
 
+  # Windows Defender false-positives new unsigned installers, and the only honest answer to "is
+  # this safe?" is a checksum published beside the download. Runs after every build job so the
+  # list covers all of them.
+  #
+  # Manual step for each Windows release, and the reason we don't buy a certificate: submit the
+  # .msi at microsoft.com/wdsi/filesubmission as "Software developer" → "Incorrectly detected as
+  # malware". Turnaround is usually a day, and it clears the detection for everyone.
+  checksums:
+    needs: [create-release, build]
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_ID: ${{ needs.create-release.outputs.release_id }}
+        run: |
+          mkdir assets && cd assets
+          # The release is still a draft, so its assets are fetched by id rather than by tag.
+          gh api --paginate "repos/${{ github.repository }}/releases/$RELEASE_ID/assets" \
+            -q '.[] | "\(.id) \(.name)"' | while read -r id name; do
+            gh api -H 'Accept: application/octet-stream' \
+              "repos/${{ github.repository }}/releases/assets/$id" > "$name"
+          done
+          sha256sum ./* > ../SHA256SUMS.txt
+          gh api --method POST -H "Content-Type: text/plain" \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/$RELEASE_ID/assets?name=SHA256SUMS.txt" \
+            --input ../SHA256SUMS.txt
+
   # The headless image, for a house whose always-on machine has no desktop. Two native runners
   # rather than qemu: an emulated arm64 Rust build takes the better part of an hour.
   docker:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,56 @@ Raspberry Pi, an Android APK, and the `ghcr.io/d4vid87/weatherdesk` container im
 
 ## [Unreleased]
 
+Everything here came out of what people reported after 3.0.8.
+
+### Fixed
+
+- **A station no longer stops reporting after the first reading.** One throttle was shared by every
+  source, and it compared the timestamp inside the report rather than the clock on this machine. A
+  console set even slightly ahead of real time — a WeatherLink Live is the one people hit — parked
+  that throttle in the future, and every later reading was dropped until the app was restarted. The
+  gate is now per source and runs on our own clock, so a wrong console clock can't stall it, and a
+  push station and a polled one no longer starve each other. Report timestamps are clamped to
+  within ten minutes of now, so a badly set console can't scatter rows across the archive either.
+- **Consoles that upload on a different path are answered.** Weather Underground clones — Vevor,
+  Sainlogic, Fine Offset and the rest — vary in where they post: with and without the
+  `/weatherstation/` prefix, with and without a trailing slash on `/data/report`. All of them reach
+  the ingest route now instead of a 404.
+- **Placeholders stop claiming a Tempest token is required.** Panels that only need a location said
+  "Needs a Tempest token", which sent people off to open accounts they never needed. They now say
+  what is actually missing, and an install with only a saved place gets its forecast, ten-day and
+  story — those come from open-meteo, free and worldwide.
+- Failed station polls say what went wrong. A timeout or a refused connection was silent; it now
+  logs the failure kind (never the URL — these carry API keys).
+
+### Added
+
+- **The running version is on screen**, beside Settings → Check for updates, and comes from the
+  build rather than a string in the page that went stale two releases ago.
+- **Station reporting**, under Settings: what each source last did, how many rows it has stored and
+  how long ago. Answers "is my console actually getting through?" without a log file, and a
+  screenshot of it answers most of a bug report.
+- **Re-upload to Weather Underground and PWSWeather.** A console holds one upload address, so
+  pointing it at WeatherDesk takes it off whichever network it was on. Put the station ID and key
+  for either service under Settings → This computer and each reading is sent on once a minute.
+- **A WBGT gauge** — the heat-stress number that accounts for sun and wind, which the heat index
+  doesn't. Estimated from temperature, humidity, solar and wind, and labelled as an estimate: the
+  real instrument is a black globe on a stand.
+- **Airports can be added by code.** Type an ICAO like `KBDL` under Nearby stations for anywhere the
+  radius scan doesn't reach, and it survives later scans. **Reset dismissed** brings back an airport
+  that was closed with its ×.
+- **A Help section in Settings**: per-brand setup, what version you're on and how to update, how to
+  restore a panel you closed, where the forecasts come from, reading the dashboard on an iPad or
+  phone, Docker, and what to do when Defender quarantines the installer.
+
+### Changed
+
+- The hidden-panel list has its own heading and names panels the way the page does, instead of
+  sitting unlabelled below the saved layouts showing raw ids.
+- Every release now publishes `SHA256SUMS.txt`, so an installer can be checked against it — and
+  each Windows build is reported to Microsoft as a false detection.
+- Bug reports have a template that asks for the version, install type and station brand up front.
+
 ## [3.0.8] — 2026-08-20
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -176,9 +176,13 @@ slower. Nothing else to fill in here.
 then the awnet app → *Custom server*, same address and path. Ambient's consoles speak their own
 query-string format; the server recognises it.
 
-**Weather Underground protocol.** Many other consoles can only be told a WU server. Point them at
-the app's IP and port and leave the path alone — `/weatherstation/updateweatherstation.php` is
-answered too, with the `success` body those clients look for.
+**Weather Underground protocol.** Many other consoles can only be told a WU server — Vevor,
+Sainlogic, Fine Offset and most of the rest. Point them at the app's IP and port and leave the path
+alone; every spelling those firmwares use is answered (`/weatherstation/updateweatherstation.php`,
+the bare `/updateweatherstation.php`, `/data/report`), with the `success` body they look for. Two
+things catch people out: the console must be allowed plain **HTTP**, not HTTPS, and it must accept
+a port other than 80. Firmware that insists on either needs a router rule forwarding port 80 to
+8088 on this machine.
 
 **Davis — Vantage Pro2, Vantage Pro2 Plus, Vantage Vue.** Needs a WeatherLink Live (or a Console
 6313) on the network. Put its IP in *WeatherLink Live address*; the app polls its local API every
@@ -309,6 +313,10 @@ forecasts, the 10-day list, history charts, model agreement, alerts. The pressur
 
 - **Windows** — run the `.msi`. The app is unsigned, so SmartScreen shows a warning: **More info →
   Run anyway**. Allow the Windows Firewall prompt on first launch, or the tablet can't connect.
+  Defender occasionally quarantines a new unsigned installer outright — a false positive, reported
+  to Microsoft for each release. Windows Security → Protection history → the item → **Restore**,
+  then **Allow on device**. Every release ships a `SHA256SUMS.txt` to check the download against
+  first: `certutil -hashfile WeatherDesk_*.msi SHA256`.
 - **macOS** — open the `.dmg`, drag WeatherDesk to Applications. Unsigned, so on first launch macOS
   refuses it: **System Settings → Privacy & Security → Open Anyway**, or in a terminal
   `xattr -dr com.apple.quarantine /Applications/WeatherDesk.app`.
@@ -410,8 +418,17 @@ reaches the others without a reload. A browser that can't reach the stream falls
 exactly as before.
 
 **Updates.** `Settings → Check for updates` downloads and installs a signed release in place on
-Windows, macOS and Linux packages. Flatpak installs update through Flatpak, and Android stays a
-sideload.
+Windows, macOS and Linux packages. The version you are running is printed beside that button.
+Flatpak installs update through Flatpak, and Android stays a sideload. Builds older than the
+updater have to be reinstalled once from the releases page; settings and history survive.
+
+**Re-uploading to Weather Underground or PWSWeather.** Most consoles hold one upload address, so
+pointing yours at WeatherDesk takes it off whichever network it was on. Put the station ID and key
+for either service under `Settings → This computer` and the app re-sends each reading once a
+minute.
+
+**Panels.** The × beside a panel's grip hides it; `Settings → Hidden panels` lists what is hidden
+and puts it back. `Reset panel layout` restores everything at once.
 
 ### Docker / no desktop at all
 

--- a/site/index.html
+++ b/site/index.html
@@ -605,6 +605,7 @@
       <div class="gauge" data-panel="g-uv"><h3>UV / solar</h3><div id="g-uv"></div></div>
       <div class="gauge" data-panel="g-ltg"><h3>Lightning</h3><div id="g-ltg"></div></div>
       <div class="gauge" data-panel="g-wet"><h3>Wet bulb</h3><div id="g-wet"></div></div>
+      <div class="gauge" data-panel="g-wbgt"><h3 title="Estimated from temperature, humidity and solar — not a measured WBGT">WBGT</h3><div id="g-wbgt"></div></div>
     </div>
 
     <div class="grid" id="desk-grid" data-panel="desk-grid">
@@ -687,8 +688,9 @@
       <div class="card" style="grid-column: span 2">
         <h2>Nearby stations</h2>
         <div class="row" style="margin:0 0 8px">
-          <input id="add-station-id" placeholder="public station ID (tempestwx.com/map)" inputmode="numeric">
+          <input id="add-station-id" placeholder="public station ID, or an airport code like KBDL">
           <button id="btn-add-station" style="flex:0 0 auto">Add</button>
+          <button id="btn-nearby-reset" style="flex:0 0 auto">Reset dismissed</button>
         </div>
         <div id="signals-table"></div>
       </div>
@@ -776,6 +778,8 @@
     </div>
     <label>Ingest key (optional — pins the upload path)</label>
     <input id="set-ingest-key" type="password" placeholder="blank = any device on the LAN">
+    <label>Station reporting</label>
+    <div id="ingest-diag" class="muted" style="font-size:12px"></div>
     <label>Units</label>
     <select id="set-units"><option value="imperial">Imperial</option><option value="metric">Metric</option></select>
     <label>Obs refresh (seconds)</label><input id="set-refresh" type="number" min="10" step="10">
@@ -839,6 +843,7 @@
       <button id="btn-csv">History CSV</button>
       <button id="btn-backup">Backup archive</button>
       <button id="btn-update">Check for updates</button>
+      <span id="app-version" class="muted" style="font-size:12px;align-self:center"></span>
     </div>
     <input id="import-file" type="file" accept="application/json,.json" hidden>
     <div class="row">
@@ -858,6 +863,8 @@
       <button id="btn-layout-save" style="flex:0 0 auto">Save layout</button>
     </div>
     <div id="layout-list"></div>
+    <h2 style="font-size:13px;margin-top:18px">Hidden panels</h2>
+    <p class="muted" style="font-size:12px">Closed a panel with its ×? Click it here to put it back.</p>
     <div id="hidden-list"></div>
     <h2 style="font-size:13px;margin-top:18px">Panel catalog</h2>
     <p class="muted" style="font-size:12px">Move any Desk panel to another tab. It keeps working
@@ -948,6 +955,76 @@
     <label>Home Assistant URL</label><input id="set-ha-url" placeholder="http://homeassistant.local:8123">
     <label>Home Assistant token</label><input id="set-ha-token" type="password" placeholder="long-lived access token">
     <label>Entities to show</label><input id="set-ha-entities" placeholder="light.porch, sensor.attic_temp">
+
+    <!-- Help. Plain <details> and no script: this is the manual people asked for, and it has to
+         still be readable on an install whose JavaScript is having a bad day. Keep in step with
+         the "Other weather stations" section of the README. -->
+    <h2 style="font-size:13px;margin-top:18px">Help</h2>
+    <details><summary>Set up my station</summary>
+      <div class="muted" style="font-size:12px">
+        <p>Pick your brand above under <b>Another brand of station</b>, then set the location
+          (Places, below). No Tempest and no account of any kind is needed.</p>
+        <p><b>Tempest.</b> tempestwx.com → Settings → Data Authorizations → create a personal use
+          token. The station ID is the number in your tempestwx.com station URL.</p>
+        <p><b>Ecowitt</b> (Wittboy, GW1100/1200/2000/3000). WSView Plus → your gateway →
+          <i>Customized</i> upload. Protocol Ecowitt, server this computer's IP, path
+          <code>/ingest</code>, port <code>8088</code>, interval 16 s or slower.</p>
+        <p><b>Ambient Weather</b> (WS-2902, WS-4000, WS-2000, WS-5000). Console firmware 4.2.8 or
+          newer, then the awnet app → <i>Custom server</i>, same address and path.</p>
+        <p><b>Weather Underground clones</b> (Vevor, Sainlogic, Fine Offset and friends). Point the
+          console's WU server at this computer's IP and port and leave the path alone. Two things
+          catch people out: the console must be allowed plain <b>HTTP</b>, not HTTPS, and it must
+          accept a port other than 80. Firmware that insists on HTTPS or port 80 needs a router
+          rule forwarding port 80 to 8088 on this machine.</p>
+        <p><b>Davis</b> (Vantage Pro2, Vantage Vue). Needs a WeatherLink Live or Console 6313 on
+          the network; put its IP in <i>WeatherLink Live address</i>. No cloud, no key.</p>
+        <p><b>KestrelMet 6000</b>, or an Ambient console you would rather leave on Ambient's
+          servers: both keys from ambientweather.net → My devices → API keys.</p>
+        <p><b>La Crosse.</b> Account email and password. Unofficial — it reads the API their app
+          uses and can stop working without notice.</p>
+        <p><b>AcuRite Iris</b> and anything else: an RTL-SDR dongle and
+          <code>rtl_433 -C si -F json</code> piped to <code>/ingest</code> — see the README.</p>
+        <p>Whatever the brand, <b>Station reporting</b> above shows what has arrived and when.</p>
+      </div>
+    </details>
+    <details><summary>What version am I on, and how do I update?</summary>
+      <div class="muted" style="font-size:12px">The version is beside <b>Check for updates</b>
+        above, which downloads and installs the latest release. Older builds that predate the
+        updater have to be reinstalled once from
+        <a href="https://github.com/d4vid87/weatherdesk/releases">the releases page</a>; settings
+        and history survive.</div>
+    </details>
+    <details><summary>I closed a panel and can't get it back</summary>
+      <div class="muted" style="font-size:12px">The <b>Hidden panels</b> list above — click the
+        panel's name to restore it. <b>Reset panel layout</b> puts everything back at once.</div>
+    </details>
+    <details><summary>Where do the forecasts come from?</summary>
+      <div class="muted" style="font-size:12px">A Tempest station gets WeatherFlow's own forecast.
+        Everything else gets open-meteo, which is free and worldwide — Brazil, Europe, anywhere.
+        Watches and warnings come from the NWS and so are US-only.</div>
+    </details>
+    <details><summary>Can I see this on an iPad, a phone or another computer?</summary>
+      <div class="muted" style="font-size:12px">Yes — open the address in this window's title bar
+        in any browser on the same network. Add <code>/public</code> to the end for a read-only
+        version with no settings drawer, which is the one to leave on a wall tablet.</div>
+    </details>
+    <details><summary>Docker / Raspberry Pi</summary>
+      <div class="muted" style="font-size:12px"><code>ghcr.io/d4vid87/weatherdesk:latest</code>,
+        run with <code>--network host</code> and a volume on <code>/data</code>. There is a
+        compose file in the repo. Headless: no window, same LAN dashboard.</div>
+    </details>
+    <details><summary>Windows Defender quarantined the installer</summary>
+      <div class="muted" style="font-size:12px">A false positive, and a common one for new
+        unsigned installers. Windows Security → Protection history → the item → Restore, then
+        Allow on device. Every release also ships a <code>SHA256SUMS.txt</code> you can check the
+        download against, and each Windows build is reported to Microsoft as a false detection.</div>
+    </details>
+    <details><summary>Something is wrong — where do I report it?</summary>
+      <div class="muted" style="font-size:12px">
+        <a href="https://github.com/d4vid87/weatherdesk/issues">github.com/d4vid87/weatherdesk/issues</a>.
+        For anything about a station not reporting, a screenshot of <b>Station reporting</b> above
+        answers most of the questions first.</div>
+    </details>
 
     <div id="diag" style="margin-top:12px"></div>
     <p class="muted" style="font-size:12px">Token: tempestwx.com → Settings → Data Authorizations → create personal use token.

--- a/site/index.html
+++ b/site/index.html
@@ -836,6 +836,13 @@
     <input id="set-cwop" placeholder="e.g. EW1234">
     <p class="muted" style="font-size:12px">Sends your readings to the Citizen Weather Observer
       Program every ten minutes, where forecast models can use them. Callsigns are public.</p>
+    <label>Weather Underground station ID</label><input id="set-wu-id" placeholder="e.g. KCTHARTF12">
+    <label>Weather Underground station key</label><input id="set-wu-key" type="password">
+    <label>PWSWeather station ID</label><input id="set-pws-id">
+    <label>PWSWeather API key</label><input id="set-pws-key" type="password">
+    <p class="muted" style="font-size:12px">Re-uploads whatever your station reports here, once a
+      minute. Consoles hold one upload address, so pointing yours at WeatherDesk takes it off
+      these networks — this puts it back.</p>
 
     <div class="row">
       <button id="btn-export">Export settings</button>

--- a/site/js/app.js
+++ b/site/js/app.js
@@ -100,6 +100,10 @@ export const configured = () => !!(_settings.token && _settings.stationId);
 // still gates everything that talks to WeatherFlow; this gates what any station can drive.
 export const hasSource = () => configured() || !!(_settings.stationSource && _settings.lat != null);
 
+// Forecasts only need a point on the earth: open-meteo and the NWS are free and worldwide. An
+// install with no station at all still gets a ten-day and a story out of a saved place.
+export const hasLocation = () => coords().lat != null;
+
 // Coordinates the non-Tempest panels point at: the active saved place, else the station.
 export function coords() {
   const p = _settings.places.find((x) => x.id === _settings.activePlace);

--- a/site/js/app.js
+++ b/site/js/app.js
@@ -51,6 +51,9 @@ const DEFAULTS = {
   // CWOP callsign to report to (empty = off). Not a secret: callsigns are public and the
   // network's passcode for stations like ours is the constant -1.
   cwopId: '',
+  // Relay the station on to the two networks a console usually uploads to — pointing it at this
+  // app takes it away from them, and most consoles only hold one address.
+  wuId: '', wuKey: '', pwsId: '', pwsKey: '',
   // Broker topics to read back and show on the Home card. [{ topic, label, unit }]
   mqttSubs: [],
   // --- Other brands of station. Empty means a Tempest (or nothing yet). ---

--- a/site/js/boot.js
+++ b/site/js/boot.js
@@ -137,6 +137,10 @@ function fillDrawer() {
   $('set-quiet-end').value = s.quietEnd || '';
   $('set-http-port').value = s.httpPort || '';
   $('set-cwop').value = s.cwopId || '';
+  $('set-wu-id').value = s.wuId || '';
+  $('set-wu-key').value = s.wuKey || '';
+  $('set-pws-id').value = s.pwsId || '';
+  $('set-pws-key').value = s.pwsKey || '';
   $('set-source').value = s.stationSource || '';
   $('set-wll').value = s.wllHost || '';
   $('set-awn-api').value = s.awnApiKey || '';
@@ -291,6 +295,10 @@ $('btn-save').onclick = async () => {
     quietEnd: $('set-quiet-end').value,
     httpPort: $('set-http-port').value.trim(),
     cwopId: $('set-cwop').value.trim().toUpperCase(),
+    wuId: $('set-wu-id').value.trim(),
+    wuKey: $('set-wu-key').value.trim(),
+    pwsId: $('set-pws-id').value.trim(),
+    pwsKey: $('set-pws-key').value.trim(),
     stationSource: $('set-source').value,
     wllHost: $('set-wll').value.trim(),
     awnApiKey: $('set-awn-api').value.trim(),

--- a/site/js/boot.js
+++ b/site/js/boot.js
@@ -1,5 +1,5 @@
 // Wire the shell: settings drawer, diagnostics, nav, section modules.
-import { settings, saveSettings, configured, hasSource, initNav, applyTabs, fullscreen, refreshAll, notify, load, store, applyEco, ecoOn, initKiosk, expires } from './app.js';
+import { settings, saveSettings, configured, hasSource, hasLocation, initNav, applyTabs, fullscreen, refreshAll, notify, load, store, applyEco, ecoOn, initKiosk, expires } from './app.js';
 import * as api from './api.js';
 import { initDesk, refreshDesk, refreshObs, refreshAlerts, refreshAqi } from './desk.js';
 import { initIntel, refreshModels, refreshNowcast } from './intel.js';
@@ -163,23 +163,48 @@ function fillDrawer() {
   renderCatalog();
   renderStations();
   fillSites();
+  $('app-version').textContent = APP_VERSION ? `v${APP_VERSION}` : '';
+  renderDiag();
 }
 
-// Panels are hidden from their own grip; this is the only way back, so it lists them by id —
-// short enough to recognise, and no second name to keep in sync with the markup.
+// What each station source last did. A snapshot each time the drawer opens is enough — this is
+// read by someone who is already looking at it, or screenshotting it into a bug report.
+function renderDiag() {
+  const el = $('ingest-diag');
+  if (!el) return;
+  fetch(`${SRV}/diag`)
+    .then((r) => r.json())
+    .then((d) => {
+      const rows = Object.entries(d).map(([src, v]) => {
+        const ago = Math.max(0, Math.round(Date.now() / 1000 - v.at));
+        return `<div>${src} · ${v.rows} rows · ${v.ok ? '' : 'error: '}${v.what} · ${ago}s ago</div>`;
+      });
+      el.innerHTML = rows.join('') || 'No station has reported here yet.';
+    })
+    .catch(() => { el.innerHTML = ''; });
+}
+
+// A panel's own heading, so the lists read the way the page does. Falls back to the id for a
+// panel that has no heading — better than a blank button.
+function panelTitle(id) {
+  const el = document.querySelector(`[data-panel="${id}"]`);
+  return el?.querySelector('h1,h2,h3')?.textContent.trim() || id;
+}
+
+// Panels are hidden from their own grip, and this is the only way back — people who close one by
+// accident have to be able to find it, so it lives under its own heading and names the panel.
 function renderHiddenPanels() {
   const ids = hiddenPanels();
   $('hidden-list').innerHTML = ids.length
     ? ids.map((id, i) => `<button class="place-hit" data-hidden="${i}" style="flex:0 0 auto"></button>`).join('')
     : '<div class="muted" style="font-size:12px">No hidden panels</div>';
   $('hidden-list').querySelectorAll('[data-hidden]').forEach((b) => {
-    b.textContent = `${ids[+b.dataset.hidden]} ×`;
+    b.textContent = `${panelTitle(ids[+b.dataset.hidden])} ×`;
     b.onclick = () => { unhide(ids[+b.dataset.hidden]); renderHiddenPanels(); };
   });
 }
 
-// One row per panel: its id (short enough to recognise, and no second name to keep in step with
-// the markup) and the tab it lives on.
+// One row per panel: its heading and the tab it lives on.
 function renderCatalog() {
   const el = $('panel-catalog');
   if (!el) return;
@@ -188,7 +213,7 @@ function renderCatalog() {
       <span class="place-hit" style="flex:1" data-name="${id}"></span>
       <select data-panel-tab="${id}" style="flex:0 0 110px">${opts}</select>
     </div>`).join('');
-  el.querySelectorAll('[data-name]').forEach((s) => { s.textContent = s.dataset.name; });
+  el.querySelectorAll('[data-name]').forEach((s) => { s.textContent = panelTitle(s.dataset.name); });
   el.querySelectorAll('[data-panel-tab]').forEach((sel) => {
     sel.value = tabOf(sel.dataset.panelTab);
     sel.onchange = () => setTab(sel.dataset.panelTab, sel.value);
@@ -446,8 +471,11 @@ $('btn-wiz-demo').onclick = () => {
 // --- what's new ---
 //
 // A dashboard that gains a feature nobody notices has not gained a feature.
-const APP_VERSION = '2.0.1';
+// The binary injects this (`server::ver_script`, and `gui.rs` for the desktop window) so there is
+// one version in the build, not a literal here that goes stale the first release nobody edits it.
+const APP_VERSION = window.__WD_VER || '';
 function changelog() {
+  if (!APP_VERSION) return; // served from a static host: no version to be honest about
   // Raw string, not store(): this is compared to a literal, and a JSON-quoted one never matches.
   const seen = localStorage.getItem('wd.lastVersion');
   if (seen === APP_VERSION) return;
@@ -869,9 +897,16 @@ if (!hasSource() && !PUBLIC) {
   // UDP-only mode: a desktop install with a hub on the LAN has real local data with no token at
   // all, so the modules start either way. Every refresh job early-returns without a token, so an
   // unconfigured init is a handful of no-ops.
-  for (const id of ['tenday', 'alerts', 'story', 'agree-verdict', 'changes', 'verify']) {
-    const el = $(id);
-    if (el) el.innerHTML = '<div class="muted">Needs a Tempest token — open ⚙ Settings</div>';
+  // Only blank them when there is nowhere to point a forecast at. A Tempest token is one way in,
+  // not the only one — saying otherwise sent people off to open accounts they never needed.
+  if (!hasLocation()) {
+    const body = settings().stationSource
+      ? 'Needs a station location — open ⚙ Settings and search a city under Places'
+      : 'Needs a station — open ⚙ Settings';
+    for (const id of ['tenday', 'alerts', 'story', 'agree-verdict', 'changes', 'verify']) {
+      const el = $(id);
+      if (el) el.innerHTML = `<div class="muted">${body}</div>`;
+    }
   }
 }
 // lat/lon must land before the open-meteo/NWS jobs start (resolves immediately when unconfigured)

--- a/site/js/desk.js
+++ b/site/js/desk.js
@@ -1,6 +1,6 @@
 // 01 Desk — current conditions, near-term forecast, alerts, AQI.
 import * as api from './api.js';
-import { settings, coords, configured, hasSource, U, num, timeStr, dayStr, notify, every, stamp, store, load, setStorm } from './app.js';
+import { settings, coords, configured, hasSource, hasLocation, U, num, timeStr, dayStr, notify, every, stamp, store, load, setStorm } from './app.js';
 
 // Last-good copies of the two payloads the Desk can't render without. An outage that spans a
 // reload would otherwise leave the whole page at `--`; in-session failures already keep the DOM.
@@ -38,8 +38,9 @@ export const icon = (k) => ICON[k] || '·';
 
 export async function refreshDesk() {
   // Not `configured()`: an Ecowitt or a Davis has no Tempest forecast, and `api.betterForecast`
-  // hands those installs the open-meteo payload in the same shape.
-  if (!hasSource()) return;
+  // hands those installs the open-meteo payload in the same shape — which needs a location and
+  // nothing else, so an install with only a saved place gets a forecast too.
+  if (!hasSource() && !hasLocation()) return;
   let res;
   try {
     res = await cached('wd.cache.fc', api.betterForecast);

--- a/site/js/pro.js
+++ b/site/js/pro.js
@@ -342,6 +342,13 @@ function renderGauges(fc) {
   const wb = c.wet_bulb_temperature;
   $('g-wet').innerHTML = gauge(icon.thermometer((wb - (metric ? 0 : 32)) / (metric ? 35 : 60)),
     `<b>${num(wb)}°</b><span>Air ${num(c.air_temperature)}°</span>`);
+
+  const taC = metric ? c.air_temperature : (c.air_temperature - 32) / 1.8;
+  const windMps = c.wind_avg / (metric ? 3.6 : 2.23694);
+  const wbgt = wbgtC(taC, c.relative_humidity, c.solar_radiation || 0, windMps);
+  const shown = wbgt == null ? null : metric ? wbgt : wbgt * 1.8 + 32;
+  $('g-wbgt').innerHTML = gauge(icon.thermometer(((shown ?? 0) - (metric ? 0 : 32)) / (metric ? 35 : 60)),
+    `<b>${shown == null ? '--' : num(shown)}°</b><span>${shown == null ? 'no humidity' : `estimated · ${wbgtWord(metric ? shown * 1.8 + 32 : shown)}`}</span>`);
 }
 
 const uvWord = (v) => (v >= 11 ? 'Extreme' : v >= 8 ? 'Very high' : v >= 6 ? 'High' : v >= 3 ? 'Moderate' : 'Low');
@@ -412,6 +419,36 @@ function dewPointC(c, rh) {
   const g = (17.625 * c) / (243.04 + c) + Math.log(rh / 100);
   return (243.04 * g) / (17.625 - g);
 }
+
+// Wet-bulb temperature from air temperature and humidity, Stull (2011). Within a few tenths of
+// a degree over the range a weather station sees.
+function wetBulbC(c, rh) {
+  if (c == null || !(rh > 0)) return null;
+  return c * Math.atan(0.151977 * Math.sqrt(rh + 8.313659))
+    + Math.atan(c + rh) - Math.atan(rh - 1.676331)
+    + 0.00391838 * rh ** 1.5 * Math.atan(0.023101 * rh) - 4.686035;
+}
+
+// Wet Bulb Globe Temperature — the heat-stress number the military, athletics and OSHA use,
+// because it accounts for sun and wind where the heat index doesn't.
+//
+// ponytail: an estimate, because the real instrument is a 15 cm black globe nobody has in their
+// garden. The ISO weighting is exact; what is estimated is the globe temperature, from solar and
+// wind (Hunter & Minyard) — sun heats the globe, wind carries it away, which is the whole reason
+// WBGT says something the heat index doesn't. Out of the sun the globe reads air temperature and
+// the weighting collapses to the indoor form. Swap in Liljegren if somebody turns up with a real
+// globe to compare against.
+export function wbgtC(taC, rh, solar = 0, windMps = 1) {
+  if (taC == null || !(rh > 0)) return null;
+  const tw = wetBulbC(taC, rh);
+  if (tw == null) return null;
+  if (!(solar >= 100)) return 0.7 * tw + 0.3 * taC;
+  const tg = taC + 0.021 * solar - 0.42 * Math.max(windMps, 0) + 3.6;
+  return 0.7 * tw + 0.2 * tg + 0.1 * taC;
+}
+
+// The NWS flag categories, in °F.
+const wbgtWord = (f) => (f >= 90 ? 'Extreme' : f >= 88 ? 'Very high' : f >= 85 ? 'High' : f >= 80 ? 'Moderate' : 'Low');
 
 function renderLocal(o) {
   const metric = settings().units === 'metric';
@@ -490,4 +527,10 @@ if (location.search.includes('selftest')) {
   console.assert(Math.abs(dewPointC(20, 100) - 20) < 0.1, 'pro: saturated air dews at the air temperature');
   console.assert(Math.abs(dewPointC(20, 50) - 9.3) < 0.3, 'pro: 20°C at 50% dews near 9.3°C');
   console.assert(dewPointC(20, 0) === null, 'pro: no humidity, no dew point');
+  console.assert(Math.abs(wetBulbC(20, 50) - 13.7) < 0.5, 'pro: 20°C at 50% wet-bulbs near 13.7°C');
+  const sun = wbgtC(35, 50, 800, 1);
+  console.assert(sun > 31 && sun < 35, 'pro: 35°C/50% in full sun is an extreme WBGT', sun);
+  console.assert(wbgtC(35, 50, 0, 1) < sun, 'pro: shade must read cooler than sun');
+  console.assert(wbgtC(35, 50, 800, 8) < sun, 'pro: wind must carry heat off the globe');
+  console.assert(wbgtC(20, 0, 500, 1) === null, 'pro: no humidity, no WBGT');
 }

--- a/site/js/signals.js
+++ b/site/js/signals.js
@@ -20,9 +20,12 @@ const MPS = { imperial: 2.23694, metric: 3.6 }; // rapid_wind is always m/s
 async function scanNearby() {
   const s = settings();
   const r = s.nearbyRadius;
+  // An airport typed in by hand is not something a scan gets to take away — radius 0 is the
+  // default, so a wholesale clear used to lose it on the next save.
+  const manual = s.nearbyMetar.filter((m) => m.manual);
   if (!r || s.lat == null) {
-    if (s.nearbyMetar.length) {
-      saveSettings({ nearbyMetar: [] });
+    if (s.nearbyMetar.length !== manual.length) {
+      saveSettings({ nearbyMetar: manual });
       refreshSignals();
     }
     return;
@@ -36,9 +39,9 @@ async function scanNearby() {
     // same air mass, half an hour late.
     const metar = (list.features || [])
       .map((f) => ({ id: f.properties.stationIdentifier, name: f.properties.name, c: f.geometry.coordinates }))
-      .filter((x) => !s.nearbyExclude.includes(x.id) && near(x.c[1], x.c[0]))
+      .filter((x) => !s.nearbyExclude.includes(x.id) && !manual.some((m) => m.id === x.id) && near(x.c[1], x.c[0]))
       .slice(0, 3);
-    saveSettings({ nearbyMetar: metar.map(({ id, name }) => ({ id, name })) });
+    saveSettings({ nearbyMetar: [...manual, ...metar.map(({ id, name }) => ({ id, name }))] });
   } catch (e) { console.warn('nearby METAR scan:', e.message); }
   refreshSignals();
 }
@@ -235,14 +238,34 @@ export function initSignals() {
   renderStrikes();
   renderNotifLog();
   $('btn-add-station').onclick = () => {
+    const raw = $('add-station-id').value.trim();
+    // An airport code, for the parts of the country the radius scan reaches past — the NWS
+    // station list is nearest-first and capped, so a neighbouring state's airport never appears
+    // on its own. `api.metarObs()` reads any ICAO the NWS publishes.
+    const icao = (raw.toUpperCase().match(/^[A-Z]{4}$/) || [])[0];
+    if (icao) {
+      const s = settings();
+      saveSettings({
+        nearbyMetar: [...s.nearbyMetar.filter((m) => m.id !== icao), { id: icao, name: icao, manual: true }],
+        nearbyExclude: s.nearbyExclude.filter((x) => x !== icao),
+      });
+      $('add-station-id').value = '';
+      refreshSignals();
+      return;
+    }
     // Pasting the map/station URL is what people actually have in hand. Station ids run 4+
     // digits, so the first such run is the id in every form of the link.
-    const id = ($('add-station-id').value.match(/\d{4,}/) || [])[0];
+    const id = (raw.match(/\d{4,}/) || [])[0];
     if (!id) return;
     const list = settings().nearbyStations;
     if (!list.includes(id)) saveSettings({ nearbyStations: [...list, id] });
     $('add-station-id').value = '';
     refreshSignals();
+  };
+  // The × on a row is remembered forever, which is right until somebody wants one back.
+  $('btn-nearby-reset').onclick = () => {
+    saveSettings({ nearbyExclude: [] });
+    scanNearby();
   };
   // connectWs() self-guards on the token, so a non-Tempest station gets the neighbour scan and
   // the comparison rows without one.

--- a/src-tauri/src/cwop.rs
+++ b/src-tauri/src/cwop.rs
@@ -84,16 +84,18 @@ pub fn packet(
     )
 }
 
-/// Latest reading plus the rain sums, straight out of the archive.
+/// Latest reading plus the rain sums, straight out of the archive. The tail of the vector — UV,
+/// solar and the day's rain — is only read by the upload relay; CWOP's packet stops at pressure.
 fn latest(conn: &rusqlite::Connection) -> Option<(i64, Vec<Option<f64>>, f64, f64)> {
     let row = conn
         .query_row(
-            "SELECT ts, wind_dir, wind_avg, wind_gust, temp, humidity, pressure FROM obs ORDER BY ts DESC LIMIT 1",
+            "SELECT ts, wind_dir, wind_avg, wind_gust, temp, humidity, pressure, uv, solar, day_rain \
+             FROM obs ORDER BY ts DESC LIMIT 1",
             [],
             |r| {
                 Ok((
                     r.get::<_, i64>(0)?,
-                    vec![r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?, r.get(5)?, r.get(6)?],
+                    vec![r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?, r.get(5)?, r.get(6)?, r.get(7)?, r.get(8)?, r.get(9)?],
                 ))
             },
         )
@@ -145,6 +147,81 @@ pub fn start(data_dir: std::path::PathBuf, cfg_path: std::path::PathBuf) {
     });
 }
 
+// --- Relaying to Weather Underground and PWSWeather ---
+//
+// Both speak the same protocol a station would have spoken to them directly, so this is the same
+// readings sent on a second time. It exists because pointing a console at this app takes it away
+// from wherever it used to upload — Ray's Vevor and every other clone can only be told one
+// address. Ten lines here gives them both.
+
+/// The reading as WU protocol query parameters. Imperial, because the protocol is, and a missing
+/// reading is left out entirely rather than sent as a zero — a zero is a measurement.
+fn wu_params(dateutc: &str, v: &[Option<f64>], rain_1h: f64, rain_day: Option<f64>) -> String {
+    let mut q = format!("&dateutc={}&softwaretype=WeatherDesk&action=updateraw", dateutc.replace(' ', "%20"));
+    let mut put = |k: &str, val: Option<f64>| {
+        if let Some(x) = val {
+            q.push_str(&format!("&{k}={x:.2}"));
+        }
+    };
+    put("winddir", v[0]);
+    put("windspeedmph", v[1].map(|x| x / MPS_PER_MPH));
+    put("windgustmph", v[2].map(|x| x / MPS_PER_MPH));
+    put("tempf", v[3].map(|c| c * 9.0 / 5.0 + 32.0));
+    put("humidity", v[4]);
+    // ponytail: baromin is the station's own pressure, not sea level, so it reads low at
+    // altitude — derive SLP from the configured elevation if anyone up a mountain complains.
+    put("baromin", v[5].map(|mb| mb / MB_PER_INHG));
+    put("UV", v[6]);
+    put("solarradiation", v[7]);
+    put("dailyrainin", rain_day.map(|mm| mm / 25.4));
+    put("rainin", Some(rain_1h / 25.4));
+    q
+}
+
+const MPS_PER_MPH: f64 = 0.447_04;
+const MB_PER_INHG: f64 = 33.863_9;
+
+/// A minute apart while either service has an id and a key. Same settings-per-tick habit as
+/// `start`, so filling the fields in takes effect without a restart.
+pub fn start_relay(data_dir: std::path::PathBuf, cfg_path: std::path::PathBuf) {
+    std::thread::spawn(move || loop {
+        std::thread::sleep(Duration::from_secs(60));
+        let s = |k: &str| crate::setting(&cfg_path, k).unwrap_or_default();
+        let (wu_id, wu_key, pws_id, pws_key) = (s("wuId"), s("wuKey"), s("pwsId"), s("pwsKey"));
+        let wu = !wu_id.is_empty() && !wu_key.is_empty();
+        let pws = !pws_id.is_empty() && !pws_key.is_empty();
+        if !wu && !pws {
+            continue;
+        }
+        let Ok(conn) = store::open(&store::db_path(&data_dir)) else { continue };
+        let Some((ts, v, rain_1h, _)) = latest(&conn) else { continue };
+        // Same reasoning as CWOP: a station that went offline an hour ago must not keep
+        // publishing the same temperature.
+        if (crate::server::epoch() as i64) - ts > 1800 {
+            continue;
+        }
+        let (y, mo, d, h, mi, sec) = crate::server::utc_ymdhms(ts);
+        let params = wu_params(&format!("{y:04}-{mo:02}-{d:02} {h:02}:{mi:02}:{sec:02}"), &v, rain_1h, v[8]);
+        // Status code or error kind only, never the URL or the error's Display: the password
+        // rides in the query string, which is how both of these protocols work.
+        let post = |what: &str, url: String| match ureq::get(&url).timeout(Duration::from_secs(20)).call() {
+            Ok(_) => {}
+            Err(ureq::Error::Status(code, _)) => eprintln!("weatherdesk: {what} upload refused ({code})"),
+            Err(ureq::Error::Transport(t)) => eprintln!("weatherdesk: {what} upload failed ({:?})", t.kind()),
+        };
+        if wu {
+            post("WU", format!(
+                "https://weatherstation.wunderground.com/weatherstation/updateweatherstation.php?ID={wu_id}&PASSWORD={wu_key}{params}"
+            ));
+        }
+        if pws {
+            post("PWSWeather", format!(
+                "https://pwsupdate.pwsweather.com/api/v1/submitwx?ID={pws_id}&PASSWORD={pws_key}{params}"
+            ));
+        }
+    });
+}
+
 // ponytail: one check, against a hand-worked example — every field here is fixed width, and one
 // character out of place makes the whole report silently invalid at the other end.
 #[cfg(test)]
@@ -178,5 +255,29 @@ mod tests {
         let line = packet("EW1", 0.0, 0.0, (1, 0, 0), None, None, None, None, None, None, None, None, None);
         assert!(line.contains("_.../...g...t..."), "a missing reading was reported as zero: {line}");
         assert!(!line.contains('b'), "no pressure means no pressure field: {line}");
+    }
+
+    #[test]
+    fn relay_params_are_imperial() {
+        let v = vec![
+            Some(180.0), Some(4.4704), Some(8.9408), Some(25.0), Some(55.0), Some(1013.21),
+            Some(7.0), Some(812.4), Some(2.54),
+        ];
+        let q = wu_params("2026-08-21 14:30:00", &v, 0.0, v[8]);
+        assert!(q.contains("&tempf=77.00"), "25 C should upload as 77 F: {q}");
+        assert!(q.contains("&windspeedmph=10.00") && q.contains("&windgustmph=20.00"), "{q}");
+        assert!(q.contains("&baromin=29.92"), "{q}");
+        assert!(q.contains("&dailyrainin=0.10"), "{q}");
+        assert!(q.contains("&dateutc=2026-08-21%2014:30:00"), "{q}");
+    }
+
+    #[test]
+    fn a_missing_relay_reading_is_omitted_not_zeroed() {
+        let v = vec![None, None, None, None, Some(55.0), None, None, None, None];
+        let q = wu_params("2026-08-21 14:30:00", &v, 0.0, None);
+        for absent in ["tempf", "winddir", "baromin", "solarradiation", "dailyrainin"] {
+            assert!(!q.contains(absent), "{absent} was sent without a reading behind it: {q}");
+        }
+        assert!(q.contains("&humidity=55.00"), "{q}");
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -67,6 +67,7 @@ pub fn start_services(data_dir: PathBuf, cfg_path: PathBuf) -> (std::sync::Arc<s
     std::thread::spawn(move || server::listen_udp(listener));
     server::start_backfill(state.clone());
     cwop::start(state.data_dir.clone(), state.cfg_path.clone());
+    cwop::start_relay(state.data_dir.clone(), state.cfg_path.clone());
     ingest::start_pollers(state.clone());
     let port = server::serve(state.clone(), want);
     (state, port)

--- a/src-tauri/src/server.rs
+++ b/src-tauri/src/server.rs
@@ -127,7 +127,7 @@ fn json(body: String) -> ResponseBox {
 ///
 /// `cwopId` is deliberately absent: a CWOP callsign is public by design (the network's passcode
 /// for receive-only stations is the constant -1), and redacting it would only break the badge.
-const SECRET_KEYS: [&str; 11] = [
+const SECRET_KEYS: [&str; 13] = [
     "token",
     "mqttUser",
     "mqttPass",
@@ -141,6 +141,10 @@ const SECRET_KEYS: [&str; 11] = [
     "lacrosseEmail",
     "lacrossePass",
     "ingestKey",
+    // Upload keys for the relay. The station ids are public (they name your station on both
+    // sites); the keys are what stop anyone else from posting as you.
+    "wuKey",
+    "pwsKey",
 ];
 
 fn redact(config_json: &str) -> String {
@@ -615,9 +619,10 @@ mod tests {
         let out = redact(
             r#"{"settings":{"token":"abc123","mqttPass":"hunter2","ntfyTopic":"secret-topic",
                 "awnApiKey":"awn-key","awnAppKey":"awn-app","lacrossePass":"lax-pw","ingestKey":"pushpin",
+                "wuKey":"wu-pw","pwsKey":"pws-pw",
                 "stationId":"1234","lat":33.1,"units":"imperial"}}"#,
         );
-        for needle in ["abc123", "hunter2", "secret-topic", "awn-key", "awn-app", "lax-pw", "pushpin"] {
+        for needle in ["abc123", "hunter2", "secret-topic", "awn-key", "awn-app", "lax-pw", "pushpin", "wu-pw", "pws-pw"] {
             assert!(!out.contains(needle), "{needle} leaked into the public config: {out}");
         }
         assert!(out.contains("1234") && out.contains("imperial"), "public config lost the station");


### PR DESCRIPTION
#41–#44 were stacked, so each merged into its parent branch rather than into `main` — only #40 landed here. This is the same four commits, already reviewed there, cherry-picked onto `main`.

- **#41** — placeholders that stop claiming a Tempest token is needed, findable hidden panels, version + Station reporting in the drawer, airports by ICAO, WBGT gauge, in-app Help.
- **#42** — Weather Underground / PWSWeather upload relay.
- **#43** — `SHA256SUMS.txt` on every release, issue template, README gaps.
- **#44** — the `[Unreleased]` changelog entry.

Verified after the cherry-pick: tree is byte-identical to the reviewed tip (`git diff` against it is empty), `cargo test` 23 passed, every JS module parses.

Once this is in, the intermediate branches (`feedback/ingest-reliability`, `feedback/dashboard-ux`, `feedback/upload-relay`, `feedback/support-and-checksums`, `feedback/changelog`) are dead and can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)