### PR TITLE
Polish batch, PWA shell, and the fixes people wrote in about

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,41 @@ Raspberry Pi, an Android APK, and the `ghcr.io/d4vid87/weatherdesk` container im
 
 ## [Unreleased]
 
+### Added
+- Animated hero: rain, snow, drifting cloud and lightning drawn behind the numbers, keyed to the
+  current conditions icon. Off entirely in eco mode and while the tab is hidden.
+- Countdown to the next solar event on the hero ("Sunset in 1h 14m"), and visibility beside
+  feels-like when the forecast source reports it.
+- Source health dots at the end of the ticker — one per station source the LAN server holds,
+  hover for its `/diag` line. Hidden where there is no server.
+- Region presets (US/UK/EU/CA/AU) and a 12/24-hour clock setting, honoured by every time on the
+  page including the big clock.
+- "Why this forecast" — model timing, spread and station edge as one sentence above the model
+  agreement rows — plus a trust badge from this install's own verification record.
+- Kiosk mode: one switch for fullscreen, locked layout, hidden header and a screen wake lock.
+  `k` toggles it; Escape, `f` or three taps on the clock leave it.
+
+### Fixed
+- A severe-weather banner now comes down when the warning expires, and a continued NWS warning
+  no longer re-chimes every five minutes — the dedupe key is the warning, not its id (#38 sibling).
+- A 401 on someone else's Tempest station now says the station isn't shared publicly instead of
+  blaming your token (#38).
+- **The barometer shows your barometer.** A station's own pressure reading is measured where it
+  stands; every console quotes it reduced to sea level, and the gauge was quietly falling back to
+  the model's sea-level pressure instead. Non-Tempest readings are now reduced using the station's
+  elevation, which is the two-hundredths of an inch that made the dashboard look wrong next to a
+  Davis or an Ecowitt console.
+- **Self-check no longer probes WeatherFlow on installs that have no Tempest** — an Ambient or a
+  Davis owner saw two red rows and reasonably read them as a broken app. It now checks the local
+  station instead, and says so when nothing has reported in the last hour (#37).
+- **The first-run wizard stops leading with a Tempest token.** Both routes are visible from the
+  start and the other-brand section opens by default; nothing autofocuses the token field.
+- **The phone app now says a console can't upload to it** instead of showing an address on
+  `tauri://localhost` that nothing on the network can reach, and points at the cloud sources.
+
+### Documentation
+- WeeWX connects with no plugin: point its Weather Underground uploader at `/ingest` (#47).
+
 ## [3.0.9] — 2026-08-21
 
 Everything here came out of what people reported after 3.0.8.

--- a/README.md
+++ b/README.md
@@ -184,6 +184,11 @@ things catch people out: the console must be allowed plain **HTTP**, not HTTPS, 
 a port other than 80. Firmware that insists on either needs a router rule forwarding port 80 to
 8088 on this machine.
 
+**WeeWX.** WeeWX already speaks the WU protocol, so it needs no plugin — in `weewx.conf`, under
+`[StdRESTful] [[Wunderground]]`, set `server_url = http://<host>:8088/ingest`, any `station` and
+`password`, and `enable = true`. Pick *Weather Underground protocol* as the brand here. That also
+covers every driver WeeWX has, which is most hardware that exists (issue #47).
+
 **Davis — Vantage Pro2, Vantage Pro2 Plus, Vantage Vue.** Needs a WeatherLink Live (or a Console
 6313) on the network. Put its IP in *WeatherLink Live address*; the app polls its local API every
 ten seconds. No cloud, no key.
@@ -203,6 +208,11 @@ done
 
 Anything `rtl_433` decodes lands the same way, so this is also the escape hatch for a station no
 other section covers.
+
+**On the phone app.** The Android build is a dashboard, not a server: it has no address a console
+can upload to. Cloud sources (*Ambient Weather Network*, *La Crosse*) work there directly; for a
+push brand, run the desktop build or the Docker image on a machine that stays on and point the
+phone at that address.
 
 **La Crosse Technology (C85845 and friends).** Account email and password. This one is unofficial —
 it reads the API their own app uses, and it can stop working without notice. Those readings are
@@ -478,9 +488,31 @@ behind a proxy.
 ## Installing on a phone
 
 The dashboard ships a web manifest, so any phone browser pointed at the LAN URL can add it to the
-home screen and run it full-screen. There is no service worker and there won't be: the LAN server
-is plain http, which cannot register one, and a cached copy of a live dashboard would be showing
-yesterday's weather with today's confidence.
+home screen and run it full-screen.
+
+Put it behind https and it also installs as a proper PWA: `site/sw.js` caches the shell — the page,
+the modules, the icons — so the dashboard still draws when the wifi is down, with the last good
+forecast and observation marked stale. The weather itself is never cached by the worker, and the
+network wins whenever it answers, so an update can't be pinned by a stale cache. Over plain http
+nothing registers, and behaviour is exactly what it was.
+
+The simplest LAN https is Caddy with its own CA:
+
+```
+weather.home.arpa {
+  tls internal
+  reverse_proxy 127.0.0.1:8088
+}
+```
+
+**That address is the whole dashboard, and `GET /config` serves the station token to anyone who
+asks it** — put it in front of screens you trust, not the internet. What goes on the internet is
+`/public` and nothing else (see the section above). On nginx, add `proxy_buffering off;` and a
+long `proxy_read_timeout` or the `/events` stream dies after a minute.
+
+With https there is also a **Browser notifications** checkbox in Settings: alerts become real
+notifications while the tab is in the background. There is no push server, so the page has to be
+open — for a phone that is asleep, use the ntfy channel.
 
 ## Other devices
 
@@ -519,10 +551,11 @@ MIT. See [LICENSE](LICENSE).
 
 ## Notes
 
-No service worker and no PWA install: the app is useless offline because every source is a cloud
-API, and the LAN origin is insecure anyway, so the Notification API is unavailable. Alerts render
-as an in-page banner queue with a WebAudio chime instead. The desktop build does raise real OS
-notifications, through Tauri rather than the browser API, and only when its window is hidden.
+The service worker caches the shell only, and only on a secure origin — the plain-http LAN origin
+can't register one, and every weather source is a cloud API, so offline means "the page still
+draws, with the last reading marked stale". Alerts render as an in-page banner queue with a
+WebAudio chime; on https they can also raise browser notifications, and the desktop build raises
+real OS ones through Tauri. All three only fire when the window is hidden.
 
 Releasing: the desktop updater needs `TAURI_SIGNING_PRIVATE_KEY` and
 `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` in the repo secrets, matching the public key in

--- a/site/index.html
+++ b/site/index.html
@@ -5,8 +5,9 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <meta name="color-scheme" content="dark light">
 <meta name="theme-color" content="#0b0f14">
-<!-- Installable from a phone's browser. No service worker on purpose: the LAN server is plain
-     http, which cannot register one, and an offline cache of a live dashboard would be a lie. -->
+<!-- Installable from a phone's browser. sw.js caches the shell only, and only on a secure
+     origin — see shouldRegisterSW() in js/boot.js. The weather itself is never cached there;
+     desk.js keeps the last good forecast and obs and marks them stale. -->
 <link rel="manifest" href="manifest.json">
 <link rel="icon" href="favicon-32.png" sizes="32x32" type="image/png">
 <link rel="apple-touch-icon" href="icon-192.png">
@@ -234,7 +235,13 @@
   }
   #hero .rz-e, #hero .rz-se { background-image: linear-gradient(135deg, transparent 42%, #ffffffcc 42%); }
 
+  /* kiosk: the panels and nothing else. Exit with f, Escape, or three taps on the clock. */
+  body.kiosk header { display: none; }
   /* hero */
+  #hero-fx { position: absolute; inset: 0; pointer-events: none; }
+  /* the canvas is positioned, so the content has to be too or it paints underneath */
+  #hero > *:not(#hero-fx):not(#hero-icon) { position: relative; z-index: 1; }
+  #hero > #hero-icon { z-index: 1; }
   #hero { padding: 16px 20px 20px; color: #fff; overflow: hidden; border-radius: 12px;
     background: linear-gradient(160deg, #1f6fb8, #7fb6e6); }
   #hero-clock { display: flex; align-items: baseline; gap: 14px; flex-wrap: wrap; margin-bottom: 10px;
@@ -258,6 +265,10 @@
   .live.on { color: #7dffb0; }
 
   /* ticker */
+#src-health { display: flex; gap: 5px; align-items: center; }
+#src-health i { width: 8px; height: 8px; border-radius: 50%; background: #46c26a; }
+#src-health i.stale { background: #e2b23c; }
+#src-health i.bad { background: #e2553c; }
   #ticker { display: flex; align-items: center; gap: 8px; background: var(--panel); border: 1px solid var(--line);
     border-radius: 10px; padding: 8px 10px; }
   #ticker-track { flex: 1; white-space: nowrap; overflow: hidden; display: flex; gap: 14px; align-items: center;
@@ -490,6 +501,7 @@
   <button class="iconbtn" id="btn-refresh">↻</button>
   <button class="iconbtn" id="btn-full">⛶</button>
   <button class="iconbtn" id="btn-lock" title="Lock panel layout">🔓</button>
+  <button class="iconbtn" id="btn-kiosk" title="Kiosk mode">🖥</button>
   <button class="iconbtn" id="btn-settings">⚙</button>
 </header>
 
@@ -499,8 +511,9 @@
   <div class="wizard-box">
     <img src="icon-512.png" alt="" style="display:block;width:180px;max-width:60%;margin:0 auto 10px">
     <h2 style="margin-top:0;text-align:center">Welcome to WeatherDesk</h2>
-    <p class="muted" style="font-size:13px">Paste a Tempest personal use token and pick your station.
-      Get one at tempestwx.com → Settings → Data Authorizations.</p>
+    <p class="muted" style="font-size:13px">Two ways in. <b>Tempest owners:</b> paste a personal
+      use token (tempestwx.com → Settings → Data Authorizations). <b>Every other brand</b> —
+      Ecowitt, Ambient, Davis, AcuRite, La Crosse — needs no token at all: open the second box.</p>
     <div class="row">
       <input id="wiz-token" type="password" placeholder="personal use token">
       <button class="primary" id="btn-wiz-find" style="flex:0 0 auto">Find stations</button>
@@ -512,7 +525,7 @@
     </div>
     <p class="muted" style="font-size:12px">No station? The desktop app also reads a Tempest hub
       directly off the network with no token at all.</p>
-    <details id="wiz-other" style="margin-top:10px">
+    <details id="wiz-other" style="margin-top:10px" open>
       <summary style="cursor:pointer;font-size:13px">Not a Tempest? Ecowitt, Ambient, Davis, AcuRite, La Crosse…</summary>
       <p class="muted" style="font-size:12px">Pick the brand, then say where the station is —
         the forecast comes from open-meteo, the readings come from your own sensors.</p>
@@ -534,6 +547,7 @@
     <div><span>r</span><span>refresh everything</span></div>
     <div><span>f</span><span>fullscreen</span></div>
     <div><span>s</span><span>settings</span></div>
+    <div><span>k</span><span>kiosk mode</span></div>
     <div><span>?</span><span>this list</span></div>
     <div><span>Esc</span><span>close</span></div>
   </div>
@@ -566,7 +580,7 @@
       </div>
     </div>
 
-    <div id="ticker" data-panel="ticker"><div id="ticker-track"></div><button id="ticker-pause">❚❚</button></div>
+    <div id="ticker" data-panel="ticker"><div id="ticker-track"></div><span id="src-health"></span><button id="ticker-pause">❚❚</button></div>
 
     <div id="ha-panel" data-panel="ha" style="display:none">
       <h2 id="ha-stamp">Home Assistant<span id="mqtt-state" class="muted" style="float:right;font-size:12px"></span></h2>
@@ -618,7 +632,8 @@
       </div>
 
       <div class="card" data-panel="agree">
-        <h2>Model agreement</h2>
+        <h2>Model agreement<span id="trust" class="muted" style="float:right;font-size:12px"></span></h2>
+        <div id="why" style="margin-bottom:6px"></div>
         <div id="agree-verdict" style="margin-bottom:6px"></div>
         <div id="agree-rows" class="kv-rows"></div>
         <div id="timing" class="muted" style="margin-top:8px;font-size:13px"></div>
@@ -692,6 +707,10 @@
           <button id="btn-add-station" style="flex:0 0 auto">Add</button>
           <button id="btn-nearby-reset" style="flex:0 0 auto">Reset dismissed</button>
         </div>
+        <p class="muted" style="font-size:12px;margin:0 0 8px">WeatherFlow publish no station
+          search, so Tempest neighbours have to be added by ID — find one on the public map at
+          tempestwx.com/map and paste its station number. A station whose owner hasn't shared it
+          publicly can't be read with your token; airport codes always work.</p>
         <div id="signals-table"></div>
       </div>
 
@@ -762,6 +781,12 @@
         Ecowitt, path <code>/ingest</code>. Ambient: awnet app → Custom server (firmware 4.2.8+).
         Upload interval 16 s or slower.</p>
     </div>
+    <div id="src-nopush" hidden>
+      <p class="muted" style="font-size:12px">This phone build has no address a console can upload
+        to — it isn't a server. Two ways round it: pick <b>Ambient Weather Network cloud</b> above
+        and paste your API keys (works anywhere), or run the desktop build / Docker image on a
+        machine that stays on, point the console at that, and open its address in this app.</p>
+    </div>
     <div id="src-wll" hidden>
       <label>WeatherLink Live address on the LAN</label>
       <input id="set-wll" placeholder="192.168.1.50">
@@ -780,8 +805,16 @@
     <input id="set-ingest-key" type="password" placeholder="blank = any device on the LAN">
     <label>Station reporting</label>
     <div id="ingest-diag" class="muted" style="font-size:12px"></div>
+    <label>Region preset</label>
+    <div class="row" id="region-presets">
+      <button data-region="US">US</button><button data-region="UK">UK</button>
+      <button data-region="EU">EU</button><button data-region="CA">CA</button>
+      <button data-region="AU">AU</button>
+    </div>
     <label>Units</label>
     <select id="set-units"><option value="imperial">Imperial</option><option value="metric">Metric</option></select>
+    <label>Clock</label>
+    <select id="set-clock"><option value="auto">Follow this device</option><option value="12">12-hour</option><option value="24">24-hour</option></select>
     <label>Obs refresh (seconds)</label><input id="set-refresh" type="number" min="10" step="10">
     <label>Wind gust alert threshold</label><input id="set-gust" type="number" min="0">
     <label>Nearby sensor radius (mi, 0 = manual only)</label><input id="set-nearby-radius" type="number" min="0">
@@ -822,6 +855,7 @@
     <label>Cycle tabs every (seconds, 0 = off)</label><input id="set-kiosk" type="number" min="0" step="5">
     <label><input id="set-night-dim" type="checkbox"> Dim the screen overnight</label>
     <label><input id="set-speak" type="checkbox"> Read severe alerts aloud</label>
+    <label><input id="set-web-notif" type="checkbox"> Browser notifications (https only)</label>
 
     <label style="margin-top:14px">Eco mode (slower polling, no animation)</label>
     <select id="set-eco">

--- a/site/js/api.js
+++ b/site/js/api.js
@@ -19,10 +19,20 @@ function qs(obj) {
 export function errHint(status, url) {
   if (!url.startsWith(SWD)) return '';
   if (status === 401 || status === 403) {
-    return ' — token rejected: create or check a personal use token at tempestwx.com → Settings → Data Authorizations';
+    // A token only reads its own account. A 401 for someone else's station ID means that station
+    // isn't shared with the public API, not that the token is bad — issue #38.
+    return foreignStation(url)
+      ? " — that station isn't readable with your token: WeatherFlow only shares a station's data with its owner unless the owner has made it public"
+      : ' — token rejected: create or check a personal use token at tempestwx.com → Settings → Data Authorizations';
   }
   if (status === 404) return ' — not found: check the station/device ID';
   return '';
+}
+
+// The station ID in an observations/stations URL, when it isn't the one this install is set up on.
+function foreignStation(url) {
+  const id = url.match(/\/(?:observations\/stn|stations)\/(\d+)/)?.[1];
+  return !!id && id !== String(settings().stationId);
 }
 
 // NWS answers every request with an ETag and honours If-None-Match, and the alert feed is polled
@@ -194,6 +204,22 @@ export const omWords = (code) => WORDS[WMO[code] ?? 'cloudy'] || '';
 // `ownTuple` is the station's own SI reading. Where a sensor measured something, the sensor
 // wins; the model keeps what no backyard station has (dew point, feels-like, sea-level
 // pressure, wet bulb) rather than this file growing a second psychrometry.
+// A backyard station measures the pressure where it stands; every console and every forecast
+// quotes it reduced to sea level. Reporting the raw reading against a model's MSL is why a Davis
+// on Long Island read 30.06 on the dashboard and 30.08 on its own display. Multiplicative, so it
+// works in whatever unit the reading is already in; `elev` is metres, `tempC` the outside air.
+export function toSeaLevel(p, elev, tempC = 15) {
+  // No elevation, no honest reduction — the caller falls back to the model's MSL rather than
+  // publishing a mountain station's raw reading as if it were sea level.
+  if (p == null || elev == null) return null;
+  if (!elev) return p;
+  return p * (1 - (0.0065 * elev) / (tempC + 0.0065 * elev + 273.15)) ** -5.257;
+}
+
+// 15 °C is the standard-atmosphere fallback: a station with no thermometer still gets a
+// reduction that is right to a hundredth of an inch at backyard elevations.
+const tempC = (t, metric) => (t == null ? 15 : metric ? t : (t - 32) / 1.8);
+
 export function shapeOm(j, ownTuple = null) {
   const metric = settings().units === 'metric';
   const cur = j.current || {};
@@ -251,6 +277,8 @@ export function shapeOm(j, ownTuple = null) {
     uv: at('uv_index'),
     solar_radiation: at('shortwave_radiation'),
     wet_bulb_temperature: at('wet_bulb_temperature_2m'),
+    // metres, whatever the unit params say — open-meteo doesn't convert this one. Hero converts.
+    visibility: at('visibility'),
     icon: omIcon(cur.weather_code, day),
     conditions: omWords(cur.weather_code),
   };
@@ -268,6 +296,9 @@ export function shapeOm(j, ownTuple = null) {
       solar_radiation: own(o[OBS.solar]),
       precip_accum_local_day: own(o[OBS.dayRain]),
       station_pressure: own(o[OBS.press]),
+      // The barometer gauge reads `sea_level_pressure`; without this line it showed the model's
+      // MSL forever and a real barometer sat unused two fields away.
+      sea_level_pressure: own(toSeaLevel(o[OBS.press], j.elevation, tempC(o[OBS.temp], metric))),
     };
     for (const k in overlay) if (overlay[k] !== undefined) c[k] = overlay[k];
   }
@@ -282,7 +313,7 @@ export async function omForecast(lat = coords().lat, lon = coords().lon) {
     current: 'temperature_2m,relative_humidity_2m,dew_point_2m,apparent_temperature,is_day,'
       + 'weather_code,pressure_msl,surface_pressure,wind_speed_10m,wind_direction_10m,wind_gusts_10m',
     hourly: 'temperature_2m,precipitation_probability,weather_code,wind_speed_10m,wind_gusts_10m,'
-      + 'wind_direction_10m,uv_index,shortwave_radiation,wet_bulb_temperature_2m',
+      + 'wind_direction_10m,uv_index,shortwave_radiation,wet_bulb_temperature_2m,visibility',
     daily: 'weather_code,temperature_2m_max,temperature_2m_min,sunrise,sunset,'
       + 'precipitation_probability_max,precipitation_sum',
     forecast_days: 10, timezone: 'auto', timeformat: 'unixtime',
@@ -500,6 +531,12 @@ if (location.search.includes('selftest')) {
   const band = ensembleBand({ hourly: { time: ['1970-01-01T00:00'], temperature_2m_member01: [1], temperature_2m_member02: [9] } });
   console.assert(band[0].lo === 1 && band[0].hi === 9, 'api: ensemble band spans the members');
 
+  // 7 m of Long Island: the reduction is the ~0.02 inHg that made a Davis owner think the
+  // dashboard was reading his barometer wrong.
+  console.assert(Math.abs(toSeaLevel(30.06, 7, 19) - 30.085) < 0.005, 'api: pressure reduced to sea level');
+  console.assert(toSeaLevel(30.06, 0) === 30.06, 'api: a station at sea level is already reduced');
+  console.assert(toSeaLevel(null, 100) === null, 'api: no reading, no reduction');
+
   console.assert(normalFor({ '03-04': { hi: 60, lo: 40 } }, new Date(2020, 2, 4)).hi === 60, 'api: normals key is month-day');
 
   // The open-meteo forecast adapter: every non-Tempest station's hero, day cards and ticker
@@ -537,10 +574,23 @@ if (location.search.includes('selftest')) {
 // --- Diagnostics: ping each source, return [{name, ok, detail}] ---
 
 export async function diagnostics() {
+  // Issue #37: an Ambient or a Davis install has no Tempest account, so probing WeatherFlow
+  // painted two red rows on every self-check and people read them as the app being broken.
+  // Probe what this install actually uses — and name the forecast after where it comes from.
   const checks = [
-    ['Tempest station', () => station()],
-    ['Tempest obs', () => stationObs()],
-    ['Tempest forecast', () => betterForecast()],
+    ...(settings().token ? [
+      ['Tempest station', () => station()],
+      ['Tempest obs', () => stationObs()],
+      ['Tempest forecast', () => betterForecast()],
+    ] : [
+      ...(settings().stationSource ? [['Local station', async () => {
+        // A reachable archive with nothing in it is the failure people actually hit: the console
+        // was never pointed at /ingest. Green there would be a lie.
+        const j = await localObs(1);
+        if (!j.obs?.length) throw new Error('no reports in the last hour — check the console is uploading to this address');
+      }]] : []),
+      ['Open-Meteo forecast', () => betterForecast()],
+    ]),
     ['NWS alerts', () => alerts()],
     ['Open-Meteo models', () => multiModel()],
     ['Open-Meteo AQI', () => aqi()],

--- a/site/js/app.js
+++ b/site/js/app.js
@@ -2,7 +2,10 @@
 
 const DEFAULTS = {
   token: '', stationId: '', deviceId: '', lat: null, lon: null, stationName: '',
-  units: 'imperial', refreshSec: 60, places: [], activePlace: null,
+  units: 'imperial', refreshSec: 60,
+  // 'auto' follows the browser locale; the other two are for the screen that lives in a country
+  // its OS wasn't set up for.
+  clock24: 'auto', places: [], activePlace: null,
   // nearbyStations stays bare id strings: an older client on the same /config reads it directly,
   // and anything object-shaped would land in its URLs as [object Object]. New keys are additive.
   nearbyStations: [],
@@ -35,6 +38,9 @@ const DEFAULTS = {
   theme: 'dark', accent: '', fontScale: 1, density: 'normal', bigNumbers: false,
   // Kiosk: seconds per tab when cycling (0 = off), and dimming through the night window.
   kioskCycleSec: 0, nightDim: false,
+  // Kiosk: header gone, layout locked, fullscreen, screen held awake. One switch because on a
+  // wall panel these four are never wanted apart.
+  kiosk: false,
   // 'auto' | 'on' | 'off' — see ecoOn(). Auto is the point of the setting: the tablet on the wall
   // should not need anyone to know it is the slow machine.
   eco: 'auto',
@@ -44,6 +50,9 @@ const DEFAULTS = {
   // Kiosk speech: read severe alerts aloud. Off by default — a dashboard that talks without
   // being asked is a dashboard someone unplugs.
   speakAlerts: false,
+  // Browser notifications, secure origins only. Off until asked for: the permission prompt is
+  // rude unprompted, and the desktop app already raises real ones through Tauri.
+  webNotif: false,
   // Palette pack on top of the theme: '', 'oled', 'solarized', 'contrast', 'eink'.
   palette: '',
   // The LAN server's port. Empty means 8088. Desktop only, and a restart applies it.
@@ -96,6 +105,12 @@ export function store(key, value) {
   catch (e) { console.warn('localStorage full', key, e); }
 }
 
+if (location.search.includes('selftest')) {
+  const noon = new Date(2020, 0, 1, 13, 5).getTime() / 1000;
+  console.assert(timeStr(noon, { clock24: '24' }).startsWith('13'), 'app: 24-hour clock reads 13:05');
+  console.assert(/1:05/.test(timeStr(noon, { clock24: '12' })), 'app: 12-hour clock reads 1:05');
+}
+
 export const configured = () => !!(_settings.token && _settings.stationId);
 
 // Whether there is a station behind this dashboard at all — a Tempest with a token, or any other
@@ -127,8 +142,11 @@ export function num(v, digits = 0) {
   return v == null || Number.isNaN(v) ? '--' : (+v).toFixed(digits);
 }
 
-export function timeStr(epochSec) {
-  return new Date(epochSec * 1000).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+export function timeStr(epochSec, s = _settings) {
+  return new Date(epochSec * 1000).toLocaleTimeString([], {
+    hour: 'numeric', minute: '2-digit',
+    ...(s.clock24 === 'auto' || !s.clock24 ? {} : { hour12: s.clock24 === '12' }),
+  });
 }
 
 export function dayStr(epochSec) {
@@ -177,6 +195,7 @@ export function notify({ id, category = 'info', title, body }) {
   const wrap = document.getElementById('notif-stack');
   const el = document.createElement('div');
   el.className = `notif notif-${category}`;
+  el.dataset.nid = id || '';
   el.innerHTML = `<div class="notif-title"></div><div class="notif-body"></div><button class="notif-x">×</button>`;
   el.querySelector('.notif-title').textContent = title;
   el.querySelector('.notif-body').textContent = body || '';
@@ -195,6 +214,20 @@ export function notify({ id, category = 'info', title, body }) {
   chime();
   speak(entry);
   native(entry);
+  webNative(entry);
+}
+
+// Severe banners are the one kind that never time out (see above), so something has to take them
+// down when the warning expires. desk.js calls this each alert poll with what is still out.
+export function dismissStale(category, liveIds) {
+  // Also forget them: the dedupe key is now the warning's identity, not a one-shot NWS id, so
+  // without this the same warning next month would be silently swallowed for the session's life.
+  for (const n of notifLog) if (n.category === category && n.id && !liveIds.has(n.id)) seen.delete(n.id);
+  const wrap = document.getElementById('notif-stack');
+  if (!wrap) return;
+  for (const el of [...wrap.children]) {
+    if (el.classList.contains(`notif-${category}`) && !liveIds.has(el.dataset.nid)) el.remove();
+  }
 }
 
 // A wall panel across the room can't be read, and the person it matters to isn't holding it.
@@ -214,6 +247,15 @@ function native({ category, title, body }) {
     .then((ok) => (ok ? true : api.requestPermission().then((p) => p === 'granted')))
     .then((ok) => ok && api.sendNotification({ title, body: body || '' }))
     .catch(() => {});
+}
+
+// The browser's own notification, for the installed PWA and any HTTPS tab. Same rule as native():
+// only when this window isn't the one being looked at. No Push API — the page has to be alive,
+// which is what the ntfy channel is for.
+function webNative({ category, title, body }) {
+  if (!_settings.webNotif || category === 'info' || !document.hidden) return;
+  if (!('Notification' in window) || Notification.permission !== 'granted' || window.__TAURI__) return;
+  try { new Notification(title, { body: body || '', tag: title }); } catch { /* not allowed here */ }
 }
 
 // Off the machine: a banner is no use to anyone who isn't looking at the dashboard.
@@ -535,6 +577,20 @@ if (location.search.includes('selftest')) {
   console.assert(webhookBody('https://example.com/hook', alert).category === 'severe',
     'webhook: anything else keeps the generic shape');
 }
+
+// A dashboard whose whole job is to be looked at should not go dark mid-thunderstorm. Only
+// exists on a secure origin (Tauri, localhost, HTTPS); plain-HTTP LAN silently does without.
+let wakeLock = null;
+export async function holdScreen(on) {
+  if (!on) { try { await wakeLock?.release(); } catch { /* already gone */ } wakeLock = null; return; }
+  if (!navigator.wakeLock || wakeLock) return;
+  try { wakeLock = await navigator.wakeLock.request('screen'); } catch { wakeLock = null; }
+}
+// The browser drops the lock whenever the tab is hidden — including every screen-off — so it has
+// to be taken again on the way back.
+document.addEventListener('visibilitychange', () => {
+  if (!document.hidden && _settings.kiosk) holdScreen(true);
+});
 
 export function fullscreen() {
   if (document.fullscreenElement) document.exitFullscreen();

--- a/site/js/boot.js
+++ b/site/js/boot.js
@@ -1,5 +1,5 @@
 // Wire the shell: settings drawer, diagnostics, nav, section modules.
-import { settings, saveSettings, configured, hasSource, hasLocation, initNav, applyTabs, fullscreen, refreshAll, notify, load, store, applyEco, ecoOn, initKiosk, expires } from './app.js';
+import { settings, saveSettings, configured, hasSource, hasLocation, initNav, applyTabs, fullscreen, holdScreen, refreshAll, notify, load, store, applyEco, ecoOn, initKiosk, expires } from './app.js';
 import * as api from './api.js';
 import { initDesk, refreshDesk, refreshObs, refreshAlerts, refreshAqi } from './desk.js';
 import { initIntel, refreshModels, refreshNowcast } from './intel.js';
@@ -100,6 +100,11 @@ export function ingestUrl(key = settings().ingestKey) {
   return `${window.__WD_SRV || location.origin}/ingest${key ? `/${key}` : ''}`;
 }
 
+// The Android build has no LAN server behind it — `__TAURI__` without `__WD_SRV` — so there is
+// no address a WS-2902 console could ever upload to. Saying "point the console at
+// tauri://localhost" is how two people spent an evening trying.
+export const canIngest = (env = window) => !(env.__TAURI__ && env.__WD_SRV === undefined);
+
 // Only the fields the chosen brand needs. The push brands need none at all, which is the point
 // of showing them the address instead.
 function showSourceFields() {
@@ -109,7 +114,8 @@ function showSourceFields() {
   $('src-wll').hidden = v !== 'wll';
   $('src-awn').hidden = v !== 'awn';
   $('src-lax').hidden = v !== 'lacrosse';
-  if (push) $('src-url').value = ingestUrl($('set-ingest-key').value.trim());
+  $('src-nopush').hidden = !(push && !canIngest());
+  if (push) $('src-url').value = canIngest() ? ingestUrl($('set-ingest-key').value.trim()) : '';
 }
 
 function fillDrawer() {
@@ -118,6 +124,7 @@ function fillDrawer() {
   $('set-station').value = s.stationId;
   $('set-device').value = s.deviceId;
   $('set-units').value = s.units;
+  $('set-clock').value = s.clock24 || 'auto';
   $('set-refresh').value = s.refreshSec;
   $('set-gust').value = s.windGustAlert;
   $('set-nearby-radius').value = s.nearbyRadius ?? 0;
@@ -132,6 +139,7 @@ function fillDrawer() {
   $('set-kiosk').value = s.kioskCycleSec || 0;
   $('set-night-dim').checked = !!s.nightDim;
   $('set-speak').checked = !!s.speakAlerts;
+  $('set-web-notif').checked = !!s.webNotif;
   $('set-palette').value = s.palette || '';
   $('set-quiet-start').value = s.quietStart || '';
   $('set-quiet-end').value = s.quietEnd || '';
@@ -262,6 +270,23 @@ $('btn-settings').onclick = () => { fillDrawer(); openDrawer(true); };
 $('set-source').onchange = showSourceFields;
 $('set-ingest-key').oninput = showSourceFields;
 $('btn-close').onclick = () => { openDrawer(false); loadDeskRadar(); };
+// A preset is two dropdowns someone would otherwise have to know to change together. It only
+// fills the fields — Save is still Save.
+const REGIONS = {
+  US: ['imperial', '12'], UK: ['metric', '24'], EU: ['metric', '24'],
+  CA: ['metric', '12'], AU: ['metric', '12'],
+};
+$('region-presets').onclick = (e) => {
+  const r = REGIONS[e.target.dataset.region];
+  if (!r) return;
+  [$('set-units').value, $('set-clock').value] = r;
+};
+
+// The permission prompt has to come off a click, and Save is the only click there is.
+$('set-web-notif').onchange = (e) => {
+  if (e.target.checked && window.Notification?.permission === 'default') Notification.requestPermission().catch(() => {});
+};
+
 $('btn-full').onclick = fullscreen;
 $('btn-refresh').onclick = refreshAll;
 
@@ -275,6 +300,7 @@ $('btn-save').onclick = async () => {
     stationId: $('set-station').value.trim(),
     deviceId: $('set-device').value.trim(),
     units: $('set-units').value,
+    clock24: $('set-clock').value,
     refreshSec: +$('set-refresh').value || 60,
     windGustAlert: +$('set-gust').value || 30,
     nearbyRadius: +$('set-nearby-radius').value || 0,
@@ -290,6 +316,7 @@ $('btn-save').onclick = async () => {
     kioskCycleSec: +$('set-kiosk').value || 0,
     nightDim: $('set-night-dim').checked,
     speakAlerts: $('set-speak').checked,
+    webNotif: $('set-web-notif').checked,
     palette: $('set-palette').value,
     quietStart: $('set-quiet-start').value,
     quietEnd: $('set-quiet-end').value,
@@ -482,6 +509,29 @@ $('btn-wiz-demo').onclick = () => {
 // The binary injects this (`server::ver_script`, and `gui.rs` for the desktop window) so there is
 // one version in the build, not a literal here that goes stale the first release nobody edits it.
 const APP_VERSION = window.__WD_VER || '';
+
+// A dashboard on a wall is exactly the thing that should still draw its own shell when the wifi
+// drops — desk.js already keeps the last forecast and obs, so all that was missing was the files.
+// Not in the desktop or Android app (they ship their own assets), and not on a plain-http LAN
+// origin, which cannot register one at all.
+export function shouldRegisterSW(env = window) {
+  return 'serviceWorker' in navigator && env.isSecureContext
+    && !env.__TAURI__ && env.__WD_SRV === undefined;
+}
+if (location.search.includes('selftest')) {
+  const env = (o) => ({ isSecureContext: true, __WD_SRV: undefined, ...o });
+  console.assert(shouldRegisterSW(env({})), 'sw: https browser registers');
+  console.assert(!shouldRegisterSW(env({ isSecureContext: false })), 'sw: plain-http LAN does not');
+  console.assert(!shouldRegisterSW(env({ __TAURI__: {}, __WD_SRV: '' })), 'sw: desktop app does not');
+  console.assert(!shouldRegisterSW(env({ __TAURI__: {} })), 'sw: the Android app does not either');
+  console.assert(!shouldRegisterSW(env({ __WD_SRV: 'http://x' })), 'sw: a page served by the app does not');
+  console.assert(canIngest(env({})), 'ingest: a browser is already on a reachable address');
+  console.assert(canIngest(env({ __TAURI__: {}, __WD_SRV: 'http://x' })), 'ingest: the desktop app carries a LAN address');
+  console.assert(!canIngest(env({ __TAURI__: {} })), 'ingest: the phone app has nowhere for a console to report');
+}
+if (shouldRegisterSW()) {
+  navigator.serviceWorker.register(`sw.js?v=${APP_VERSION}`).catch(() => {});
+}
 function changelog() {
   if (!APP_VERSION) return; // served from a static host: no version to be honest about
   // Raw string, not store(): this is compared to a literal, and a JSON-quoted one never matches.
@@ -558,6 +608,27 @@ function applyLock() {
 }
 
 $('btn-lock').onclick = () => { saveSettings({ layoutLocked: !settings().layoutLocked }); applyLock(); };
+
+// --- kiosk mode: fullscreen + locked + no chrome + screen held awake, as one switch ---
+function applyKiosk() {
+  const on = !!settings().kiosk;
+  document.body.classList.toggle('kiosk', on);
+  holdScreen(on);
+}
+function setKiosk(on) {
+  saveSettings({ kiosk: on, layoutLocked: on || settings().layoutLocked });
+  applyKiosk();
+  applyLock();
+  if (on !== !!document.fullscreenElement) fullscreen();
+}
+$('btn-kiosk').onclick = () => setKiosk(!settings().kiosk);
+// With the header hidden there is no button left, and a wall tablet has no Escape key.
+let taps = [];
+$('hero-clock').addEventListener('click', () => {
+  taps = [...taps, Date.now()].filter((t) => Date.now() - t < 1500);
+  if (taps.length >= 3) { taps = []; if (settings().kiosk) setKiosk(false); }
+});
+applyKiosk();
 
 // Phone rearrange mode. At phone width the grips and the × are hidden, because left on they cover
 // the panel titles and eat taps meant for the panel — so the Android app and a phone browser had
@@ -884,9 +955,13 @@ document.addEventListener('keydown', (e) => {
     tabs[+e.key - 1]?.click();
     return;
   }
-  if (e.key === 'Escape') { openDrawer(false); $('shortcuts').hidden = true; loadDeskRadar(); return; }
+  if (e.key === 'Escape') {
+    if (settings().kiosk) setKiosk(false);
+    openDrawer(false); $('shortcuts').hidden = true; loadDeskRadar(); return;
+  }
   if (e.key === '?') { $('shortcuts').hidden = !$('shortcuts').hidden; return; }
   if (e.key === 'f') fullscreen();
+  else if (e.key === 'k') setKiosk(!settings().kiosk);
   else if (e.key === 'r') refreshAll();
   else if (e.key === 's' && !PUBLIC) { fillDrawer(); openDrawer(true); }
 });
@@ -901,7 +976,8 @@ changelog();
 
 if (!hasSource() && !PUBLIC) {
   $('wizard').hidden = false;
-  $('wiz-token').focus();
+  // No autofocus on the token field: it put a cursor in a Tempest-only box for people who own
+  // an Ambient, and they reported the app as demanding an account they can't have.
   // UDP-only mode: a desktop install with a hub on the LAN has real local data with no token at
   // all, so the modules start either way. Every refresh job early-returns without a token, so an
   // unconfigured init is a handful of no-ops.

--- a/site/js/desk.js
+++ b/site/js/desk.js
@@ -1,6 +1,6 @@
 // 01 Desk — current conditions, near-term forecast, alerts, AQI.
 import * as api from './api.js';
-import { settings, coords, configured, hasSource, hasLocation, U, num, timeStr, dayStr, notify, every, stamp, store, load, setStorm } from './app.js';
+import { settings, coords, configured, hasSource, hasLocation, U, num, timeStr, dayStr, notify, dismissStale, every, stamp, store, load, setStorm } from './app.js';
 
 // Last-good copies of the two payloads the Desk can't render without. An outage that spans a
 // reload would otherwise leave the whole page at `--`; in-session failures already keep the DOM.
@@ -101,10 +101,15 @@ export async function refreshAlerts() {
   // Storm mode: while something serious is out, every panel goes back to full rate whatever eco
   // and the hour say. This is the one time the dashboard is being watched.
   setStorm(feats.some((f) => ['Severe', 'Extreme'].includes(f.properties?.severity)));
+  // NWS mints a fresh id for every continuation of the same warning, so keying the dedupe on it
+  // re-chimed the same tornado warning every 5 minutes. Key on what the warning IS instead — a
+  // severity change still gets through, which is the one update worth a second chime.
+  const key = (p) => `${p.event}|${p.areaDesc}|${p.severity}`;
   feats.forEach((f) => notify({
-    id: f.properties.id, category: 'severe',
+    id: key(f.properties), category: 'severe',
     title: f.properties.event, body: f.properties.headline || '',
   }));
+  dismissStale('severe', new Set(feats.map((f) => key(f.properties))));
 }
 
 export async function refreshAqi() {

--- a/site/js/fx.js
+++ b/site/js/fx.js
@@ -1,0 +1,113 @@
+// Weather in the hero: rain, snow, drifting cloud and lightning drawn on one canvas behind the
+// numbers. Pure decoration — every path here is allowed to do nothing.
+import { ecoOn } from './app.js';
+
+let ctx = null, parts = [], regime = '', raf = 0, flash = 0;
+
+// Which particle regime an icon key means. Anything unlisted (clear, fog, wind) draws nothing.
+function regimeFor(key = '') {
+  if (key.includes('thunder')) return 'storm';
+  if (key.includes('snow') || key.includes('sleet')) return 'snow';
+  if (key.includes('rain')) return 'rain';
+  if (key.includes('cloudy')) return 'cloud';
+  return '';
+}
+
+const N = { rain: 60, storm: 60, snow: 45, cloud: 6 };
+
+function seed(w, h) {
+  const rnd = (a, b) => a + Math.random() * (b - a);
+  parts = Array.from({ length: N[regime] || 0 }, () => (regime === 'cloud'
+    ? { x: rnd(-0.2, 1) * w, y: rnd(0.02, 0.45) * h, r: rnd(30, 70), vx: rnd(4, 12) }
+    : { x: Math.random() * w, y: Math.random() * h, len: rnd(8, 18), vy: rnd(regime === 'snow' ? 25 : 320, regime === 'snow' ? 60 : 620), vx: rnd(-15, regime === 'snow' ? 25 : 60) }));
+}
+
+function frame(t) {
+  raf = requestAnimationFrame(frame);
+  const c = ctx.canvas, w = c.width, h = c.height;
+  const dt = Math.min(0.05, (t - (frame.last || t)) / 1000);
+  frame.last = t;
+  ctx.clearRect(0, 0, w, h);
+  if (regime === 'cloud') {
+    ctx.fillStyle = 'rgba(255,255,255,0.07)';
+    for (const p of parts) {
+      p.x += p.vx * dt;
+      if (p.x - p.r > w) p.x = -p.r;
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, p.r, 0, 7);
+      ctx.fill();
+    }
+    return;
+  }
+  if (regime === 'snow') {
+    ctx.fillStyle = 'rgba(255,255,255,0.75)';
+    for (const p of parts) {
+      p.y += p.vy * dt; p.x += Math.sin(p.y / 40) * p.vx * dt;
+      if (p.y > h) { p.y = -4; p.x = Math.random() * w; }
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, 1.6, 0, 7);
+      ctx.fill();
+    }
+    return;
+  }
+  ctx.strokeStyle = 'rgba(190,220,255,0.45)';
+  ctx.lineWidth = 1.2;
+  ctx.beginPath();
+  for (const p of parts) {
+    p.y += p.vy * dt; p.x += p.vx * dt;
+    if (p.y > h) { p.y = -p.len; p.x = Math.random() * w; }
+    ctx.moveTo(p.x, p.y);
+    ctx.lineTo(p.x - p.vx * 0.03, p.y + p.len);
+  }
+  ctx.stroke();
+  if (regime === 'storm') {
+    // one flash every few seconds, two frames of white — cheaper and more convincing than a bolt
+    if (flash > 0) { ctx.fillStyle = `rgba(255,255,255,${0.35 * flash})`; ctx.fillRect(0, 0, w, h); flash -= dt * 4; }
+    else if (Math.random() < dt / 6) flash = 1;
+  }
+}
+
+function stop() {
+  cancelAnimationFrame(raf);
+  raf = 0;
+  if (ctx) ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+}
+
+function sizeTo(hero) {
+  const c = ctx.canvas;
+  c.width = hero.clientWidth;
+  c.height = hero.clientHeight;
+  seed(c.width, c.height);
+}
+
+// Called from the hero render with the current conditions icon key.
+export function setScene(iconKey) {
+  // Eco is a promise about the machine, not a preference about looks: the wall tablet gets none
+  // of this. ponytail: no per-effect setting until someone asks for one.
+  if (ecoOn()) return stop();
+  const hero = document.getElementById('hero');
+  if (!hero) return;
+  if (!ctx) {
+    const c = document.createElement('canvas');
+    c.id = 'hero-fx';
+    hero.prepend(c);
+    ctx = c.getContext('2d');
+    addEventListener('resize', () => ctx && sizeTo(hero));
+    document.addEventListener('visibilitychange', () => {
+      if (document.hidden) stop();
+      else if (regime) { frame.last = 0; raf = raf || requestAnimationFrame(frame); }
+    });
+  }
+  const r = regimeFor(iconKey);
+  if (r === regime && raf) return;
+  regime = r;
+  if (!regime) return stop();
+  sizeTo(hero);
+  if (!raf && !document.hidden) { frame.last = 0; raf = requestAnimationFrame(frame); }
+}
+
+if (location.search.includes('selftest')) {
+  console.assert(regimeFor('possibly-thunderstorm-day') === 'storm', 'fx: thunder is a storm');
+  console.assert(regimeFor('rainy') === 'rain' && regimeFor('snow') === 'snow', 'fx: rain and snow');
+  console.assert(regimeFor('clear-day') === '', 'fx: clear skies draw nothing');
+}

--- a/site/js/intel.js
+++ b/site/js/intel.js
@@ -32,6 +32,34 @@ function nowIndex() {
   return best;
 }
 
+// The three panels below this one already say everything; nobody reads three panels. This is the
+// same numbers as one sentence — assembled, not computed.
+function renderWhy({ worst, onsetMedian, onsetCount, edge }) {
+  const parts = [];
+  if (onsetMedian != null) {
+    parts.push(`Precip around ${new Date(onsetMedian).toLocaleString([], { weekday: 'short', hour: 'numeric' })}`
+      + ` in ${onsetCount} of ${MODEL_LIST.length} models`);
+  } else parts.push('No model has precip in the next 48h');
+  if (worst != null) {
+    parts.push(worst < 3 ? `models agree within ${num(worst, 1)}${U.temp()}`
+      : `models disagree by up to ${num(worst, 1)}${U.temp()}`);
+  }
+  if (edge != null && Math.abs(edge) >= 1) {
+    parts.push(`your station is running ${num(Math.abs(edge), 1)}${U.temp()} ${edge > 0 ? 'warmer' : 'cooler'} than guidance`);
+  }
+  $('why').textContent = `${parts.join(', ')}.`;
+
+  // How well this dashboard's own forecasts have actually verified — the only honest badge.
+  const a = accuracy();
+  const el = $('trust');
+  el.textContent = a.mae == null ? '' : `${trustWord(a.mae)} · MAE ${num(a.mae, 1)}${U.temp()}`;
+}
+
+export const trustWord = (mae) => (mae <= 3 ? 'Good' : mae <= 5 ? 'Fair' : 'Watch closely');
+
+// What the three renders below found, kept so the sentence can be written once from all of them.
+const why = { worst: null, onsetMedian: null, onsetCount: 0, edge: null };
+
 function renderAgreement() {
   const i0 = nowIndex();
   const rows = [];
@@ -47,6 +75,8 @@ function renderAgreement() {
     const rainSum = seriesFor('precipitation', m).slice(i0, i0 + 24).reduce((a, b) => a + (b || 0), 0);
     rows.push(`<div><span>${SHORT[m]}</span><span>${num(t, 1)}${U.temp()} · ${num(rainSum, 2)} ${U.precip()}/24h</span></div>`);
   }
+  why.worst = worst;
+  renderWhy(why);
   const verdict = worst < 3 ? 'tight' : worst < 7 ? 'moderate' : 'wide';
   $('agree-verdict').textContent = `${verdict} (max spread ${num(worst, 1)}${U.temp()}${worstHour ? ` at ${timeStr(new Date(worstHour).getTime() / 1000)}` : ''})`;
   $('agree-rows').innerHTML = rows.join('');
@@ -61,10 +91,15 @@ function renderTiming() {
       if ((p[i] || 0) > 0.01) { onsets.push(new Date(models.hourly.time[i]).getTime()); break; }
     }
   }
-  if (!onsets.length) { $('timing').textContent = 'No precip in any model, next 48h'; return; }
+  if (!onsets.length) {
+    why.onsetMedian = null; why.onsetCount = 0; renderWhy(why);
+    $('timing').textContent = 'No precip in any model, next 48h';
+    return;
+  }
   onsets.sort((a, b) => a - b);
   const median = onsets[Math.floor(onsets.length / 2)];
   const spreadH = (onsets[onsets.length - 1] - onsets[0]) / 3600e3;
+  why.onsetMedian = median; why.onsetCount = onsets.length; renderWhy(why);
   $('timing').innerHTML = `Consensus onset <b>${new Date(median).toLocaleString([], { weekday: 'short', hour: 'numeric' })}</b>`
     + ` · ${onsets.length}/${MODEL_LIST.length} models · spread ${num(spreadH, 1)}h`;
 }
@@ -76,6 +111,8 @@ function renderEdge() {
   const vals = MODEL_LIST.map((m) => seriesFor('temperature_2m', m)[i0]).filter((v) => v != null);
   const consensus = vals.reduce((a, b) => a + b, 0) / vals.length;
   const d = cc.air_temperature - consensus;
+  why.edge = d;
+  renderWhy(why);
   $('edge').innerHTML = `Station <b>${num(cc.air_temperature, 1)}${U.temp()}</b> vs model consensus `
     + `${num(consensus, 1)}${U.temp()} — running <b>${d >= 0 ? '+' : ''}${num(d, 1)}${U.temp()}</b>`;
 }
@@ -158,6 +195,11 @@ export function renderTrack() {
     ? `<div>24h-lead temp MAE <b>${num(a.mae, 1)}${U.temp()}</b> over ${a.n} checks</div>`
       + a.recent.map((v) => `<div class="muted" style="font-size:12px">${timeStr(v.targetHour)}: forecast ${num(v.fTemp)} / actual ${num(v.obsTemp)} (${(v.fTemp - v.obsTemp) >= 0 ? '+' : ''}${num(v.fTemp - v.obsTemp, 1)})</div>`).join('')
     : '<div class="muted">Collecting — first score lands 24h after setup.</div>';
+}
+
+if (location.search.includes('selftest')) {
+  console.assert(trustWord(2) === 'Good' && trustWord(4) === 'Fair' && trustWord(9) === 'Watch closely',
+    'intel: trust badge thresholds');
 }
 
 export function initIntel() {

--- a/site/js/pro.js
+++ b/site/js/pro.js
@@ -6,6 +6,7 @@ import { forecast as deskForecast } from './desk.js';
 import * as icon from './icons.js';
 import { initLayout } from './layout.js';
 import { normalToday } from './almanac.js';
+import { setScene } from './fx.js';
 
 const $ = (id) => document.getElementById(id);
 const SVGNS = 'http://www.w3.org/2000/svg';
@@ -60,6 +61,13 @@ function moonGlyph(age, size = 13) {
   </svg>`;
 }
 
+// "Sunset 8:14 PM" is a fact; "Sunset in 1h 14m" is the one people read across a room.
+export function until(epochSec, now = Date.now() / 1000) {
+  const m = Math.round((epochSec - now) / 60);
+  if (m < 0 || m > 24 * 60) return '';
+  return m < 60 ? `${m}m` : `${Math.floor(m / 60)}h ${m % 60}m`;
+}
+
 function renderHero(fc) {
   const c = fc.current_conditions, d = fc.forecast.daily[0];
   const [a, b] = skyFor(Date.now() / 1000, d.sunrise, d.sunset);
@@ -69,12 +77,20 @@ function renderHero(fc) {
   $('hero-cond').textContent = c.conditions || '';
   $('hero-hilo').textContent = `High ${num(d.air_temp_high)}° / Low ${num(d.air_temp_low)}°`;
   const muggy = c.dew_point >= 70 ? 'Very muggy' : c.dew_point >= 65 ? 'Muggy' : c.dew_point >= 55 ? 'Comfortable' : 'Dry';
-  $('hero-feels').textContent = `Now · Feels like ${num(c.feels_like)}° · ${muggy}`;
-  $('hero-sun').textContent = `Sunset ${timeStr(d.sunset)} · Sunrise ${timeStr(fc.forecast.daily[1]?.sunrise || d.sunrise)}`;
+  // Visibility only comes from open-meteo (Tempest has no such field), so it stays optional.
+  const vis = c.visibility == null ? ''
+    : ` · ${num(settings().units === 'metric' ? c.visibility / 1000 : c.visibility / 1609.34, 1)} ${U.dist()} vis`;
+  $('hero-feels').textContent = `Now · Feels like ${num(c.feels_like)}° · ${muggy}${vis}`;
+  const nextSunrise = fc.forecast.daily[1]?.sunrise || d.sunrise;
+  const [nextName, nextAt] = Date.now() / 1000 < d.sunset ? ['Sunset', d.sunset] : ['Sunrise', nextSunrise];
+  const soon = until(nextAt);
+  $('hero-sun').textContent = (soon ? `${nextName} in ${soon} · ` : '')
+    + `Sunset ${timeStr(d.sunset)} · Sunrise ${timeStr(nextSunrise)}`;
   const m = moon();
   $('hero-moon').innerHTML = `${moonGlyph(m.age)} ${m.name} · ${m.illum}%`;
   $('hero-moonset').textContent = `${m.nextName} ${m.nextDate.toLocaleString([], { weekday: 'short', month: 'short', day: 'numeric' })}`;
   $('hero-icon').innerHTML = icon.wxHero(c.icon, 150);
+  setScene(c.icon);
   renderNormal(d);
 }
 
@@ -497,7 +513,22 @@ function renderLocal(o) {
 window.addEventListener('wd:ws-obs', (e) => { if (!deskForecast()) renderLocal(e.detail); });
 window.addEventListener('wd:forecast', (e) => renderPro(e.detail));
 
+// One dot per station source the LAN server is holding, hover for the /diag line itself. Nothing
+// at all on a static host or a desktop with no server — there is no source to be healthy.
+async function renderHealth() {
+  const el = $('src-health');
+  try {
+    const d = await (await fetch(`${window.__WD_SRV || ''}/diag`)).json();
+    el.innerHTML = Object.entries(d).map(([src, v]) => {
+      const ago = Math.max(0, Math.round(Date.now() / 1000 - v.at));
+      const cls = !v.ok ? 'bad' : ago > 600 ? 'stale' : '';
+      return `<i class="${cls}" title="${src} · ${v.rows} rows · ${v.what} · ${ago}s ago"></i>`;
+    }).join('');
+  } catch { el.innerHTML = ''; }
+}
+
 export function initPro() {
+  every('pro-health', 300, renderHealth);
   every('pro-history', 300, async () => { await loadHistory(); renderPro(); });
   every('pro-consensus', 900, async () => { await loadConsensus(); renderPro(); });
   every('pro-qpf', 1800, async () => { await loadQpf(); renderPro(); });
@@ -507,9 +538,10 @@ export function initPro() {
   const eco = ecoOn();
   every('clock', eco ? 30 : 1, () => {
     const d = new Date();
+    const h12 = settings().clock24 === 'auto' || !settings().clock24 ? {} : { hour12: settings().clock24 === '12' };
     $('clock-time').textContent = d.toLocaleTimeString([], eco
-      ? { hour: 'numeric', minute: '2-digit' }
-      : { hour: 'numeric', minute: '2-digit', second: '2-digit' });
+      ? { hour: 'numeric', minute: '2-digit', ...h12 }
+      : { hour: 'numeric', minute: '2-digit', second: '2-digit', ...h12 });
     $('clock-date').textContent = d.toLocaleDateString([], { weekday: 'short', month: 'short', day: 'numeric' });
   });
   every('pro-clock', 60, () => { if (deskForecast()) renderHero(deskForecast()); });
@@ -524,6 +556,8 @@ export function initPro() {
 
 // ponytail-lite self-check: the only arithmetic here that isn't a straight unit multiply.
 if (location.search.includes('selftest')) {
+  console.assert(until(Date.now() / 1000 + 5400) === '1h 30m', 'pro: 90 minutes reads as 1h 30m');
+  console.assert(until(Date.now() / 1000 - 60) === '', 'pro: a past event has no countdown');
   console.assert(Math.abs(dewPointC(20, 100) - 20) < 0.1, 'pro: saturated air dews at the air temperature');
   console.assert(Math.abs(dewPointC(20, 50) - 9.3) < 0.3, 'pro: 20°C at 50% dews near 9.3°C');
   console.assert(dewPointC(20, 0) === null, 'pro: no humidity, no dew point');

--- a/site/sw.js
+++ b/site/sw.js
@@ -1,0 +1,40 @@
+// Shell cache only. There is no precache list on purpose: this app has no bundler and twenty
+// unversioned modules, so a hand-written manifest would rot the first time one was renamed.
+// Everything is cached as it is fetched, and the network still wins whenever it answers.
+const VER = new URL(self.location).searchParams.get('v') || 'dev';
+const CACHE = `wd-shell-${VER}`;
+
+// The API surface. None of it is ever cached or intercepted: /events is an open SSE stream,
+// /history streams CSV, /config carries the token, and a stale copy of any of them is a bug.
+const API = /^\/(events|config|udp|history|diag|ingest|backup\.db|proxy)(\/|$|\?)/;
+
+self.addEventListener('install', () => self.skipWaiting());
+
+self.addEventListener('activate', (e) => e.waitUntil((async () => {
+  for (const k of await caches.keys()) if (k.startsWith('wd-shell-') && k !== CACHE) await caches.delete(k);
+  await self.clients.claim();
+})()));
+
+self.addEventListener('fetch', (e) => {
+  const req = e.request;
+  const url = new URL(req.url);
+  if (req.method !== 'GET' || url.origin !== self.location.origin || API.test(url.pathname)) return;
+
+  const dest = req.destination;
+  // Icons and fonts never change under a given URL; anything that is code or markup must not be
+  // pinned by a cache, or a fixed bug could stay fixed only on the machines that never went offline.
+  const cacheFirst = dest === 'image' || dest === 'font';
+
+  e.respondWith((async () => {
+    const hit = await caches.match(req);
+    if (cacheFirst && hit) return hit;
+    try {
+      const res = await fetch(req);
+      if (res.ok) (await caches.open(CACHE)).put(req, res.clone());
+      return res;
+    } catch (err) {
+      if (hit) return hit;
+      throw err;
+    }
+  })());
+});


### PR DESCRIPTION
Three strands, all frontend — no Rust changes.

## Polish (3.1.0)
Animated hero keyed to the conditions icon (off in eco mode and while the tab is hidden) · countdown to the next solar event · visibility beside feels-like · source health dots on the ticker · region presets and a 12/24-hour clock · "why this forecast" over the model agreement rows plus a trust badge from this install's own verification record · kiosk mode composing fullscreen, layout lock, hidden header and a wake lock.

Skipped deliberately: a wind-unit override (labels also feed charts and alert rules — a label-only conversion would lie), shipped layout presets (would mean inventing snapshot blobs blind).

## PWA (3.2.0)
Shell-only service worker. No precache list: no bundler here, and a hand-written manifest of twenty unversioned files rots. Runtime cache-on-fetch, network-first except images/fonts, full passthrough for non-GET, cross-origin and every API route so SSE and CSV streaming are untouched. Cache name `wd-shell-{ver}`, busted via `sw.js?v=`. Registration gated off the desktop app, the Android app and plain-HTTP LAN.

README HTTPS recipes state the trust model: the full dashboard behind HTTPS is for trusted screens only, because `GET /config` serves the station token to any client. Only `/public` goes on the internet.

## What people wrote in about
- **The barometer now shows your barometer.** A station measures pressure where it stands; every console quotes it reduced to sea level. Only `station_pressure` was overlaid, so the gauge kept the model's MSL. Reduced now with open-meteo's own elevation — 30.06 at 7 m / 19 °C becomes 30.085, which is what the reporter's Davis reads. No elevation → no reduction, model MSL stays.
- **Self-check no longer probes WeatherFlow on installs with no Tempest** (#37). It checks the local archive instead, and fails honestly when nothing has reported in the last hour — the failure people actually hit.
- **401 on someone else's station** says the station isn't shared publicly instead of blaming the token (#38).
- **Severe banners come down** when the warning expires, and a continued NWS warning no longer re-chimes every five minutes.
- **First-run wizard stops leading with a Tempest token** — both routes visible, nothing autofocuses a field an Ambient owner can't fill.
- **The phone app admits a console can't upload to it** instead of printing an address on `tauri://localhost`, and points at the cloud sources.
- **WeeWX** needs no plugin: aim its Weather Underground uploader at `/ingest` (#47, documented).

## Verification
`?selftest` gains asserts for the sea-level reduction, the 12/24-hour clock, the countdown formatter, the trust-badge thresholds, the service-worker gating table and the ingest-address table. Every module passes `node --check` as ESM.

Not verified in a browser — no browser harness on this machine. The animated hero, kiosk mode and the install/offline path want a manual pass before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)