### PR TITLE
fix: e-ink hero, wizard place search, polled-station wind, and an elevation setting (3.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ and the format loosely follows [Keep a Changelog](https://keepachangelog.com/en/
 Every release ships desktop installers (Linux `.deb`, Windows, macOS), an arm64 `.deb` for the
 Raspberry Pi, an Android APK, and the `ghcr.io/d4vid87/weatherdesk` container image.
 
+## [3.1.1] — 2026-08-23
+
+Three things testers wrote in about, and the elevation setting the barometer always wanted.
+
+### Fixed
+- E-ink palette: the hero (and with it the clock) was white text on a white card, because the
+  palette strips background images and the hero's colour lived only in a gradient. It now paints
+  in the palette's own ink with a border, like every other e-ink panel.
+- Eco mode's clock pace and seconds format were read once at load, so the toggle did nothing
+  until a reload. The clock job re-registers on every settings change.
+- Place search in the setup wizard looked dead: the results rendered below the fold of the
+  wizard's scroll box, and a ZIP match was labelled "06092, Connecticut, United States" with the
+  town nowhere in sight. Results scroll into view, labels carry the town, and the search is
+  biased to your language and the location already on file.
+- Polled stations (Davis WeatherLink Live and friends) showed the forecast model's wind on the
+  gauges between forecast fetches — five minutes of somebody else's weather. Every observation
+  now repaints the cached forecast with the station's own reading.
+- A leftover Tempest device ID from an earlier setup beat the current brand when loading three
+  hours of history, which is what left the hero reading "999m old". Brand wins, and switching
+  brands clears the stale ID.
+- `/diag` called the healthy state "throttled" — the WeatherLink poll runs faster than the
+  archive's write gate by design. It now says so in words that don't look like a fault.
+
+### Added
+- Station elevation in Settings, in feet or metres to match your units. Only the barometer uses
+  it: a station reading is reduced to sea level before it is shown, and doing that with the
+  forecast model's elevation for the grid square instead of yours is why the dashboard and the
+  console disagreed by a few hundredths of an inch.
+- The live wind card says "1-min avg · polled" for brands that are polled. Only a Tempest hub
+  broadcasts true three-second wind; resending a one-minute average every ten seconds is not a
+  fast needle and shouldn't look like one.
+- Settings warns when two consoles are writing into one archive with no ingest key set — their
+  rows interleave and the trends read as noise.
+
 ## [3.1.0] — 2026-08-22
 
 ### Added

--- a/site/index.html
+++ b/site/index.html
@@ -242,8 +242,11 @@
   /* the canvas is positioned, so the content has to be too or it paints underneath */
   #hero > *:not(#hero-fx):not(#hero-icon) { position: relative; z-index: 1; }
   #hero > #hero-icon { z-index: 1; }
-  #hero { padding: 16px 20px 20px; color: #fff; overflow: hidden; border-radius: 12px;
+  #hero { padding: 16px 20px 20px; color: var(--hero-text, #fff); overflow: hidden; border-radius: 12px;
     background: linear-gradient(160deg, #1f6fb8, #7fb6e6); }
+  /* e-ink kills background-image, so the gradient goes and white-on-white would follow. */
+  html[data-palette="eink"] #hero { --hero-text: var(--text); background-color: var(--bg);
+    border: 1px solid var(--line); }
   #hero-clock { display: flex; align-items: baseline; gap: 14px; flex-wrap: wrap; margin-bottom: 10px;
     font-variant-numeric: tabular-nums; }
   #clock-time { font-size: 56px; font-weight: 700; line-height: 1; }
@@ -692,6 +695,7 @@
           <div>
             <div class="now-temp"><span id="live-wind">--</span><small id="live-wind-unit">mph</small></div>
             <div id="live-dir" class="muted"></div>
+            <div id="live-rate" class="muted" style="font-size:12px"></div>
           </div>
         </div>
         <div class="muted" style="font-size:12px;margin-top:6px">socket: <span id="ws-state">idle</span></div>
@@ -760,6 +764,11 @@
     <label>Tempest API token</label><input id="set-token" type="password" placeholder="personal use token">
     <label>Station ID</label><input id="set-station" inputmode="numeric">
     <label>Device ID (Tempest sensor)</label><input id="set-device" inputmode="numeric">
+    <label>Station elevation <span id="set-elev-unit">(ft)</span></label>
+    <input id="set-elev" inputmode="decimal" placeholder="from the forecast model">
+    <p class="muted" style="font-size:12px">Only the barometer uses it: a station reading is
+      reduced to sea level before it is shown, and doing that with the model's elevation instead
+      of yours is why the dashboard and the console disagree by a few hundredths.</p>
     <h2 style="font-size:13px;margin-top:18px">Another brand of station</h2>
     <p class="muted" style="font-size:12px">Leave as Tempest unless you have one of these. Push
       brands need no keys — point the console at the address shown below.</p>

--- a/site/js/api.js
+++ b/site/js/api.js
@@ -283,27 +283,35 @@ export function shapeOm(j, ownTuple = null) {
     conditions: omWords(cur.weather_code),
   };
 
-  if (ownTuple) {
-    const o = siToDisplay([[...ownTuple]])[0];
-    const own = (v) => (v == null ? undefined : v);
-    const overlay = {
-      air_temperature: own(o[OBS.temp]),
-      relative_humidity: own(o[OBS.rh]),
-      wind_avg: own(o[OBS.windAvg]),
-      wind_gust: own(o[OBS.windGust]),
-      wind_direction: own(o[OBS.windDir]),
-      uv: own(o[OBS.uv]),
-      solar_radiation: own(o[OBS.solar]),
-      precip_accum_local_day: own(o[OBS.dayRain]),
-      station_pressure: own(o[OBS.press]),
-      // The barometer gauge reads `sea_level_pressure`; without this line it showed the model's
-      // MSL forever and a real barometer sat unused two fields away.
-      sea_level_pressure: own(toSeaLevel(o[OBS.press], j.elevation, tempC(o[OBS.temp], metric))),
-    };
-    for (const k in overlay) if (overlay[k] !== undefined) c[k] = overlay[k];
-  }
+  if (ownTuple) overlayStation(c, ownTuple, j.elevation);
 
-  return { current_conditions: c, forecast: { daily, hourly } };
+  // Kept so a later observation can be overlaid on this same payload without refetching.
+  return { current_conditions: c, forecast: { daily, hourly }, elevation: j.elevation };
+}
+
+// The station's reading painted over the model's guess. Exported because observations arrive
+// far more often than forecasts do — a five-minute-old model wind is not "your" wind.
+export function overlayStation(c, tuple, elevation) {
+  const metric = settings().units === 'metric';
+  const o = siToDisplay([[...tuple]])[0];
+  const own = (v) => (v == null ? undefined : v);
+  const overlay = {
+    air_temperature: own(o[OBS.temp]),
+    relative_humidity: own(o[OBS.rh]),
+    wind_avg: own(o[OBS.windAvg]),
+    wind_gust: own(o[OBS.windGust]),
+    wind_direction: own(o[OBS.windDir]),
+    uv: own(o[OBS.uv]),
+    solar_radiation: own(o[OBS.solar]),
+    precip_accum_local_day: own(o[OBS.dayRain]),
+    station_pressure: own(o[OBS.press]),
+    // The barometer gauge reads `sea_level_pressure`; without this line it showed the model's
+    // MSL forever and a real barometer sat unused two fields away.
+    sea_level_pressure: own(toSeaLevel(o[OBS.press], settings().elevationM ?? elevation,
+      tempC(o[OBS.temp], metric))),
+  };
+  for (const k in overlay) if (overlay[k] !== undefined) c[k] = overlay[k];
+  return c;
 }
 
 export async function omForecast(lat = coords().lat, lon = coords().lon) {
@@ -374,8 +382,22 @@ export function aqi(lat = coords().lat, lon = coords().lon) {
   })}`);
 }
 
+// A ZIP hit comes back with name="06092" and the town only in `city`, so a label without it
+// reads as a bare number among five countries' worth of matches.
+export function placeLabel(p) {
+  return [p.name, p.city && p.city !== p.name ? p.city : null, p.state, p.country]
+    .filter(Boolean).join(', ');
+}
+
 export function geocode(q) {
-  return getJSON(`https://photon.komoot.io/api/?${qs({ q, limit: 5 })}`);
+  const c = coords();
+  const lang = (navigator.language || 'en').slice(0, 2);
+  return getJSON(`https://photon.komoot.io/api/?${qs({
+    q, limit: 5,
+    // Photon only speaks these three; anything else has to fall back or it 400s.
+    lang: ['en', 'de', 'fr'].includes(lang) ? lang : 'en',
+    ...(c.lat != null && c.lon != null ? { lat: c.lat, lon: c.lon } : {}),
+  })}`);
 }
 
 // 31 members of the GFS ensemble, which between them are an honest answer to "how sure is

--- a/site/js/app.js
+++ b/site/js/app.js
@@ -2,6 +2,10 @@
 
 const DEFAULTS = {
   token: '', stationId: '', deviceId: '', lat: null, lon: null, stationName: '',
+  // Metres above sea level, always — the drawer converts for whoever types feet. Null means
+  // "use the forecast model's elevation for this grid square", which is right to a few metres
+  // in flat country and tens of metres in a valley, which is a barometer's worth of error.
+  elevationM: null,
   units: 'imperial', refreshSec: 60,
   // 'auto' follows the browser locale; the other two are for the screen that lives in a country
   // its OS wasn't set up for.

--- a/site/js/boot.js
+++ b/site/js/boot.js
@@ -118,6 +118,15 @@ function showSourceFields() {
   if (push) $('src-url').value = canIngest() ? ingestUrl($('set-ingest-key').value.trim()) : '';
 }
 
+// Blank means "no override" — a null, not a zero. Zero is a real elevation at the coast.
+function elevMetres() {
+  const raw = $('set-elev').value.trim();
+  if (!raw) return null;
+  const v = Number(raw);
+  if (!Number.isFinite(v)) return null;
+  return settings().units === 'metric' ? v : v * 0.3048;
+}
+
 function fillDrawer() {
   const s = settings();
   $('set-token').value = s.token;
@@ -149,6 +158,11 @@ function fillDrawer() {
   $('set-wu-key').value = s.wuKey || '';
   $('set-pws-id').value = s.pwsId || '';
   $('set-pws-key').value = s.pwsKey || '';
+  // Stored in metres; shown in whatever the rest of the app is speaking.
+  const feet = s.units !== 'metric';
+  $('set-elev-unit').textContent = feet ? '(ft)' : '(m)';
+  $('set-elev').value = s.elevationM == null ? ''
+    : String(Math.round(feet ? s.elevationM / 0.3048 : s.elevationM));
   $('set-source').value = s.stationSource || '';
   $('set-wll').value = s.wllHost || '';
   $('set-awn-api').value = s.awnApiKey || '';
@@ -191,6 +205,11 @@ function renderDiag() {
         const ago = Math.max(0, Math.round(Date.now() / 1000 - v.at));
         return `<div>${src} · ${v.rows} rows · ${v.ok ? '' : 'error: '}${v.what} · ${ago}s ago</div>`;
       });
+      // One archive, one timeline: two consoles reporting without an ingest key interleave
+      // their rows and the trends read as noise. The real fix is per-station rows (3.3.0).
+      const writing = Object.values(d).filter((v) => v.rows > 0).length;
+      if (writing > 1) rows.push('<div class="warn">two stations are reporting here — their rows '
+        + 'interleave into one archive. Set an ingest key so only yours is stored.</div>');
       el.innerHTML = rows.join('') || 'No station has reported here yet.';
     })
     .catch(() => { el.innerHTML = ''; });
@@ -326,7 +345,11 @@ $('btn-save').onclick = async () => {
     wuKey: $('set-wu-key').value.trim(),
     pwsId: $('set-pws-id').value.trim(),
     pwsKey: $('set-pws-key').value.trim(),
+    elevationM: elevMetres(),
     stationSource: $('set-source').value,
+    // Switching to a non-Tempest brand: the old WeatherFlow device id has to go with it, or
+    // history and the age chip keep asking WeatherFlow about a station that isn't there.
+    ...($('set-source').value ? { deviceId: '' } : {}),
     wllHost: $('set-wll').value.trim(),
     awnApiKey: $('set-awn-api').value.trim(),
     awnAppKey: $('set-awn-app').value.trim(),
@@ -464,13 +487,15 @@ async function wizardFind() {
     try {
       const hits = (await api.geocode(q)).features || [];
       $('wiz-place-list').innerHTML = hits
-        .map((h, i) => `<button class="place-hit" data-hit="${i}">${[h.properties.name, h.properties.state, h.properties.country].filter(Boolean).join(', ')}</button>`)
+        .map((h, i) => `<button class="place-hit" data-hit="${i}">${api.placeLabel(h.properties)}</button>`)
         .join('') || '<div class="muted">no matches</div>';
+      // The wizard box scrolls; results land below the fold and read as "the button did nothing".
+      $('wiz-place-list').scrollIntoView({ block: 'nearest' });
       $('wiz-place-list').querySelectorAll('[data-hit]').forEach((b) => {
         b.onclick = () => {
           const h = hits[+b.dataset.hit];
           const [lon, lat] = h.geometry.coordinates;
-          saveSettings({ stationSource: sel.value || 'ecowitt', lat, lon, stationName: h.properties.name || q });
+          saveSettings({ stationSource: sel.value || 'ecowitt', lat, lon, stationName: h.properties.city || h.properties.name || q });
           $('wizard').hidden = true;
           fillDrawer();
           refreshAll();
@@ -1018,6 +1043,13 @@ if (location.search.includes('selftest')) {
   console.assert(mayPush(true), 'config: a screen that has pulled may push');
   console.assert(mayPush(false) === (configured() || !!settings().stationSource),
     'config: without a pull, only a screen that knows its station pushes');
+
+  // The bug that read as "the Find button does nothing": a ZIP match's town is in `city`, so
+  // without it the list showed five bare numbers and none of them looked like home.
+  console.assert(api.placeLabel({ name: '06092', city: 'Simsbury', state: 'Connecticut', country: 'United States' })
+    === '06092, Simsbury, Connecticut, United States', 'geocode label keeps the town');
+  console.assert(api.placeLabel({ name: 'Simsbury', city: 'Simsbury', state: 'Connecticut' })
+    === 'Simsbury, Connecticut', 'geocode label does not repeat the town');
 
   // The fetch deadline every screen depends on, on the browsers that have no AbortSignal.timeout.
   const sig = expires(50);

--- a/site/js/desk.js
+++ b/site/js/desk.js
@@ -61,6 +61,15 @@ export async function refreshDesk() {
   window.dispatchEvent(new CustomEvent('wd:forecast', { detail: fc }));
 }
 
+// A forecast is fetched every few minutes; the station reports every few seconds. Repaint the
+// cached payload with the new reading so the gauges show the garden, not the model.
+window.addEventListener('wd:ws-obs', (e) => {
+  if (!latestForecast) return;
+  api.overlayStation(latestForecast.current_conditions, e.detail, latestForecast.elevation);
+  renderCurrent(latestForecast.current_conditions);
+  window.dispatchEvent(new CustomEvent('wd:forecast', { detail: latestForecast }));
+});
+
 function renderCurrent(c) {
   if (!c) return;
   document.title = `${num(c.air_temperature)}${U.temp()} · WeatherDesk`;

--- a/site/js/places.js
+++ b/site/js/places.js
@@ -47,7 +47,7 @@ async function search() {
     const j = await api.geocode(q);
     $('place-results').innerHTML = (j.features || []).map((f, i) => {
       const p = f.properties;
-      const label = [p.name, p.state, p.country].filter(Boolean).join(', ');
+      const label = api.placeLabel(p);
       return `<button class="place-hit" data-i="${i}">${label}</button>`;
     }).join('') || '<div class="muted">no matches</div>';
     $('place-results').querySelectorAll('.place-hit').forEach((b) => {
@@ -56,7 +56,7 @@ async function search() {
         const p = f.properties;
         const place = {
           id: String(Date.now()),
-          name: [p.name, p.state].filter(Boolean).join(', '),
+          name: [p.city || p.name, p.state].filter(Boolean).join(', '),
           lat: f.geometry.coordinates[1], lon: f.geometry.coordinates[0],
         };
         saveSettings({ places: [...settings().places, place], activePlace: place.id });

--- a/site/js/pro.js
+++ b/site/js/pro.js
@@ -379,8 +379,10 @@ async function loadHistory() {
     // out of this server's archive, which is where its reports were stored on the way in. Same
     // tuples either way, so the trends, the arrows and the ticker don't know the difference.
     let j = null;
-    if (s.deviceId && /^\d+$/.test(s.deviceId)) j = await api.deviceObs(s.deviceId, end - 3 * 3600, end);
-    else if (s.stationSource) j = await api.localObs(3);
+    // stationSource first: a leftover Tempest deviceId from an earlier setup would otherwise
+    // send a Davis owner to WeatherFlow for history and every row would come back empty.
+    if (s.stationSource) j = await api.localObs(3);
+    else if (s.deviceId && /^\d+$/.test(s.deviceId)) j = await api.deviceObs(s.deviceId, end - 3 * 3600, end);
     if (!j) return;
     history = j.obs || [];
     renderStatus();
@@ -527,14 +529,9 @@ async function renderHealth() {
   } catch { el.innerHTML = ''; }
 }
 
-export function initPro() {
-  every('pro-health', 300, renderHealth);
-  every('pro-history', 300, async () => { await loadHistory(); renderPro(); });
-  every('pro-consensus', 900, async () => { await loadConsensus(); renderPro(); });
-  every('pro-qpf', 1800, async () => { await loadQpf(); renderPro(); });
-  every('pro-ensemble', 1800, loadEnsemble);
-  // A second hand is a repaint a second, forever — the single most expensive idle thing on the
-  // page. In eco the seconds go and so does 29 of every 30 repaints.
+// Re-registered on every settings change: `every` keys by name, so the eco pace and the seconds
+// format both follow the toggle without a reload.
+export function registerClock() {
   const eco = ecoOn();
   every('clock', eco ? 30 : 1, () => {
     const d = new Date();
@@ -544,6 +541,19 @@ export function initPro() {
       : { hour: 'numeric', minute: '2-digit', second: '2-digit', ...h12 });
     $('clock-date').textContent = d.toLocaleDateString([], { weekday: 'short', month: 'short', day: 'numeric' });
   });
+}
+
+export function initPro() {
+  every('pro-health', 300, renderHealth);
+  every('pro-history', 300, async () => { await loadHistory(); renderPro(); });
+  every('pro-consensus', 900, async () => { await loadConsensus(); renderPro(); });
+  every('pro-qpf', 1800, async () => { await loadQpf(); renderPro(); });
+  every('pro-ensemble', 1800, loadEnsemble);
+  // A second hand is a repaint a second, forever — the single most expensive idle thing on the
+  // page. In eco the seconds go and so does 29 of every 30 repaints.
+  registerClock();
+  // The eco toggle changes both the pace and the seconds format; re-register instead of reloading.
+  window.addEventListener('wd:settings', registerClock);
   every('pro-clock', 60, () => { if (deskForecast()) renderHero(deskForecast()); });
 
   // A class, not an inline style: inline would outrank the rule that stops the animation whenever

--- a/site/js/signals.js
+++ b/site/js/signals.js
@@ -184,6 +184,9 @@ export function renderRapid(mps, dir) {
   $('live-wind').textContent = num(v, 1);
   $('live-wind-unit').textContent = U.wind();
   $('live-dir').textContent = `${deg2compass(dir)} ${num(dir)}°`;
+  // Only a Tempest hub sends true 3-second wind. A polled brand's "rapid" packet is the
+  // station's own 1-minute average resent every 10s; saying so beats implying a fast needle.
+  $('live-rate').textContent = settings().stationSource ? '1-min avg · polled' : '3-second';
   const needle = $('live-needle');
   if (needle) needle.style.transform = `rotate(${dir}deg)`;
 }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weatherdesk"
-version = "3.1.0"
+version = "3.1.1"
 description = "Self-hosted WeatherFlow Tempest dashboard"
 authors = ["David May"]
 license = "MIT"

--- a/src-tauri/src/ingest.rs
+++ b/src-tauri/src/ingest.rs
@@ -321,7 +321,8 @@ fn take(state: &Arc<State>, f: &Fields, raw_ts: f64, src: i64, origin: &'static 
     let m = all.entry(origin).or_default();
     if !keep(at, m, raw_ts) {
         drop(all);
-        note(origin, true, "throttled", false);
+        // Healthy: the poll is faster than the archive write gate. "throttled" read as a fault.
+        note(origin, true, "ok · waiting for next write slot", false);
         return false;
     }
     let t = tuple(f, ts, m);
@@ -413,10 +414,17 @@ fn get(url: &str, origin: &'static str) -> Option<serde_json::Value> {
 /// somebody wants the fast needle.
 fn poll_wll(state: &Arc<State>, host: &str) {
     let Some(v) = get(&format!("http://{host}/v1/current_conditions"), "wll") else { return };
-    let Some(conds) = v.pointer("/data/conditions").and_then(|c| c.as_array()) else { return };
     let ts = v.pointer("/data/ts").and_then(|t| t.as_f64()).unwrap_or(epoch() as f64);
+    let f = wll_fields(&v);
+    if !f.is_empty() {
+        take(state, &f, ts, SRC_INGEST, "wll");
+    }
+}
 
+/// The payload-to-fields half of the WLL poll, split out so it can be tested without a console.
+fn wll_fields(v: &serde_json::Value) -> Fields {
     let mut f = Fields::new();
+    let Some(conds) = v.pointer("/data/conditions").and_then(|c| c.as_array()) else { return f };
     for c in conds {
         let g = |k: &str| c.get(k).and_then(|x| x.as_f64());
         // Structure type 1 is the ISS — the outdoor sensor suite. The others are the barometer
@@ -448,9 +456,7 @@ fn poll_wll(state: &Arc<State>, host: &str) {
             _ => {}
         }
     }
-    if !f.is_empty() {
-        take(state, &f, ts, SRC_INGEST, "wll");
-    }
+    f
 }
 
 /// Millimetres per tip, from the gauge Davis says is installed. Default is the 0.01 in gauge
@@ -729,6 +735,32 @@ mod tests {
         assert!(close(t[2], 4.4704));
         assert!(close(t[4], 180.0));
         assert!(close(t[18], 10.0));
+    }
+
+    /// A real /v1/current_conditions body, trimmed to the fields we read. Solar and UV come off
+    /// the ISS record and used to be dropped on the floor.
+    #[test]
+    fn a_wll_payload_becomes_the_fields_the_tuple_wants() {
+        let v = serde_json::json!({"data": {"ts": 1_700_000_000i64, "conditions": [
+            {"data_structure_type": 1, "temp": 71.6, "hum": 54.0,
+             "wind_speed_avg_last_1_min": 4.0, "wind_speed_hi_last_2_min": 11.0,
+             "wind_dir_scalar_avg_last_1_min": 190.0, "solar_rad": 812.0, "uv_index": 6.5,
+             "rainfall_daily": 14.0, "rain_size": 1},
+            {"data_structure_type": 3, "bar_absolute": 29.61, "bar_sea_level": 29.86},
+            {"data_structure_type": 4, "temp_in": 70.0}]}});
+        let f = wll_fields(&v);
+        assert_eq!(f.get("tempf").map(String::as_str), Some("71.6"));
+        assert_eq!(f.get("windspeedmph").map(String::as_str), Some("4"));
+        assert_eq!(f.get("winddir").map(String::as_str), Some("190"));
+        assert_eq!(f.get("uv").map(String::as_str), Some("6.5"));
+        assert_eq!(f.get("solarradiation").map(String::as_str), Some("812"));
+        // 14 tips of the 0.01 in gauge is 3.556 mm, not 14 of anything.
+        let rain: f64 = f.get("dailyrainmm").unwrap().parse().unwrap();
+        assert!((rain - 3.556).abs() < 1e-6, "rain was {rain}");
+        // The archive holds station pressure; sea level is derived from altitude downstream.
+        assert_eq!(f.get("baromabsin").map(String::as_str), Some("29.61"));
+        // The indoor record is not the outdoor temperature.
+        assert!(!f.contains_key("temp_in"));
     }
 
     #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "WeatherDesk",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "identifier": "io.github.davidmay87.weatherdesk",
   "build": {
     "frontendDist": "../site"


### PR DESCRIPTION
Three reports from a Davis VP2 tester and an e-ink kiosk user, plus the setting the barometer always needed.

## Fixed
- **E-ink hero invisible.** `html[data-palette="eink"] *` strips `background-image`, and `#hero`'s colour was `#fff` over a gradient — white on white, reported as "the hour is blacked out in kiosk mode". Kiosk CSS was innocent. Hero text now routes through `--hero-text` and the palette overrides it.
- **Eco clock frozen.** `ecoOn()` was captured once in `initPro`; the clock job now lives in `registerClock()` and re-registers on `wd:settings`.
- **Wizard "Find" looked dead.** Results rendered below the fold of `.wizard-box` (no `scrollIntoView`) and labels omitted Photon's `city`, so "06092" listed as a bare ZIP among four countries. Added `api.placeLabel()` (used by the wizard and Places), scrolling, and language/proximity bias on the geocode.
- **Polled stations showed model wind.** The station overlay only ran when a forecast arrived, and `pro.js`'s `wd:ws-obs` handler was dead-ended behind `if (!deskForecast())`. Overlay extracted to `api.overlayStation()`; `desk.js` re-applies it on every observation and repaints.
- **"999m old" chip.** A leftover numeric `deviceId` beat `stationSource` in `loadHistory`. Brand wins now, and selecting a brand clears the stale ID.
- **`/diag` said "throttled"** for the healthy case (10s poll vs 55s write gate). Now `ok · waiting for next write slot`.

## Added
- Station elevation setting (ft/m by units, stored in metres). Feeds `toSeaLevel` instead of open-meteo's grid-square elevation — the actual cause of the console/dashboard barometer gap.
- Live wind card labels polled sources "1-min avg · polled"; only a Tempest hub sends true 3-second wind.
- Settings warns when two origins are writing rows with no ingest key set.

## Tests
- New `a_wll_payload_becomes_the_fields_the_tuple_wants` — the WLL parse split into `wll_fields()` so a synthetic `/v1/current_conditions` body can be asserted (temp, wind, UV, solar, rain tips × gauge size, station pressure, indoor record rejected). There was no WLL coverage at all before.
- `?selftest` asserts for `placeLabel` on a ZIP hit and on a hit whose name and city match.
- `cargo test`: 25 passing. Clippy clean apart from two pre-existing `is_multiple_of` warnings.

Not verified against real Davis hardware — that goes back to the tester after release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)