### PR TITLE
Brand-first wizard, WeatherLink auto-find, live first-reading check

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -160,6 +160,8 @@
     border: 1px solid var(--line); border-radius: 8px; font: inherit;
   }
   .row { display: flex; gap: 8px; margin-top: 12px; flex-wrap: wrap; }
+  /* display:flex outranks the UA [hidden] rule, so a hidden .row would still show. */
+  .row[hidden] { display: none; }
   .row button { flex: 1; padding: 9px; border-radius: 8px; border: 1px solid var(--line);
     background: var(--panel2); color: var(--text); font: inherit; cursor: pointer; }
   .row button.primary { background: var(--accent); color: #04121d; border-color: var(--accent); }
@@ -514,32 +516,37 @@
   <div class="wizard-box">
     <img src="icon-512.png" alt="" style="display:block;width:180px;max-width:60%;margin:0 auto 10px">
     <h2 style="margin-top:0;text-align:center">Welcome to WeatherDesk</h2>
-    <p class="muted" style="font-size:13px">Two ways in. <b>Tempest owners:</b> paste a personal
-      use token (tempestwx.com → Settings → Data Authorizations). <b>Every other brand</b> —
-      Ecowitt, Ambient, Davis, AcuRite, La Crosse — needs no token at all: open the second box.</p>
+    <p class="muted" style="font-size:13px">Pick the brand of station in the garden. Every brand
+      except Tempest needs no token and no account — the readings come from your own sensors, the
+      forecast from open-meteo.</p>
+    <select id="wiz-source"></select>
+    <div class="row" style="margin-top:8px">
+      <input id="wiz-place" placeholder="town or postcode">
+      <button id="btn-wiz-place" style="flex:0 0 auto">Find</button>
+    </div>
+    <div id="wiz-place-list" style="margin-top:8px"></div>
+    <div id="wiz-wll" class="row" style="margin-top:8px" hidden>
+      <input id="wiz-wll-host" placeholder="192.168.1.50">
+      <button id="btn-wiz-wll" style="flex:0 0 auto">Find console</button>
+    </div>
+    <p id="wiz-target" class="muted" style="font-size:12px"></p>
+
+    <h3 style="font-size:13px;margin:16px 0 4px">Tempest owners</h3>
+    <p class="muted" style="font-size:12px">Paste a personal use token — tempestwx.com &rarr;
+      Settings &rarr; Data Authorizations.</p>
     <div class="row">
       <input id="wiz-token" type="password" placeholder="personal use token">
       <button class="primary" id="btn-wiz-find" style="flex:0 0 auto">Find stations</button>
     </div>
     <div id="wiz-list" style="margin-top:8px"></div>
+    <p class="muted" style="font-size:12px">No token? The desktop app also reads a Tempest hub
+      directly off the network with none at all.</p>
+
+    <div id="wiz-first" class="muted" style="font-size:12px;margin-top:10px"></div>
     <div class="row" style="margin-top:10px">
       <button id="btn-wiz-demo">Skip — just show me the weather somewhere</button>
       <button id="btn-wiz-close" style="flex:0 0 auto">Close</button>
     </div>
-    <p class="muted" style="font-size:12px">No station? The desktop app also reads a Tempest hub
-      directly off the network with no token at all.</p>
-    <details id="wiz-other" style="margin-top:10px" open>
-      <summary style="cursor:pointer;font-size:13px">Not a Tempest? Ecowitt, Ambient, Davis, AcuRite, La Crosse…</summary>
-      <p class="muted" style="font-size:12px">Pick the brand, then say where the station is —
-        the forecast comes from open-meteo, the readings come from your own sensors.</p>
-      <select id="wiz-source"></select>
-      <div class="row" style="margin-top:8px">
-        <input id="wiz-place" placeholder="town or postcode">
-        <button id="btn-wiz-place" style="flex:0 0 auto">Find</button>
-      </div>
-      <div id="wiz-place-list" style="margin-top:8px"></div>
-      <p id="wiz-target" class="muted" style="font-size:12px"></p>
-    </details>
   </div>
 </div>
 

--- a/site/js/boot.js
+++ b/site/js/boot.js
@@ -1,5 +1,5 @@
 // Wire the shell: settings drawer, diagnostics, nav, section modules.
-import { settings, saveSettings, configured, hasSource, hasLocation, initNav, applyTabs, fullscreen, holdScreen, refreshAll, notify, load, store, applyEco, ecoOn, initKiosk, expires } from './app.js';
+import { settings, saveSettings, configured, hasSource, hasLocation, initNav, applyTabs, fullscreen, holdScreen, refreshAll, notify, load, store, applyEco, ecoOn, initKiosk, expires, num, U } from './app.js';
 import * as api from './api.js';
 import { initDesk, refreshDesk, refreshObs, refreshAlerts, refreshAqi } from './desk.js';
 import { initIntel, refreshModels, refreshNowcast } from './intel.js';
@@ -436,6 +436,29 @@ async function hydrateStation() {
   }
 }
 
+// The wizard has always closed on a saved setting, which is not the same thing as a working
+// station: a console pointed at the wrong address looks identical until the dashboard is empty.
+// Wait for one real number instead, and say what it was.
+async function firstReading(fetcher) {
+  const out = $('wiz-first');
+  out.className = 'muted';
+  out.textContent = 'waiting for the first reading…';
+  for (let i = 0; i < 15; i++) {
+    try {
+      const t = await fetcher();
+      if (t != null) {
+        out.className = 'ok';
+        out.textContent = `${num(t, 1)}${U.temp()} received ✓`;
+        setTimeout(() => { $('wizard').hidden = true; }, 1500);
+        return;
+      }
+    } catch { /* the console may still be mid-upload; the loop is the retry */ }
+    await new Promise((r) => setTimeout(r, 2000));
+  }
+  out.className = 'fail';
+  out.textContent = 'no reading yet — the dashboard is open behind this; check the console is uploading to the address above';
+}
+
 // --- first run ---
 //
 // The old first run opened the whole settings drawer at someone who had not yet decided to care.
@@ -458,7 +481,7 @@ async function wizardFind() {
       b.onclick = async () => {
         const st = list[+b.dataset.wiz];
         saveSettings({ stationId: String(st.station_id) });
-        $('wizard').hidden = true;
+        firstReading(async () => (await api.stationObs()).obs?.[0]?.air_temperature);
         await hydrateStation();
         refreshAll();
         for (const el of ['tenday', 'alerts', 'story', 'agree-verdict', 'changes', 'verify']) {
@@ -479,6 +502,7 @@ async function wizardFind() {
   sel.innerHTML = $('set-source').innerHTML;
   const target = () => {
     const v = sel.value;
+    $('wiz-wll').hidden = v !== 'wll';
     $('wiz-target').textContent = ['ecowitt', 'ambient', 'wu', 'rtl433'].includes(v)
       ? `Point the console at ${ingestUrl()}`
       : v ? 'Fill in the address or keys under ⚙ Settings once this is closed.' : '';
@@ -499,9 +523,13 @@ async function wizardFind() {
         b.onclick = () => {
           const h = hits[+b.dataset.hit];
           const [lon, lat] = h.geometry.coordinates;
-          saveSettings({ stationSource: sel.value || 'ecowitt', lat, lon, stationName: h.properties.city || h.properties.name || q });
-          $('wizard').hidden = true;
+          saveSettings({
+            stationSource: sel.value || 'ecowitt', lat, lon,
+            stationName: h.properties.city || h.properties.name || q,
+            ...($('wiz-wll-host').value.trim() ? { wllHost: $('wiz-wll-host').value.trim() } : {}),
+          });
           fillDrawer();
+          firstReading(async () => (await api.localObs(1)).obs?.at(-1)?.[api.OBS.temp]);
           refreshAll();
           for (const el of ['tenday', 'alerts', 'story', 'agree-verdict', 'changes', 'verify']) {
             const node = $(el);
@@ -513,15 +541,16 @@ async function wizardFind() {
       $('wiz-place-list').innerHTML = `<div class="fail">${e.message}</div>`;
     }
   };
+  $('btn-wiz-wll').onclick = () => findWll($('wiz-wll-host'), $('wiz-target'));
   $('btn-wiz-place').onclick = find;
   $('wiz-place').onkeydown = (e) => { if (e.key === 'Enter') find(); };
   target();
 }
 
 // The console announces itself over mDNS, and the server is already listening for it — so the
-// address nobody can find on a router page is one button away.
-$('btn-find-wll').onclick = async () => {
-  const out = $('wll-found');
+// address nobody can find on a router page is one button away. Both the wizard and the settings
+// drawer ask the same question, so they ask it through one function.
+async function findWll(input, out) {
   out.textContent = 'looking…';
   try {
     const hits = await (await fetch(`${SRV}/discover/wll`, { signal: expires(6000) })).json();
@@ -529,12 +558,13 @@ $('btn-find-wll').onclick = async () => {
       out.textContent = 'nothing announced itself — type the address from the WeatherLink app';
       return;
     }
-    $('set-wll').value = hits[0].host;
+    input.value = hits[0].host;
     out.textContent = hits.length === 1 ? `found ${hits[0].name}` : `found ${hits.length}, using ${hits[0].name}`;
   } catch {
     out.textContent = 'this build has no server to ask — type the address instead';
   }
-};
+}
+$('btn-find-wll').onclick = () => findWll($('set-wll'), $('wll-found'));
 
 // Save first, then ask the server to try both for real: the credentials it tests are the ones
 // on disk, and a password typed with a trailing space is otherwise a silent nothing found days


### PR DESCRIPTION
Stacked on #56 (which is stacked on #54).

- **Brand-first**: the `<details>` footnote is gone. Brand picker + place search lead the wizard; the Tempest token is a labelled section under them. Most installs are not Tempest.
- **Find console**: Davis owners get an mDNS lookup beside the brand picker. Shared with the settings drawer through one `findWll(input, out)` — same question, one implementation. The found host is saved with the place.
- **Live first reading**: selecting a station used to close the wizard, which is not the same thing as a working station — a console pointed at the wrong address looks identical until the dashboard is empty. It now waits for one real number and reports it, or after 30s says nothing arrived and points at the address.
- `.row[hidden]` rule: `display:flex` outranks the UA `[hidden]` rule, so the new hidden row would otherwise have shown.

Verified in headless Chrome against a live endpoint:
- brand picker precedes the token field; Davis reveals the console row, Ecowitt hides it
- both Find console buttons resolve to `192.168.1.77` and the host lands in settings alongside the place
- a real archive reading renders `68.2°F received ✓` and the wizard closes; an empty archive leaves the fail line and the wizard open
- no page errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)