### PR TITLE
fix: run the container as a normal user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,11 +15,20 @@ FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=build /src/src-tauri/target/release/weatherdesk /usr/local/bin/weatherdesk
+# Nothing here needs root: both ports are above 1024 and /data is the only thing written.
+# The uid is fixed at 1000:1000 so a bind mount can be matched from the host. IMPORTANT: a
+# ./data left by an earlier image is owned by root, and the server says nothing about it — it
+# starts, serves the page and quietly stores no observations. Upgrading an install that binds
+# a host directory takes a one-time `sudo chown -R 1000:1000 ./data`.
+RUN groupadd --gid 1000 weatherdesk \
+    && useradd --uid 1000 --gid 1000 --home-dir /data --no-create-home weatherdesk \
+    && install -d -o weatherdesk -g weatherdesk /data
 # One directory holds the settings blob and the observation archive.
 ENV WD_DATA_DIR=/data
 VOLUME /data
 EXPOSE 8088
 EXPOSE 50222/udp
+USER weatherdesk
 # IMPORTANT: run with `network_mode: host` on Linux. The Tempest hub broadcasts to the subnet,
 # and a broadcast does not cross a bridged Docker network no matter how many ports are published.
 ENTRYPOINT ["/usr/local/bin/weatherdesk", "--headless"]


### PR DESCRIPTION
The image has no `USER`, so the headless server runs as root on whatever NAS or Pi it is installed on. It has no reason to: 8088 and 50222 are both above 1024, and `/data` is the only path it writes.

This adds a `weatherdesk` user at a fixed 1000:1000 in the runtime stage, creates `/data` owned by it, and sets `USER`. Fixed rather than a floating system uid because `./data` is a bind mount in `docker-compose.yml` and the host has to be able to match it.

That is also the upgrade cost, and it is a quiet one. A `./data` left by an earlier image is owned by root, and the server does not complain — it starts, serves the dashboard and stores nothing. Tested both ways:

```
root-owned ./data:   container running, GET / -> HTTP 200, no weatherdesk.db ever created
after chown 1000:    weatherdesk.db + -wal + -shm appear, owned by 1000
```

So an existing install needs a one-time `sudo chown -R 1000:1000 ./data`. That is noted in the Dockerfile beside the user. It probably deserves a line in the Docker section of the README as well — happy to add that here if you want it.

Verified:

```
docker run --rm --entrypoint id weatherdesk
uid=1000(weatherdesk) gid=1000(weatherdesk) groups=1000(weatherdesk)
```

and a normal run creates the archive and serves the dashboard as uid 1000.
