### PR TITLE
fix: a stray percent sign in an /ingest body takes the HTTP threads down

### DIFF
--- a/src-tauri/src/ingest.rs
+++ b/src-tauri/src/ingest.rs
@@ -50,13 +50,15 @@ fn percent_decode(s: &str) -> String {
     while i < b.len() {
         match b[i] {
             b'+' => out.push(b' '),
+            // `.get` rather than `&s[..]`: a `%` in front of a multi-byte character lands the end
+            // of that slice mid-character, and indexing there panics on a request anyone can send.
             b'%' if i + 2 < b.len() => {
-                match u8::from_str_radix(&s[i + 1..i + 3], 16) {
-                    Ok(v) => {
+                match s.get(i + 1..i + 3).and_then(|h| u8::from_str_radix(h, 16).ok()) {
+                    Some(v) => {
                         out.push(v);
                         i += 2;
                     }
-                    Err(_) => out.push(b'%'),
+                    None => out.push(b'%'),
                 }
             }
             c => out.push(c),
@@ -773,5 +775,18 @@ mod tests {
         let f = collect("/ingest", "dateutc=2026-08-19+14%3A30%3A00&tempf=77.0");
         assert_eq!(f.get("dateutc").map(String::as_str), Some("2026-08-19 14:30:00"));
         assert_eq!(f.get("tempf").map(String::as_str), Some("77.0"));
+    }
+
+    /// A `%` in front of a multi-byte character used to put a str slice mid-character and panic.
+    /// `/ingest` takes no credentials and a panicked worker thread is never replaced, so a handful
+    /// of crafted requests was enough to leave the dashboard unanswered.
+    #[test]
+    fn a_stray_percent_before_a_wide_character_does_not_panic() {
+        assert_eq!(percent_decode("%41"), "A", "a real escape must still decode");
+        assert_eq!(percent_decode("%€"), "%€");
+        assert_eq!(percent_decode("a%€b"), "a%€b");
+        // And arriving the way it would off the wire: the rest of the body still parses.
+        let f = collect("/ingest", "tempf=%€&humidity=55");
+        assert_eq!(f.get("humidity").map(String::as_str), Some("55"));
     }
 }


### PR DESCRIPTION
`/ingest` takes no credentials by default, and one POST can take out an HTTP worker thread.

`percent_decode` reads the two escape digits with `&s[i + 1..i + 3]`. When the byte after the `%` starts a multi-byte character, that range ends mid-character, and slicing a `str` there panics.

Reproduce against a stock v3.0.9 container, four times, one per worker:

```
curl -X POST --data-binary 'tempf=%€' http://<host>:8088/ingest
```

`WORKERS` is 4, the `server.recv()` loops are never respawned and there is no `catch_unwind`, so the fourth request leaves nothing answering on 8088. The container stays `running` and the hub's UDP listener keeps recording on its own thread, so the archive stays healthy while the page stops loading — which is what makes it read as a network problem rather than a crash.

Before:

```
GET /            -> HTTP 200
crafted POST x4  -> accepted
GET /            -> curl exit 56, connection reset
container state: running, 4 "not a char boundary" panics in the log
```

After:

```
GET /            -> HTTP 200
crafted POST x4  -> HTTP 400
GET /            -> HTTP 200
0 panics
```

The fix reads the same two bytes through `s.get()`, which returns `None` where the slice would have split a character. That falls into the branch a malformed escape already took — emit the `%` and carry on — so `a%€b` decodes to itself and `%41` still decodes to `A`.

The test feeds a `%` in front of a multi-byte character both directly and through `collect()`, and checks that a real escape still decodes. It panics on the old code with the message above.
