### PR TITLE
chore: release v3.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Raspberry Pi, an Android APK, and the `ghcr.io/d4vid87/weatherdesk` container im
 
 ## [Unreleased]
 
+## [3.0.9] — 2026-08-21
+
 Everything here came out of what people reported after 3.0.8.
 
 ### Fixed
@@ -278,7 +280,8 @@ tablet on the LAN — vanilla JS, no build step, no framework, no chart library.
 - Radar from [Hook Echo-WX](https://github.com/d4vid87/hookecho)
 - MIT license
 
-[Unreleased]: https://github.com/d4vid87/weatherdesk/compare/v3.0.8...HEAD
+[Unreleased]: https://github.com/d4vid87/weatherdesk/compare/v3.0.9...HEAD
+[3.0.9]: https://github.com/d4vid87/weatherdesk/compare/v3.0.8...v3.0.9
 [3.0.8]: https://github.com/d4vid87/weatherdesk/compare/v3.0.7...v3.0.8
 [3.0.7]: https://github.com/d4vid87/weatherdesk/compare/v3.0.6...v3.0.7
 [3.0.6]: https://github.com/d4vid87/weatherdesk/compare/v3.0.5...v3.0.6

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4744,7 +4744,7 @@ dependencies = [
 
 [[package]]
 name = "weatherdesk"
-version = "3.0.8"
+version = "3.0.9"
 dependencies = [
  "include_dir",
  "rusqlite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weatherdesk"
-version = "3.0.8"
+version = "3.0.9"
 description = "Self-hosted WeatherFlow Tempest dashboard"
 authors = ["David May"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "WeatherDesk",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "identifier": "io.github.davidmay87.weatherdesk",
   "build": {
     "frontendDist": "../site"


### PR DESCRIPTION
Version bump and changelog heading for the feedback round (#40, #45).

- `tauri.conf.json`, `Cargo.toml`, `Cargo.lock` → 3.0.9
- `[Unreleased]` → `## [3.0.9] — 2026-08-21`, plus the compare links

Checked: `awk` extracts the right section for the release body and updater notes, and a headless build serves `__WD_VER='3.0.9'`.

Merging this and pushing `v3.0.9` fires the release workflow — including the first run of the new `checksums` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)