### PR TITLE
feat: publish the station to MQTT from the server, not the page

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -996,12 +996,17 @@
       An ntfy.sh topic is public to anyone who guesses it, so make it long.</p>
 
     <h2 style="font-size:13px;margin-top:18px">Smart home</h2>
-    <label>MQTT WebSocket URL</label><input id="set-mqtt-url" placeholder="ws://homeassistant.local:9001">
+    <label>MQTT broker</label><input id="set-mqtt-url" placeholder="mqtt://homeassistant.local:1883">
+    <p class="muted" style="font-size:12px">The desktop and Docker builds speak plain MQTT
+      (<code>mqtt://</code> or <code>mqtts://</code>) and keep publishing with every tab closed,
+      which is what Home Assistant needs. A <code>ws://</code> address is published by this page
+      instead, and only while it is open.</p>
     <label>MQTT username</label><input id="set-mqtt-user" autocomplete="off">
     <label>MQTT password</label><input id="set-mqtt-pass" type="password" autocomplete="off">
     <label>Broker topics to show (one per line: topic | label | unit)</label>
     <textarea id="set-mqtt-subs" rows="3" placeholder="home/greenhouse/temp | Greenhouse | °F"
       style="width:100%;padding:8px;background:var(--bg);color:var(--text);border:1px solid var(--line);border-radius:8px;font:inherit"></textarea>
+    <label>Discovery prefix</label><input id="set-ha-prefix" placeholder="homeassistant">
     <label>Home Assistant URL</label><input id="set-ha-url" placeholder="http://homeassistant.local:8123">
     <label>Home Assistant token</label><input id="set-ha-token" type="password" placeholder="long-lived access token">
     <label>Entities to show</label><input id="set-ha-entities" placeholder="light.porch, sensor.attic_temp">

--- a/site/js/app.js
+++ b/site/js/app.js
@@ -37,6 +37,9 @@ const DEFAULTS = {
   // Smart home: an MQTT broker to publish to, and a Home Assistant to read back from. Both dark
   // until filled in.
   mqttUrl: '', mqttUser: '', mqttPass: '', haUrl: '', haToken: '', haEntities: '',
+  // Home Assistant's discovery topic root. Only ever changed by someone who changed it in Home
+  // Assistant first, but that someone has no other way to be found.
+  haDiscoveryPrefix: '',
   // Look and feel. 'auto' theme follows the station's own sunrise/sunset, not the OS — a wall
   // panel in a dark hallway wants the room's light, not the laptop's setting.
   theme: 'dark', accent: '', fontScale: 1, density: 'normal', bigNumbers: false,

--- a/site/js/boot.js
+++ b/site/js/boot.js
@@ -176,6 +176,7 @@ function fillDrawer() {
   $('set-webhook').value = s.webhookUrl || '';
   renderRules();
   $('set-mqtt-url').value = s.mqttUrl;
+  $('set-ha-prefix').value = s.haDiscoveryPrefix || '';
   $('set-mqtt-user').value = s.mqttUser;
   $('set-mqtt-pass').value = s.mqttPass;
   $('set-mqtt-subs').value = (s.mqttSubs || []).map((x) => [x.topic, x.label, x.unit].filter(Boolean).join(' | ')).join('\n');
@@ -360,6 +361,7 @@ $('btn-save').onclick = async () => {
     ntfyUrl: $('set-ntfy-url').value.trim() || 'https://ntfy.sh',
     webhookUrl: $('set-webhook').value.trim(),
     mqttUrl: $('set-mqtt-url').value.trim(),
+    haDiscoveryPrefix: $('set-ha-prefix').value.trim(),
     mqttUser: $('set-mqtt-user').value.trim(),
     mqttPass: $('set-mqtt-pass').value,
     mqttSubs: $('set-mqtt-subs').value.split('\n').map((line) => {

--- a/site/js/home.js
+++ b/site/js/home.js
@@ -180,11 +180,23 @@ function event(name, payload) {
   client?.publish(`${base()}/event/${name}`, JSON.stringify(payload));
 }
 
-export function initHome() {
+// The LAN server publishes over plain MQTT and keeps doing it with every tab shut, which is the
+// only way Home Assistant sensors stay available overnight. When it is, this page stays off the
+// topics entirely — two publishers on one topic set is a fight nobody wins. The in-page
+// publisher remains for a static host, a phone build, or a broker that only has a websocket
+// listener open.
+async function serverPublishing() {
+  try {
+    const d = await (await fetch(`${window.__WD_SRV || ''}/diag`, { signal: expires(4000) })).json();
+    return !!d.mqtt?.ok;
+  } catch { return false; }
+}
+
+export async function initHome() {
   client?.close();
   client = null;
   const s = settings();
-  if (s.mqttUrl && s.stationId) {
+  if (s.mqttUrl && s.stationId && !(await serverPublishing())) {
     client = mqtt({
       url: s.mqttUrl, user: s.mqttUser, pass: s.mqttPass,
       clientId: `weatherdesk-${s.stationId}-${Math.random().toString(16).slice(2, 8)}`,
@@ -200,6 +212,9 @@ export function initHome() {
       onMessage: (topic, payload) => { subValues.set(topic, payload); renderSubs(); },
       onState: (st) => { const el = $('mqtt-state'); if (el) { el.textContent = st; el.className = st === 'connected' ? 'ok' : 'muted'; } },
     });
+  } else if (s.mqttUrl && s.stationId) {
+    const el = $('mqtt-state');
+    if (el) { el.textContent = 'published by the server'; el.className = 'ok'; }
   }
   initHaPanel();
 }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -529,6 +529,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -550,7 +560,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.13.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -563,7 +573,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.13.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -1064,6 +1074,17 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
 ]
 
 [[package]]
@@ -1627,9 +1648,9 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
- "rustls",
+ "rustls 0.23.43",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower-service",
 ]
 
@@ -2543,6 +2564,12 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
@@ -3027,14 +3054,14 @@ dependencies = [
  "log",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
+ "rustls 0.23.43",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3058,6 +3085,24 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rumqttc"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1568e15fab2d546f940ed3a21f48bbbd1c494c90c99c4481339364a497f94a9"
+dependencies = [
+ "bytes",
+ "flume",
+ "futures-util",
+ "log",
+ "rustls-native-certs 0.7.3",
+ "rustls-pemfile",
+ "rustls-webpki 0.102.8",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-rustls 0.25.0",
 ]
 
 [[package]]
@@ -3104,6 +3149,20 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls"
 version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
@@ -3112,9 +3171,22 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.14",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe 0.1.6",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 2.11.1",
 ]
 
 [[package]]
@@ -3123,10 +3195,19 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3144,16 +3225,16 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni 0.22.4",
  "log",
  "once_cell",
- "rustls",
- "rustls-native-certs",
+ "rustls 0.23.43",
+ "rustls-native-certs 0.8.4",
  "rustls-platform-verifier-android",
- "rustls-webpki",
- "security-framework",
+ "rustls-webpki 0.103.14",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -3164,6 +3245,17 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -3259,12 +3351,25 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.13.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -3594,6 +3699,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3719,7 +3833,7 @@ checksum = "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9"
 dependencies = [
  "bitflags 2.13.1",
  "block2",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dbus",
@@ -3944,7 +4058,7 @@ dependencies = [
  "osakit",
  "percent-encoding",
  "reqwest",
- "rustls",
+ "rustls 0.23.43",
  "semver",
  "serde",
  "serde_json",
@@ -4211,7 +4325,30 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
 ]
 
 [[package]]
@@ -4220,7 +4357,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls",
+ "rustls 0.23.43",
  "tokio",
 ]
 
@@ -4553,7 +4690,7 @@ dependencies = [
  "flate2",
  "log",
  "once_cell",
- "rustls",
+ "rustls 0.23.43",
  "rustls-pki-types",
  "url",
  "webpki-roots 0.26.11",
@@ -4744,9 +4881,10 @@ dependencies = [
 
 [[package]]
 name = "weatherdesk"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "include_dir",
+ "rumqttc",
  "rusqlite",
  "serde_json",
  "tauri",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -40,6 +40,9 @@ rusqlite = { version = "0.32", features = ["bundled"] }
 ureq = "2"
 # The dashboard itself, so the headless binary is one file with nothing beside it.
 include_dir = "0.7"
+# MQTT for the Home Assistant integration. The blocking client: this binary has no async
+# runtime and does not want one for a publish every ten seconds.
+rumqttc = "0.24"
 # Desktop updates in place. Android is signed with its own key and stays a sideload.
 tauri-plugin-updater = { version = "2", optional = true }
 

--- a/src-tauri/src/ingest.rs
+++ b/src-tauri/src/ingest.rs
@@ -248,7 +248,7 @@ fn diags() -> &'static Mutex<HashMap<&'static str, Diag>> {
     D.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-fn note(origin: &'static str, ok: bool, what: &str, stored: bool) {
+pub fn note(origin: &'static str, ok: bool, what: &str, stored: bool) {
     let Ok(mut d) = diags().lock() else { return };
     let e = d.entry(origin).or_insert(Diag { at: 0, ok: true, what: String::new(), rows: 0 });
     e.at = epoch();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,6 +13,8 @@ pub mod cwop;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 pub mod ingest;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
+pub mod mqtt;
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 pub mod server;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 pub mod store;
@@ -69,6 +71,7 @@ pub fn start_services(data_dir: PathBuf, cfg_path: PathBuf) -> (std::sync::Arc<s
     cwop::start(state.data_dir.clone(), state.cfg_path.clone());
     cwop::start_relay(state.data_dir.clone(), state.cfg_path.clone());
     ingest::start_pollers(state.clone());
+    mqtt::start(state.data_dir.clone(), state.cfg_path.clone());
     let port = server::serve(state.clone(), want);
     (state, port)
 }

--- a/src-tauri/src/mqtt.rs
+++ b/src-tauri/src/mqtt.rs
@@ -1,0 +1,405 @@
+// Publish the station to an MQTT broker, so Home Assistant has it whether or not a browser is
+// open anywhere in the house.
+//
+// This used to live in `site/js/home.js`, which meant the sensors went unavailable the moment
+// the last tab closed — the one thing a home automation integration must not do. The page keeps
+// its Home Assistant *display* panel; publishing is the server's job now.
+//
+// Everything on the wire is SI, always, whatever the dashboard is set to. Home Assistant
+// converts for display, and a unit switch on the dashboard must never rewrite months of its
+// history.
+
+use crate::store;
+use rumqttc::{Client, LastWill, MqttOptions, QoS};
+use std::time::Duration;
+
+/// How often we look for a new row. The archive gains one a minute at best, so this is mostly
+/// a cheap "has anything changed" query.
+const POLL: Duration = Duration::from_secs(10);
+/// Retained discovery is re-sent this often: a broker that lost its retained set (a fresh
+/// container, a `mosquitto -c` with no persistence) otherwise never gets it back.
+const REANNOUNCE: Duration = Duration::from_secs(900);
+/// Home Assistant marks a sensor unavailable this long after its last value. Long enough for a
+/// station that reports every five minutes, short enough that a dead poller shows up as dead.
+const EXPIRE_AFTER: u64 = 1800;
+
+/// Column, sensor name, device_class, unit, state_class. The columns are `store`'s, so a field
+/// added there is one line here rather than a new tuple layout.
+const FIELDS: [(&str, &str, Option<&str>, &str, &str); 15] = [
+    ("temp", "temperature", Some("temperature"), "°C", "measurement"),
+    ("humidity", "humidity", Some("humidity"), "%", "measurement"),
+    ("pressure", "pressure", Some("atmospheric_pressure"), "hPa", "measurement"),
+    ("wind_avg", "wind", Some("wind_speed"), "m/s", "measurement"),
+    ("wind_gust", "gust", Some("wind_speed"), "m/s", "measurement"),
+    ("wind_lull", "wind lull", Some("wind_speed"), "m/s", "measurement"),
+    ("wind_dir", "wind direction", None, "°", "measurement"),
+    ("uv", "uv", None, "UV index", "measurement"),
+    ("solar", "solar", Some("irradiance"), "W/m²", "measurement"),
+    ("lux", "lux", Some("illuminance"), "lx", "measurement"),
+    ("rain", "rain", Some("precipitation"), "mm", "measurement"),
+    ("day_rain", "day rain", Some("precipitation"), "mm", "total_increasing"),
+    ("battery", "battery", Some("voltage"), "V", "measurement"),
+    ("strikes", "strikes", None, "strikes", "measurement"),
+    ("strike_dist", "strike distance", Some("distance"), "km", "measurement"),
+];
+
+/// Values the archive doesn't hold because they are read off the numbers next to them. Home
+/// Assistant can't derive these itself without a template sensor per house.
+/// name, device_class, unit, state_class — each optional, because a trend has none of them.
+type Derived = (&'static str, Option<&'static str>, Option<&'static str>, Option<&'static str>);
+const DERIVED: [Derived; 2] = [
+    ("feels_like", Some("temperature"), Some("°C"), Some("measurement")),
+    ("pressure_trend", None, None, None),
+];
+
+struct Conf {
+    url: String,
+    user: String,
+    pass: String,
+    station: String,
+    name: String,
+    prefix: String,
+    port: u16,
+}
+
+fn conf(cfg: &std::path::Path) -> Option<Conf> {
+    let get = |k: &str| crate::setting(cfg, k).unwrap_or_default().trim_matches('"').to_string();
+    let url = get("mqttUrl");
+    let station = get("stationId");
+    // A broker address and something to key the topics on. Without either there is nothing to
+    // publish and nothing to publish it as.
+    if url.is_empty() || station.is_empty() {
+        return None;
+    }
+    let prefix = match get("haDiscoveryPrefix") {
+        p if p.is_empty() => "homeassistant".to_string(),
+        p => p,
+    };
+    Some(Conf {
+        url,
+        user: get("mqttUser"),
+        pass: get("mqttPass"),
+        name: match get("stationName") {
+            n if n.is_empty() => format!("WeatherDesk {station}"),
+            n => n,
+        },
+        station,
+        prefix,
+        port: get("httpPort").parse().unwrap_or(crate::server::DEFAULT_PORT),
+    })
+}
+
+/// `mqtt://host:1883`, `mqtts://host:8883`, or a bare `host` — people paste all three. Returns
+/// host, port and whether it is TLS.
+fn parse_url(url: &str) -> Option<(String, u16, bool)> {
+    let (tls, rest) = match url.split_once("://") {
+        Some(("mqtts" | "ssl" | "mqtt+ssl", r)) => (true, r),
+        Some(("mqtt" | "tcp", r)) => (false, r),
+        // A ws:// URL is what the old in-page publisher wanted; this one speaks the plain
+        // protocol, which is the listener a broker has switched on by default.
+        Some(_) => return None,
+        None => (false, url),
+    };
+    let rest = rest.trim_end_matches('/');
+    let (host, port) = match rest.rsplit_once(':') {
+        Some((h, p)) => (h.to_string(), p.parse().ok()?),
+        None => (rest.to_string(), if tls { 8883 } else { 1883 }),
+    };
+    if host.is_empty() { None } else { Some((host, port, tls)) }
+}
+
+fn device(c: &Conf) -> serde_json::Value {
+    serde_json::json!({
+        "identifiers": [format!("weatherdesk_{}", c.station)],
+        "name": c.name,
+        "manufacturer": "WeatherDesk",
+        "model": "Weather station",
+        "sw_version": env!("CARGO_PKG_VERSION"),
+        // The link Home Assistant puts on the device page: back to the dashboard itself.
+        "configuration_url": format!("http://{}:{}/", crate::server::lan_ip(), c.port),
+    })
+}
+
+fn announce(client: &Client, c: &Conf) {
+    let dev = device(c);
+    let avail = format!("weatherdesk/{}/status", c.station);
+    let send = |kind: &str, slug: &str, mut cfg: serde_json::Value| {
+        cfg["device"] = dev.clone();
+        cfg["availability_topic"] = avail.clone().into();
+        let topic = format!("{}/{}/wd_{}_{}/config", c.prefix, kind, c.station, slug);
+        let _ = client.publish(topic, QoS::AtLeastOnce, true, cfg.to_string());
+    };
+    for (col, name, dc, unit, sc) in FIELDS {
+        let mut cfg = serde_json::json!({
+            "name": name,
+            "unique_id": format!("wd_{}_{}", c.station, col),
+            "state_topic": format!("weatherdesk/{}/{}", c.station, col),
+            "unit_of_measurement": unit,
+            "state_class": sc,
+            "expire_after": EXPIRE_AFTER,
+        });
+        if let Some(dc) = dc {
+            cfg["device_class"] = dc.into();
+        }
+        send("sensor", col, cfg);
+    }
+    for (name, dc, unit, sc) in DERIVED {
+        let mut cfg = serde_json::json!({
+            "name": name.replace('_', " "),
+            "unique_id": format!("wd_{}_{}", c.station, name),
+            "state_topic": format!("weatherdesk/{}/{}", c.station, name),
+            "expire_after": EXPIRE_AFTER,
+        });
+        if let Some(dc) = dc {
+            cfg["device_class"] = dc.into();
+        }
+        if let Some(u) = unit {
+            cfg["unit_of_measurement"] = u.into();
+        }
+        if let Some(s) = sc {
+            cfg["state_class"] = s.into();
+        }
+        send("sensor", name, cfg);
+    }
+    let _ = client.publish(avail, QoS::AtLeastOnce, true, "online");
+}
+
+/// Apparent temperature, SI in and SI out — the same two formulas `site/js/home.js` used, so the
+/// broker and the hero agree. Heat index above 27 °C, wind chill below 10 °C, the plain reading
+/// between them.
+pub fn feels_like(c: f64, rh: Option<f64>, ms: Option<f64>) -> f64 {
+    if c >= 27.0 {
+        if let Some(rh) = rh {
+            let f = c * 9.0 / 5.0 + 32.0;
+            let hi = -42.379 + 2.049_015_23 * f + 10.143_331_27 * rh - 0.224_755_41 * f * rh
+                - 6.837_83e-3 * f * f
+                - 5.481_717e-2 * rh * rh
+                + 1.228_74e-3 * f * f * rh
+                + 8.528_2e-4 * f * rh * rh
+                - 1.99e-6 * f * f * rh * rh;
+            return (hi - 32.0) * 5.0 / 9.0;
+        }
+    }
+    if c <= 10.0 {
+        if let Some(ms) = ms.filter(|v| *v > 1.34) {
+            let kph = ms * 3.6;
+            return 13.12 + 0.6215 * c - 11.37 * kph.powf(0.16) + 0.3965 * c * kph.powf(0.16);
+        }
+    }
+    c
+}
+
+/// Three hours of barometer in one word — the thing automations actually branch on, and the same
+/// bands the Desk's trend strip uses.
+pub fn press_trend(now_mb: f64, then_mb: f64) -> &'static str {
+    let d = now_mb - then_mb;
+    if d <= -2.0 {
+        "falling rapidly"
+    } else if d <= -0.5 {
+        "falling"
+    } else if d >= 2.0 {
+        "rising rapidly"
+    } else if d >= 0.5 {
+        "rising"
+    } else {
+        "steady"
+    }
+}
+
+/// The newest row, as (ts, column values in `FIELDS` order), plus the pressure three hours back.
+fn newest(conn: &rusqlite::Connection) -> Option<(i64, Vec<Option<f64>>, Option<f64>)> {
+    let cols = FIELDS.iter().map(|(c, ..)| *c).collect::<Vec<_>>().join(", ");
+    let (ts, vals) = conn
+        .query_row(&format!("SELECT ts, {cols} FROM obs ORDER BY ts DESC LIMIT 1"), [], |r| {
+            let ts: i64 = r.get(0)?;
+            let mut v = Vec::with_capacity(FIELDS.len());
+            for i in 0..FIELDS.len() {
+                v.push(r.get::<_, Option<f64>>(i + 1)?);
+            }
+            Ok((ts, v))
+        })
+        .ok()?;
+    let was = conn
+        .query_row(
+            "SELECT pressure FROM obs WHERE ts <= ?1 AND pressure IS NOT NULL ORDER BY ts DESC LIMIT 1",
+            [ts - 3 * 3600],
+            |r| r.get::<_, Option<f64>>(0),
+        )
+        .ok()
+        .flatten();
+    Some((ts, vals, was))
+}
+
+fn publish_row(client: &Client, c: &Conf, vals: &[Option<f64>], was: Option<f64>) {
+    let at = |name: &str| {
+        FIELDS.iter().position(|(col, ..)| *col == name).and_then(|i| vals[i])
+    };
+    for ((col, ..), v) in FIELDS.iter().zip(vals) {
+        if let Some(v) = v {
+            let _ = client.publish(
+                format!("weatherdesk/{}/{}", c.station, col),
+                QoS::AtLeastOnce,
+                true,
+                format!("{v}"),
+            );
+        }
+    }
+    if let Some(t) = at("temp") {
+        let f = (feels_like(t, at("humidity"), at("wind_avg")) * 10.0).round() / 10.0;
+        let _ = client.publish(
+            format!("weatherdesk/{}/feels_like", c.station),
+            QoS::AtLeastOnce,
+            true,
+            format!("{f}"),
+        );
+    }
+    if let (Some(p), Some(was)) = (at("pressure"), was) {
+        let _ = client.publish(
+            format!("weatherdesk/{}/pressure_trend", c.station),
+            QoS::AtLeastOnce,
+            true,
+            press_trend(p, was),
+        );
+    }
+}
+
+/// Connect, announce, and publish every new row until the config changes or the broker goes
+/// away. Returns so the caller can try again with whatever the config says then.
+fn session(data_dir: &std::path::Path, cfg_path: &std::path::Path, c: &Conf) {
+    let Some((host, port, tls)) = parse_url(&c.url) else {
+        eprintln!("weatherdesk: MQTT address must be mqtt:// or mqtts:// — the page's ws:// URL is a different listener");
+        std::thread::sleep(Duration::from_secs(300));
+        return;
+    };
+    let mut opts = MqttOptions::new(format!("weatherdesk-{}", c.station), host, port);
+    opts.set_keep_alive(Duration::from_secs(30));
+    if !c.user.is_empty() {
+        opts.set_credentials(c.user.clone(), c.pass.clone());
+    }
+    if tls {
+        opts.set_transport(rumqttc::Transport::tls_with_default_config());
+    }
+    // The broker says we are gone the moment this process does, so Home Assistant shows the
+    // sensors unavailable instead of serving a frozen reading forever.
+    opts.set_last_will(LastWill::new(
+        format!("weatherdesk/{}/status", c.station),
+        "offline",
+        QoS::AtLeastOnce,
+        true,
+    ));
+
+    let (client, mut connection) = Client::new(opts, 32);
+    // The event loop is what actually moves bytes; without something draining it nothing is sent.
+    let pump = std::thread::spawn(move || {
+        for e in connection.iter() {
+            if let Err(e) = e {
+                crate::ingest::note("mqtt", false, err_kind(&e), false);
+                // Never the error's Display: a rumqttc error can carry the broker URL, and the
+                // URL can carry a password.
+                eprintln!("weatherdesk: MQTT disconnected ({})", err_kind(&e));
+                return;
+            }
+        }
+    });
+
+    announce(&client, c);
+    // The page reads this to decide whether to run its own publisher — two publishers on one
+    // topic set is a fight nobody wins.
+    crate::ingest::note("mqtt", true, "publishing", false);
+    let mut last_announce = std::time::Instant::now();
+    let mut last_ts = 0i64;
+    loop {
+        std::thread::sleep(POLL);
+        if pump.is_finished() {
+            return;
+        }
+        // A settings change means a different broker, station or prefix: drop the session and
+        // let the caller build the next one.
+        match conf(cfg_path) {
+            Some(next) if next.url == c.url && next.station == c.station && next.prefix == c.prefix => {}
+            _ => {
+                let _ = client.publish(
+                    format!("weatherdesk/{}/status", c.station),
+                    QoS::AtLeastOnce,
+                    true,
+                    "offline",
+                );
+                let _ = client.disconnect();
+                return;
+            }
+        }
+        if last_announce.elapsed() >= REANNOUNCE {
+            announce(&client, c);
+            last_announce = std::time::Instant::now();
+        }
+        let Ok(conn) = store::open(&store::db_path(data_dir)) else { continue };
+        let Some((ts, vals, was)) = newest(&conn) else { continue };
+        if ts == last_ts {
+            continue;
+        }
+        last_ts = ts;
+        publish_row(&client, c, &vals, was);
+    }
+}
+
+/// Connection errors, named without ever quoting what we were connecting to.
+fn err_kind(e: &rumqttc::ConnectionError) -> &'static str {
+    use rumqttc::ConnectionError;
+    match e {
+        ConnectionError::Io(_) => "network",
+        ConnectionError::ConnectionRefused(_) => "refused",
+        ConnectionError::FlushTimeout => "timeout",
+        ConnectionError::MqttState(_) => "protocol",
+        _ => "error",
+    }
+}
+
+pub fn start(data_dir: std::path::PathBuf, cfg_path: std::path::PathBuf) {
+    std::thread::spawn(move || loop {
+        match conf(&cfg_path) {
+            Some(c) => {
+            session(&data_dir, &cfg_path, &c);
+            crate::ingest::note("mqtt", false, "reconnecting", false);
+        }
+            // Nothing configured: this is the default state of the app, not a fault.
+            None => std::thread::sleep(Duration::from_secs(30)),
+        }
+        std::thread::sleep(Duration::from_secs(5));
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn broker_addresses_people_actually_paste() {
+        assert_eq!(parse_url("mqtt://10.0.0.5:1883"), Some(("10.0.0.5".into(), 1883, false)));
+        assert_eq!(parse_url("mqtts://broker.lan"), Some(("broker.lan".into(), 8883, true)));
+        // A bare host is the commonest thing typed into a box labelled "broker".
+        assert_eq!(parse_url("homeassistant.local"), Some(("homeassistant.local".into(), 1883, false)));
+        // The old in-page publisher's websocket URL is a different listener; refuse it rather
+        // than silently dialling 1883 on a broker that only has 9001 open.
+        assert_eq!(parse_url("ws://10.0.0.5:9001"), None);
+        assert_eq!(parse_url(""), None);
+    }
+
+    #[test]
+    fn feels_like_uses_the_right_formula_at_each_end() {
+        // 32 °C at 70% is well above the plain reading.
+        assert!(feels_like(32.0, Some(70.0), Some(1.0)) > 38.0);
+        // -5 °C in a 5 m/s wind is well below it.
+        assert!(feels_like(-5.0, Some(60.0), Some(5.0)) < -8.0);
+        // In between, and in still air, the reading is the reading.
+        assert_eq!(feels_like(18.0, Some(50.0), Some(0.5)), 18.0);
+        assert_eq!(feels_like(-5.0, Some(60.0), None), -5.0);
+    }
+
+    #[test]
+    fn pressure_trend_bands_match_the_desk() {
+        assert_eq!(press_trend(1000.0, 1003.0), "falling rapidly");
+        assert_eq!(press_trend(1000.0, 1001.0), "falling");
+        assert_eq!(press_trend(1000.0, 1000.2), "steady");
+        assert_eq!(press_trend(1003.0, 1000.0), "rising rapidly");
+    }
+}


### PR DESCRIPTION
First piece of the 3.2.0 Home Assistant work.

## Why
The integration already existed and already worked — but `site/js/home.js` publishes over MQTT-in-a-websocket from an open tab, so every Home Assistant sensor goes unavailable the moment the last browser closes. Nobody leaves a tab open on the wall tablet overnight to keep their automations alive.

## What
New `src-tauri/src/mqtt.rs`, started from `start_services` beside the CWOP and relay threads:
- `rumqttc` blocking client (no async runtime in this binary, and none wanted for a publish every ten seconds). Plain `mqtt://` / `mqtts://`, with a bare hostname accepted because that is what people type. A `ws://` URL is refused with a message rather than silently dialled on 1883.
- Retained discovery for 15 sensors + `feels_like` + `pressure_trend`, all under one device with `manufacturer`/`model`/`sw_version`/`configuration_url`. Re-announced every 15 min so a broker with no persistence gets its retained set back.
- `expire_after: 1800` on every sensor, and a last will on `weatherdesk/<sid>/status`, so a dead station reads as unavailable rather than as a frozen reading.
- SI on the wire always. A units switch on the dashboard must never rewrite months of Home Assistant history.
- Polls the archive every 10s and publishes only when `ts` changes.
- New `haDiscoveryPrefix` setting (default `homeassistant`) for anyone who changed it in Home Assistant.

Page side: `initHome()` checks `/diag` for `mqtt.ok` and stays off the topics when the server is publishing — two publishers on one topic set is a fight nobody wins. The in-page publisher stays for a static host, the phone build, or a broker with only a websocket listener, and the panel says which one is running. The HA display panel is untouched.

## Verified
End to end against `eclipse-mosquitto:2` with a seeded archive: 17 retained discovery configs, state topics in SI (`temp 31.5`, `pressure 1006.4`, `day_rain 3.556`), `feels_like 39.6` from the heat-index branch, `pressure_trend falling rapidly` from a 3.5 hPa drop over three hours, `status online` on connect and `offline` from the last will on exit.

Unit tests: broker URL forms (`mqtt://`, `mqtts://` default port, bare host, `ws://` refused), both `feels_like` branches and the plain reading between them, and the four pressure bands. `cargo test` 28 passing, clippy clean apart from two pre-existing warnings.

## Security
Connection errors log a one-word kind, never the error's `Display` — a rumqttc error can carry the broker URL and the URL can carry a password. `mqttUser`/`mqttPass` were already in `SECRET_KEYS`; `haDiscoveryPrefix` is not a secret and deliberately stays out.

Still to come in 3.2.0: `/api/v1`, mDNS advertisement, the Home Assistant settings section with a test button, and the wizard/frontend batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)