### PR TITLE
feat: one Home Assistant settings section, with a test button that tries it for real

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -997,7 +997,12 @@
       formatted for them automatically. Alerts are sent as title, body and category only — never your token.
       An ntfy.sh topic is public to anyone who guesses it, so make it long.</p>
 
-    <h2 style="font-size:13px;margin-top:18px">Smart home</h2>
+    <h2 style="font-size:13px;margin-top:18px">Home Assistant</h2>
+    <p class="muted" style="font-size:12px">Two halves, either useful on its own: the station is
+      published to your broker and appears in Home Assistant on its own, and a few Home Assistant
+      entities can be read back onto the Signals tab.</p>
+
+    <h3 style="font-size:12px;margin:12px 0 0">Publish the station</h3>
     <label>MQTT broker</label><input id="set-mqtt-url" placeholder="mqtt://homeassistant.local:1883">
     <p class="muted" style="font-size:12px">The desktop and Docker builds speak plain MQTT
       (<code>mqtt://</code> or <code>mqtts://</code>) and keep publishing with every tab closed,
@@ -1005,13 +1010,20 @@
       instead, and only while it is open.</p>
     <label>MQTT username</label><input id="set-mqtt-user" autocomplete="off">
     <label>MQTT password</label><input id="set-mqtt-pass" type="password" autocomplete="off">
-    <label>Broker topics to show (one per line: topic | label | unit)</label>
-    <textarea id="set-mqtt-subs" rows="3" placeholder="home/greenhouse/temp | Greenhouse | °F"
-      style="width:100%;padding:8px;background:var(--bg);color:var(--text);border:1px solid var(--line);border-radius:8px;font:inherit"></textarea>
     <label>Discovery prefix</label><input id="set-ha-prefix" placeholder="homeassistant">
+    <p class="muted" style="font-size:12px">Leave this alone unless you changed it in Home
+      Assistant's own MQTT settings first.</p>
+
+    <h3 style="font-size:12px;margin:12px 0 0">Read entities back</h3>
     <label>Home Assistant URL</label><input id="set-ha-url" placeholder="http://homeassistant.local:8123">
     <label>Home Assistant token</label><input id="set-ha-token" type="password" placeholder="long-lived access token">
     <label>Entities to show</label><input id="set-ha-entities" placeholder="light.porch, sensor.attic_temp">
+    <label>Broker topics to show (one per line: topic | label | unit)</label>
+    <textarea id="set-mqtt-subs" rows="3" placeholder="home/greenhouse/temp | Greenhouse | °F"
+      style="width:100%;padding:8px;background:var(--bg);color:var(--text);border:1px solid var(--line);border-radius:8px;font:inherit"></textarea>
+
+    <button id="btn-ha-test" class="ghost" style="margin-top:10px">Test both</button>
+    <div id="ha-test-out" class="muted" style="font-size:12px;margin-top:6px"></div>
 
     <!-- Help. Plain <details> and no script: this is the manual people asked for, and it has to
          still be readable on an install whose JavaScript is having a bad day. Keep in step with

--- a/site/js/boot.js
+++ b/site/js/boot.js
@@ -58,9 +58,11 @@ export function mayPush(pulled = rev !== null) {
   return pulled || configured() || !!settings().stationSource;
 }
 
+// Returns the write, so a caller that needs the server to have the new settings before it asks
+// the server anything (the Home Assistant test button) can wait for it.
 function pushConfig() {
-  if (syncing || PUBLIC || !mayPush()) return;
-  fetch(`${SRV}/config`, {
+  if (syncing || PUBLIC || !mayPush()) return Promise.resolve();
+  return fetch(`${SRV}/config`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ _rev: rev ?? 0, at: Date.now(), settings: settings(), layout: load('wd.layout', {}) }),
@@ -531,6 +533,32 @@ $('btn-find-wll').onclick = async () => {
     out.textContent = hits.length === 1 ? `found ${hits[0].name}` : `found ${hits.length}, using ${hits[0].name}`;
   } catch {
     out.textContent = 'this build has no server to ask — type the address instead';
+  }
+};
+
+// Save first, then ask the server to try both for real: the credentials it tests are the ones
+// on disk, and a password typed with a trailing space is otherwise a silent nothing found days
+// later when an automation doesn't fire. The token never comes back to this page.
+$('btn-ha-test').onclick = async () => {
+  const out = $('ha-test-out');
+  out.textContent = 'saving and testing…';
+  // The server tests what is on disk, so these five boxes have to get there first. Save proper
+  // would close the drawer, which is where the answer is about to appear.
+  saveSettings({
+    mqttUrl: $('set-mqtt-url').value.trim(),
+    mqttUser: $('set-mqtt-user').value.trim(),
+    mqttPass: $('set-mqtt-pass').value,
+    haDiscoveryPrefix: $('set-ha-prefix').value.trim(),
+    haUrl: $('set-ha-url').value.trim(),
+    haToken: $('set-ha-token').value.trim(),
+  });
+  await pushConfig();
+  try {
+    const r = await (await fetch(`${SRV}/ha/test`, { signal: expires(30000) })).json();
+    const line = (name, x) => `<div class="${x.ok ? 'ok' : 'fail'}">${name}: ${x.what}</div>`;
+    out.innerHTML = line('broker', r.mqtt) + line('Home Assistant', r.ha);
+  } catch {
+    out.textContent = 'this build has no server to test with — publishing runs in the page instead';
   }
 };
 

--- a/src-tauri/src/api.rs
+++ b/src-tauri/src/api.rs
@@ -132,6 +132,37 @@ pub fn snapshot(state: &Arc<State>) -> String {
     body.to_string()
 }
 
+/// Both halves of the smart-home setup, tried for real: the broker we publish to, and the Home
+/// Assistant we read entities back from. The token never leaves this process — that is the whole
+/// reason this lives here rather than in a fetch from the drawer.
+pub fn test_smart_home(cfg: &std::path::Path) -> String {
+    let (mqtt_ok, mqtt_says) = crate::mqtt::probe(cfg);
+    let get = |k: &str| crate::setting(cfg, k).unwrap_or_default().trim_matches('"').to_string();
+    let (url, token) = (get("haUrl"), get("haToken"));
+    let (ha_ok, ha_says) = if url.is_empty() {
+        (false, "no Home Assistant URL set".to_string())
+    } else {
+        let base = url.trim_end_matches('/');
+        match ureq::get(&format!("{base}/api/"))
+            .set("Authorization", &format!("Bearer {token}"))
+            .timeout(Duration::from_secs(10))
+            .call()
+        {
+            Ok(_) => (true, "connected".to_string()),
+            // The status code, never the error body: a Home Assistant error page can echo the
+            // request, and the request carries the token.
+            Err(ureq::Error::Status(401 | 403, _)) => (false, "token rejected".to_string()),
+            Err(ureq::Error::Status(code, _)) => (false, format!("HTTP {code}")),
+            Err(_) => (false, "no answer".to_string()),
+        }
+    };
+    serde_json::json!({
+        "mqtt": { "ok": mqtt_ok, "what": mqtt_says },
+        "ha": { "ok": ha_ok, "what": ha_says },
+    })
+    .to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/mqtt.rs
+++ b/src-tauri/src/mqtt.rs
@@ -354,6 +354,47 @@ fn err_kind(e: &rumqttc::ConnectionError) -> &'static str {
     }
 }
 
+/// Connect to the configured broker, publish one retained value, and say what happened. The
+/// settings drawer's test button: a password typed with a trailing space is otherwise a silent
+/// nothing, discovered days later when an automation doesn't fire.
+pub fn probe(cfg_path: &std::path::Path) -> (bool, String) {
+    let Some(c) = conf(cfg_path) else {
+        return (false, "no broker address, or no station id to publish under".into());
+    };
+    let Some((host, port, tls)) = parse_url(&c.url) else {
+        return (false, "address must start mqtt:// or mqtts:// — a ws:// broker is published by the page instead".into());
+    };
+    let mut opts = MqttOptions::new(format!("weatherdesk-probe-{}", c.station), host, port);
+    opts.set_keep_alive(Duration::from_secs(5));
+    if !c.user.is_empty() {
+        opts.set_credentials(c.user.clone(), c.pass.clone());
+    }
+    if tls {
+        opts.set_transport(rumqttc::Transport::tls_with_default_config());
+    }
+    let (client, mut connection) = Client::new(opts, 8);
+    let _ = client.publish(
+        format!("weatherdesk/{}/status", c.station),
+        QoS::AtLeastOnce,
+        true,
+        "online",
+    );
+    // Wait for the broker to acknowledge the publish, not merely for the socket to open: a
+    // broker that rejects the credentials accepts the TCP connection first.
+    for _ in 0..40 {
+        match connection.recv_timeout(Duration::from_millis(250)) {
+            Ok(Ok(rumqttc::Event::Incoming(rumqttc::Packet::PubAck(_)))) => {
+                let _ = client.disconnect();
+                return (true, format!("published to {}", c.prefix));
+            }
+            Ok(Err(e)) => return (false, err_kind(&e).into()),
+            Ok(_) => {}
+            Err(_) => break,
+        }
+    }
+    (false, "no answer from the broker".into())
+}
+
 pub fn start(data_dir: std::path::PathBuf, cfg_path: std::path::PathBuf) {
     std::thread::spawn(move || loop {
         match conf(&cfg_path) {

--- a/src-tauri/src/server.rs
+++ b/src-tauri/src/server.rs
@@ -361,6 +361,9 @@ fn handle(state: &Arc<State>, mut req: Request) {
         // WeatherLink Live consoles seen on the LAN, for the wizard's find button. Names and
         // addresses of hardware on this network only — nothing here that isn't already visible
         // to anything else plugged into it.
+        // Try the broker and Home Assistant for real, and report in words. The credentials stay
+        // in this process — the page never holds the token to make this call.
+        "/ha/test" => json(crate::api::test_smart_home(&state.cfg_path)),
         "/discover/wll" => {
             let hosts = crate::discover::wll_hosts();
             json(serde_json::json!(hosts


### PR DESCRIPTION
Third piece of 3.2.0. **Stacked on #54** — merge that first, and this retargets to main on its own.

## The section
Seven boxes in the order they were added became one "Home Assistant" section with two headings — **Publish the station** (broker, credentials, discovery prefix) and **Read entities back** (HA URL, token, entities, broker topics). Either half is useful without the other, which the flat list gave no hint of. The discovery prefix gets the one line it needs: leave it alone unless you changed it in Home Assistant first.

## The test button
The actual point. A password with a trailing space, a token pasted short, a broker on a port nothing listens to — all silent today, discovered days later when an automation doesn't fire.

`GET /ha/test` (`api::test_smart_home`):
- **Broker**: `mqtt::probe` connects, publishes one retained `status` value, and waits for the **PubAck** — not merely for the socket, because a broker that rejects credentials accepts the TCP connection first.
- **Home Assistant**: `GET /api/` with the bearer token, mapping 401/403 to "token rejected".

Both run in the server, where the credentials already live: the page never holds the token to make this call. The drawer gets two lines of words. No error body is ever quoted back — a Home Assistant error page can echo the request that carried the token.

The page saves the six tested fields and awaits the config write before asking (`pushConfig` now returns its promise), rather than calling full Save, which would close the drawer the answer is about to appear in.

## Verified
Live headless server, three paths:
- Real `eclipse-mosquitto:2` + dead HA → `{"mqtt":{"ok":true,"what":"published to homeassistant"},"ha":{"ok":false,"what":"no answer"}}`
- `ws://` URL → refused with the message pointing at the in-page publisher
- Broker on a closed port → `{"ok":false,"what":"network"}`

`cargo test` 29 passing, clippy clean bar the two pre-existing warnings. Test rig torn down.

Next: the wizard polish (brand-first layout, live first reading) and the frontend batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)