### PR TITLE
feat: a versioned API (/api/v1) and an mDNS announcement

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -799,6 +799,8 @@
     <div id="src-wll" hidden>
       <label>WeatherLink Live address on the LAN</label>
       <input id="set-wll" placeholder="192.168.1.50">
+      <button id="btn-find-wll" class="ghost" style="margin-top:6px">Find it on my network</button>
+      <span id="wll-found" class="muted" style="font-size:12px"></span>
     </div>
     <div id="src-awn" hidden>
       <label>AWN API key</label><input id="set-awn-api" type="password">

--- a/site/js/boot.js
+++ b/site/js/boot.js
@@ -516,6 +516,24 @@ async function wizardFind() {
   target();
 }
 
+// The console announces itself over mDNS, and the server is already listening for it — so the
+// address nobody can find on a router page is one button away.
+$('btn-find-wll').onclick = async () => {
+  const out = $('wll-found');
+  out.textContent = 'looking…';
+  try {
+    const hits = await (await fetch(`${SRV}/discover/wll`, { signal: expires(6000) })).json();
+    if (!hits.length) {
+      out.textContent = 'nothing announced itself — type the address from the WeatherLink app';
+      return;
+    }
+    $('set-wll').value = hits[0].host;
+    out.textContent = hits.length === 1 ? `found ${hits[0].name}` : `found ${hits.length}, using ${hits[0].name}`;
+  } catch {
+    out.textContent = 'this build has no server to ask — type the address instead';
+  }
+};
+
 $('btn-wiz-find').onclick = () => wizardFind();
 $('wiz-token').onkeydown = (e) => { if (e.key === 'Enter') wizardFind(); };
 $('btn-wiz-close').onclick = () => { $('wizard').hidden = true; };

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -124,7 +124,7 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "parking",
- "polling",
+ "polling 3.11.0",
  "rustix",
  "slab",
  "windows-sys 0.61.2",
@@ -1671,7 +1671,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -1818,6 +1818,16 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "if-addrs"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b2eeee38fef3aa9b4cc5f1beea8a2444fc00e7377cafae396de3f5c2065e24"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2196,6 +2206,19 @@ dependencies = [
  "log",
  "tendril",
  "web_atoms",
+]
+
+[[package]]
+name = "mdns-sd"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fe7c11a1eb3cfbfcf702d1601c1f5f4c102cdc8665b8a557783ef634741676e"
+dependencies = [
+ "flume",
+ "if-addrs",
+ "log",
+ "polling 2.8.0",
+ "socket2 0.5.10",
 ]
 
 [[package]]
@@ -2777,6 +2800,22 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "concurrent-queue",
+ "libc",
+ "log",
+ "pin-project-lite",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3642,6 +3681,16 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
@@ -4324,7 +4373,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.5",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -4884,6 +4933,7 @@ name = "weatherdesk"
 version = "3.1.1"
 dependencies = [
  "include_dir",
+ "mdns-sd",
  "rumqttc",
  "rusqlite",
  "serde_json",
@@ -5220,6 +5270,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -5267,6 +5326,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -5328,6 +5402,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -5346,6 +5426,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -5361,6 +5447,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5394,6 +5486,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5409,6 +5507,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5430,6 +5534,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -5445,6 +5555,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -43,6 +43,9 @@ include_dir = "0.7"
 # MQTT for the Home Assistant integration. The blocking client: this binary has no async
 # runtime and does not want one for a publish every ten seconds.
 rumqttc = "0.24"
+# Advertise the dashboard on the LAN: how Home Assistant's config flow finds this server, and
+# how the setup wizard finds a WeatherLink Live (which advertises the same way).
+mdns-sd = "0.11"
 # Desktop updates in place. Android is signed with its own key and stays a sideload.
 tauri-plugin-updater = { version = "2", optional = true }
 

--- a/src-tauri/src/api.rs
+++ b/src-tauri/src/api.rs
@@ -1,0 +1,172 @@
+// The versioned read-only API. One endpoint, named fields, SI, no credentials.
+//
+// Everything else this server answers is shaped for the dashboard and free to change with it —
+// `/history/tuples` hands out bare arrays in a column order the page happens to know. That is a
+// fine contract with a page shipped in the same binary and a terrible one with a Home Assistant
+// integration somebody installed six months ago. `/api/v1` is the one that has to stay still.
+
+use crate::{ingest, server::State, store};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::Duration;
+
+/// Open-meteo, cached: (fetched_at, body). A forecast is the same for everyone in the house, and
+/// Home Assistant polling every minute must not become a request upstream every minute.
+fn cache() -> &'static Mutex<Option<(u64, serde_json::Value)>> {
+    static C: OnceLock<Mutex<Option<(u64, serde_json::Value)>>> = OnceLock::new();
+    C.get_or_init(|| Mutex::new(None))
+}
+
+const FORECAST_TTL: u64 = 900;
+
+/// Today's high, low, precipitation chance and condition code, for the weather entity. Fetched
+/// from the same free endpoint the page uses, in SI whatever the dashboard is set to.
+fn forecast(cfg: &std::path::Path) -> Option<serde_json::Value> {
+    let now = crate::server::epoch();
+    if let Ok(c) = cache().lock() {
+        if let Some((at, body)) = c.as_ref() {
+            if now.saturating_sub(*at) < FORECAST_TTL {
+                return Some(body.clone());
+            }
+        }
+    }
+    let num = |k: &str| crate::setting(cfg, k)?.trim_matches('"').parse::<f64>().ok();
+    let (lat, lon) = (num("lat")?, num("lon")?);
+    let url = format!(
+        "https://api.open-meteo.com/v1/forecast?latitude={lat}&longitude={lon}\
+         &daily=weather_code,temperature_2m_max,temperature_2m_min,precipitation_probability_max\
+         &forecast_days=5&timezone=auto&timeformat=unixtime"
+    );
+    let body = match ureq::get(&url).timeout(Duration::from_secs(20)).call() {
+        Ok(r) => serde_json::from_str::<serde_json::Value>(&r.into_string().ok()?).ok()?,
+        // Status codes only: an upstream URL carries the coordinates of somebody's house.
+        Err(ureq::Error::Status(code, _)) => {
+            eprintln!("weatherdesk: forecast fetch failed ({code})");
+            return None;
+        }
+        Err(_) => return None,
+    };
+    let d = body.get("daily")?;
+    let day = |k: &str, i: usize| d.get(k).and_then(|a| a.get(i)).cloned().unwrap_or(serde_json::Value::Null);
+    let days: Vec<serde_json::Value> = (0..5)
+        .map(|i| {
+            serde_json::json!({
+                "at": day("time", i),
+                "high_c": day("temperature_2m_max", i),
+                "low_c": day("temperature_2m_min", i),
+                "precip_chance": day("precipitation_probability_max", i),
+                "wmo_code": day("weather_code", i),
+            })
+        })
+        .collect();
+    let out = serde_json::json!({ "days": days });
+    if let Ok(mut c) = cache().lock() {
+        *c = Some((now, out.clone()));
+    }
+    Some(out)
+}
+
+/// The newest archive row as named fields, plus the two derived values the MQTT publisher also
+/// sends. Named, because a Home Assistant integration must not have to know a column order.
+fn current(conn: &rusqlite::Connection) -> Option<serde_json::Value> {
+    let cols = store::FIELDS.join(", ");
+    let (ts, vals) = conn
+        .query_row(&format!("SELECT ts, {cols} FROM obs ORDER BY ts DESC LIMIT 1"), [], |r| {
+            let ts: i64 = r.get(0)?;
+            let mut v = Vec::with_capacity(store::FIELDS.len());
+            for i in 1..=store::FIELDS.len() {
+                v.push(r.get::<_, Option<f64>>(i)?);
+            }
+            Ok((ts, v))
+        })
+        .ok()?;
+    let at = |name: &str| store::FIELDS.iter().position(|f| *f == name).and_then(|i| vals[i]);
+    let mut obj = serde_json::Map::new();
+    obj.insert("at".into(), ts.into());
+    for (f, v) in store::FIELDS.iter().zip(&vals) {
+        obj.insert((*f).into(), match v {
+            Some(x) => serde_json::Value::from(*x),
+            None => serde_json::Value::Null,
+        });
+    }
+    if let Some(t) = at("temp") {
+        let f = (crate::mqtt::feels_like(t, at("humidity"), at("wind_avg")) * 10.0).round() / 10.0;
+        obj.insert("feels_like".into(), f.into());
+    }
+    if let Some(p) = at("pressure") {
+        let was = conn
+            .query_row(
+                "SELECT pressure FROM obs WHERE ts <= ?1 AND pressure IS NOT NULL ORDER BY ts DESC LIMIT 1",
+                [ts - 3 * 3600],
+                |r| r.get::<_, Option<f64>>(0),
+            )
+            .ok()
+            .flatten();
+        if let Some(was) = was {
+            obj.insert("pressure_trend".into(), crate::mqtt::press_trend(p, was).into());
+        }
+    }
+    Some(serde_json::Value::Object(obj))
+}
+
+/// The whole payload. Units are SI and stated as such, so a consumer never has to guess which
+/// way the dashboard was set when it read this.
+pub fn snapshot(state: &Arc<State>) -> String {
+    let cfg = &state.cfg_path;
+    let get = |k: &str| crate::setting(cfg, k).map(|v| v.trim_matches('"').to_string()).unwrap_or_default();
+    let obs = state.db().and_then(|c| current(&c));
+    let body = serde_json::json!({
+        "api": 1,
+        "version": env!("CARGO_PKG_VERSION"),
+        "units": "si",
+        "station": {
+            "id": get("stationId"),
+            "name": get("stationName"),
+            "source": get("stationSource"),
+            "lat": get("lat").parse::<f64>().ok(),
+            "lon": get("lon").parse::<f64>().ok(),
+        },
+        "current": obs,
+        "forecast": forecast(cfg),
+        "health": serde_json::from_str::<serde_json::Value>(&ingest::diag_json()).unwrap_or_default(),
+    });
+    body.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Named fields, and the derived pair alongside them — the whole point of the endpoint.
+    #[test]
+    fn current_is_named_fields_not_a_bare_tuple() {
+        let conn = store::open(std::path::Path::new(":memory:")).unwrap();
+        let mut row = vec![None; store::FIELDS.len()];
+        let put = |row: &mut Vec<Option<f64>>, name: &str, v: f64| {
+            row[store::FIELDS.iter().position(|f| *f == name).unwrap()] = Some(v);
+        };
+        put(&mut row, "temp", 31.5);
+        put(&mut row, "humidity", 72.0);
+        put(&mut row, "pressure", 1006.4);
+        let now = crate::server::epoch() as i64;
+        conn.execute(
+            &format!(
+                "INSERT INTO obs (ts, {}) VALUES ({}, {})",
+                store::FIELDS.join(", "),
+                now,
+                row.iter().map(|v| v.map(|x| x.to_string()).unwrap_or_else(|| "NULL".into())).collect::<Vec<_>>().join(", ")
+            ),
+            [],
+        )
+        .unwrap();
+        conn.execute("INSERT INTO obs (ts, pressure) VALUES (?1, 1009.9)", [now - 3 * 3600]).unwrap();
+
+        let v = current(&conn).unwrap();
+        assert_eq!(v["temp"], 31.5);
+        assert_eq!(v["at"], now);
+        // A field the station doesn't have is null, not missing and not zero.
+        assert!(v["lux"].is_null());
+        // Heat index at 31.5 °C and 72% is well above the plain reading.
+        assert!(v["feels_like"].as_f64().unwrap() > 38.0);
+        assert_eq!(v["pressure_trend"], "falling rapidly");
+    }
+}

--- a/src-tauri/src/discover.rs
+++ b/src-tauri/src/discover.rs
@@ -1,0 +1,61 @@
+// Say we are here, and listen for the one other box worth finding.
+//
+// Two jobs, one protocol. Advertising `_weatherdesk._tcp` is what lets Home Assistant's config
+// flow offer this server rather than asking somebody to find its IP; browsing `_weatherlinklive`
+// is what lets the setup wizard fill in a Davis console's address for them.
+
+use mdns_sd::{ServiceDaemon, ServiceInfo};
+use std::sync::{Mutex, OnceLock};
+
+/// Davis WeatherLink Live's own service type. The console advertises it out of the box.
+const WLL: &str = "_weatherlinklive._tcp.local.";
+
+fn found() -> &'static Mutex<Vec<(String, String)>> {
+    static F: OnceLock<Mutex<Vec<(String, String)>>> = OnceLock::new();
+    F.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+/// Consoles seen on the LAN, as (name, address). The wizard's "find my WeatherLink" button.
+pub fn wll_hosts() -> Vec<(String, String)> {
+    found().lock().map(|f| f.clone()).unwrap_or_default()
+}
+
+pub fn start(port: u16) {
+    std::thread::spawn(move || {
+        let Ok(daemon) = ServiceDaemon::new() else {
+            // No mDNS is not a fault: plenty of networks block multicast, and every address in
+            // this app can still be typed in by hand.
+            return;
+        };
+        let host = crate::server::lan_ip();
+        let info = ServiceInfo::new(
+            "_weatherdesk._tcp.local.",
+            "WeatherDesk",
+            &format!("weatherdesk-{}.local.", host.replace('.', "-")),
+            host.as_str(),
+            port,
+            &[("version", env!("CARGO_PKG_VERSION")), ("path", "/api/v1")][..],
+        );
+        match info {
+            Ok(info) => {
+                let _ = daemon.register(info);
+            }
+            Err(_) => eprintln!("weatherdesk: mDNS registration failed"),
+        }
+
+        // Browsing runs for the life of the process: a console that is switched on after us is
+        // exactly the one somebody is standing there trying to set up.
+        if let Ok(rx) = daemon.browse(WLL) {
+            while let Ok(event) = rx.recv() {
+                if let mdns_sd::ServiceEvent::ServiceResolved(s) = event {
+                    let Some(addr) = s.get_addresses().iter().next().map(|a| a.to_string()) else { continue };
+                    let name = s.get_fullname().split('.').next().unwrap_or("WeatherLink").to_string();
+                    if let Ok(mut f) = found().lock() {
+                        f.retain(|(_, a)| *a != addr);
+                        f.push((name, addr));
+                    }
+                }
+            }
+        }
+    });
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,7 +9,11 @@
 // the Docker image, a dashboard for a house with no desktop in it.
 
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
+pub mod api;
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 pub mod cwop;
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+pub mod discover;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 pub mod ingest;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
@@ -73,6 +77,7 @@ pub fn start_services(data_dir: PathBuf, cfg_path: PathBuf) -> (std::sync::Arc<s
     ingest::start_pollers(state.clone());
     mqtt::start(state.data_dir.clone(), state.cfg_path.clone());
     let port = server::serve(state.clone(), want);
+    discover::start(port);
     (state, port)
 }
 

--- a/src-tauri/src/server.rs
+++ b/src-tauri/src/server.rs
@@ -355,6 +355,20 @@ fn handle(state: &Arc<State>, mut req: Request) {
         // What each station source last did, for the drawer and for a screenshot in a bug
         // report. Fixed phrases and status codes only, so there is nothing here to gate.
         "/diag" => json(ingest::diag_json()),
+        // The versioned contract: named fields, SI, no credentials. Everything else here is
+        // shaped for the page and free to change with it — this one isn't. See `api.rs`.
+        "/api/v1" => json(crate::api::snapshot(state)),
+        // WeatherLink Live consoles seen on the LAN, for the wizard's find button. Names and
+        // addresses of hardware on this network only — nothing here that isn't already visible
+        // to anything else plugged into it.
+        "/discover/wll" => {
+            let hosts = crate::discover::wll_hosts();
+            json(serde_json::json!(hosts
+                .iter()
+                .map(|(n, a)| serde_json::json!({ "name": n, "host": a }))
+                .collect::<Vec<_>>())
+            .to_string())
+        }
         // The National Hurricane Center serves its storm list without CORS headers, so no page
         // can read it. One fixed URL, fetched here and handed on — not a general proxy.
         "/proxy/nhc" => {

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -9,7 +9,7 @@ use rusqlite::{params_from_iter, Connection};
 use std::path::{Path, PathBuf};
 
 /// obs_st tuple layout minus its leading timestamp, same order as `site/js/api.js` OBS.
-const FIELDS: [&str; 18] = [
+pub const FIELDS: [&str; 18] = [
     "wind_lull",
     "wind_avg",
     "wind_gust",


### PR DESCRIPTION
Second piece of 3.2.0, on top of #53.

## `/api/v1`
`src-tauri/src/api.rs`. Everything else this server answers is shaped for the page it ships with — `/history/tuples` hands out bare arrays in a column order the page happens to know. Fine with a dashboard in the same binary, useless as a contract with a HACS integration somebody installed six months ago.

The payload: `api`/`version`/`units`, a `station` block (id, name, source, lat/lon), `current` as **named** fields with `feels_like` and `pressure_trend` derived the same way `mqtt.rs` derives them, a five-day `forecast` off open-meteo, and `health` from `/diag`.

- SI, stated as such, so nobody has to guess how the dashboard was set when it read this.
- Forecast cached 15 minutes — a forecast is the same for everyone in the house, and Home Assistant polling every minute must not become an upstream request every minute.
- No credentials, same rule as `/public`. Verified: no `token`/`pass`/`key` substring anywhere in a live response.
- `store::FIELDS` made `pub` so the column list has one home.

## mDNS
`src-tauri/src/discover.rs`, `mdns-sd`. Advertises `_weatherdesk._tcp` with `version` and `path=/api/v1` TXT records — how the HACS config flow will offer this server instead of asking for an IP. The same daemon browses `_weatherlinklive._tcp` for the life of the process (a console switched on after us is exactly the one somebody is setting up), exposed at `/discover/wll`.

Settings gains a **"Find it on my network"** button beside the WeatherLink address, which fills it in. Falls back to a plain message on a static host or phone build where there is no server to ask. No mDNS on the network is not a fault — every address in this app can still be typed by hand.

## Verified
Live headless server against a seeded archive:
- `/api/v1` returns the named-field `current` (`temp 31.5`, `feels_like 39.6`, `pressure_trend falling rapidly`, absent sensors `null` rather than `0`), a real five-day open-meteo forecast, and the station block.
- Raw mDNS query from a socket joined to `224.0.0.251`: PTR answer for `_weatherdesk._tcp` from the server.
- `/discover/wll` returns `[]` on a LAN with no Davis console, which is the honest answer here.
- New test: `current_is_named_fields_not_a_bare_tuple`. `cargo test` 29 passing, clippy clean bar the two pre-existing warnings.

Next in 3.2.0: the Home Assistant settings section with a test-connection button, then the wizard and frontend batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)