### PR TITLE
chore: write checksums without the ./ prefix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,7 +166,9 @@ jobs:
             gh api -H 'Accept: application/octet-stream' \
               "repos/${{ github.repository }}/releases/assets/$id" > "$name"
           done
-          sha256sum ./* > ../SHA256SUMS.txt
+          # Plain filenames: `sha256sum ./*` writes a ./ prefix that `sha256sum -c` then
+          # looks for literally, in a directory the downloader doesn't have.
+          sha256sum * > ../SHA256SUMS.txt
           gh api --method POST -H "Content-Type: text/plain" \
             "https://uploads.github.com/repos/${{ github.repository }}/releases/$RELEASE_ID/assets?name=SHA256SUMS.txt" \
             --input ../SHA256SUMS.txt


### PR DESCRIPTION
`sha256sum ./*` in the `checksums` job records every entry as `./WeatherDesk_…`, so `sha256sum -c SHA256SUMS.txt` looks for a `./` path relative to wherever the user downloaded to and fails on names that are sitting right there. Plain filenames verify.

The v3.1.1 draft's SHA256SUMS.txt was re-uploaded with the prefix stripped by hand; from the next tag the workflow does it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)