### PR TITLE
Frontend batch: wind unit override, layout presets, draggable Data/Signals, sun-strength and this-day-other-years panels

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -671,6 +671,8 @@
       <div class="card" data-panel="verify"><h2>Forecast accuracy</h2><div id="verify" class="muted">--</div></div>
 
       <div class="card" data-panel="sky"><h2>Sun &amp; moon</h2><div id="sky" class="kv-rows"></div></div>
+      <div class="card" data-panel="solar"><h2>Sun strength</h2><div id="solar" class="kv-rows"></div></div>
+      <div class="card" data-panel="lastyear"><h2>This day, other years</h2><div id="lastyear" class="kv-rows"></div></div>
       <div class="card" data-panel="fire"><h2>Fire &amp; dryness</h2><div id="fire" class="kv-rows"></div></div>
       <div class="card" data-panel="health"><h2>Station health</h2><div id="health" class="kv-rows"></div></div>
 

--- a/site/index.html
+++ b/site/index.html
@@ -831,10 +831,12 @@
     </div>
     <label>Units</label>
     <select id="set-units"><option value="imperial">Imperial</option><option value="metric">Metric</option></select>
+    <label>Wind unit</label>
+    <select id="set-wind-unit"><option value="">Follow units above</option><option value="mph">mph</option><option value="km/h">km/h</option><option value="m/s">m/s</option><option value="kt">knots</option></select>
     <label>Clock</label>
     <select id="set-clock"><option value="auto">Follow this device</option><option value="12">12-hour</option><option value="24">24-hour</option></select>
     <label>Obs refresh (seconds)</label><input id="set-refresh" type="number" min="10" step="10">
-    <label>Wind gust alert threshold</label><input id="set-gust" type="number" min="0">
+    <label>Wind gust alert threshold (<span id="gust-unit">mph</span>)</label><input id="set-gust" type="number" min="0">
     <label>Nearby sensor radius (mi, 0 = manual only)</label><input id="set-nearby-radius" type="number" min="0">
     <div class="row"><button id="btn-station-save">Remember this station</button></div>
     <div id="station-list"></div>

--- a/site/index.html
+++ b/site/index.html
@@ -695,7 +695,7 @@
   <section class="page" id="lab" style="padding:0"><iframe id="lab-frame" title="Forecast Lab"></iframe></section>
   <section class="page" id="signals">
     <div class="grid" id="signals-grid">
-      <div class="card">
+      <div class="card" data-panel="sig-live-wind-websocket">
         <h2>Live wind · websocket</h2>
         <div class="live-wind-wrap">
           <div class="compass"><i id="live-needle"></i></div>
@@ -711,7 +711,7 @@
         <div id="strike-log" class="kv-rows"></div>
       </div>
 
-      <div class="card" style="grid-column: span 2">
+      <div class="card" data-panel="sig-nearby-stations" style="grid-column: span 2">
         <h2>Nearby stations</h2>
         <div class="row" style="margin:0 0 8px">
           <input id="add-station-id" placeholder="public station ID, or an airport code like KBDL">
@@ -725,7 +725,7 @@
         <div id="signals-table"></div>
       </div>
 
-      <div class="card" style="grid-column: span 3">
+      <div class="card" data-panel="sig-notification-history" style="grid-column: span 3">
         <h2>Notification history</h2>
         <div id="notif-log" class="kv-rows"></div>
       </div>
@@ -733,20 +733,20 @@
   </section>
   <section class="page" id="data">
     <div class="grid" id="data-grid">
-      <div class="card"><h2 id="board-temp">Temperature</h2><canvas id="c-temp" class="chart"></canvas></div>
-      <div class="card"><h2 id="board-rain">Rain</h2><canvas id="c-rain" class="chart"></canvas></div>
-      <div class="card"><h2 id="board-wind">Wind</h2><canvas id="c-wind" class="chart"></canvas></div>
-      <div class="card"><h2 id="board-rose">Wind rose</h2><canvas id="c-rose" class="chart"></canvas></div>
-      <div class="card"><h2 id="board-press">Pressure</h2><canvas id="c-press" class="chart"></canvas></div>
-      <div class="card"><h2>Records · 7 days</h2><div id="extremes" class="kv-rows"></div></div>
-      <div class="card" style="grid-column: span 2"><h2 id="board-models">Model comparison</h2><canvas id="c-models" class="chart"></canvas></div>
-      <div class="card"><h2 id="board-accuracy">Forecast accuracy</h2><canvas id="c-accuracy" class="chart"></canvas></div>
-      <div class="card"><h2>NWS vs Tempest</h2><div id="official" class="kv-rows"></div></div>
-      <div class="card"><h2 id="board-qpf">Precip outlook</h2><canvas id="c-qpf" class="chart"></canvas></div>
-      <div class="card"><h2>Garden</h2><div id="garden" class="kv-rows"></div></div>
-      <div class="card"><h2>Almanac · all time</h2><div id="almanac" class="kv-rows"></div></div>
-      <div class="card"><h2 id="board-monthly">Month by month</h2><canvas id="c-monthly" class="chart"></canvas></div>
-      <div class="card" style="grid-column: span 2">
+      <div class="card" data-panel="data-temperature"><h2 id="board-temp">Temperature</h2><canvas id="c-temp" class="chart"></canvas></div>
+      <div class="card" data-panel="data-rain"><h2 id="board-rain">Rain</h2><canvas id="c-rain" class="chart"></canvas></div>
+      <div class="card" data-panel="data-wind"><h2 id="board-wind">Wind</h2><canvas id="c-wind" class="chart"></canvas></div>
+      <div class="card" data-panel="data-wind-rose"><h2 id="board-rose">Wind rose</h2><canvas id="c-rose" class="chart"></canvas></div>
+      <div class="card" data-panel="data-pressure"><h2 id="board-press">Pressure</h2><canvas id="c-press" class="chart"></canvas></div>
+      <div class="card" data-panel="data-records-7-days"><h2>Records · 7 days</h2><div id="extremes" class="kv-rows"></div></div>
+      <div class="card" data-panel="data-model-comparison" style="grid-column: span 2"><h2 id="board-models">Model comparison</h2><canvas id="c-models" class="chart"></canvas></div>
+      <div class="card" data-panel="data-forecast-accuracy"><h2 id="board-accuracy">Forecast accuracy</h2><canvas id="c-accuracy" class="chart"></canvas></div>
+      <div class="card" data-panel="data-nws-vs-tempest"><h2>NWS vs Tempest</h2><div id="official" class="kv-rows"></div></div>
+      <div class="card" data-panel="data-precip-outlook"><h2 id="board-qpf">Precip outlook</h2><canvas id="c-qpf" class="chart"></canvas></div>
+      <div class="card" data-panel="data-garden"><h2>Garden</h2><div id="garden" class="kv-rows"></div></div>
+      <div class="card" data-panel="data-almanac-all-time"><h2>Almanac · all time</h2><div id="almanac" class="kv-rows"></div></div>
+      <div class="card" data-panel="data-month-by-month"><h2 id="board-monthly">Month by month</h2><canvas id="c-monthly" class="chart"></canvas></div>
+      <div class="card" data-panel="data-explore-the-archive" style="grid-column: span 2">
         <h2>Explore the archive</h2>
         <div class="row" style="margin-top:0">
           <input id="ex-from" type="date" aria-label="From date" style="flex:1">
@@ -919,6 +919,9 @@
            whole house, and "I am rearranging right now" is not something to sync. -->
       <button id="btn-edit" class="phone-only">Rearrange panels</button>
     </div>
+    <p class="muted" style="font-size:12px;margin-bottom:0">Starting points — pick one, then drag
+      what's left into place and save it under a name.</p>
+    <div class="row" id="preset-row"></div>
     <div class="row">
       <input id="layout-name" placeholder="layout name (e.g. tablet)">
       <button id="btn-layout-save" style="flex:0 0 auto">Save layout</button>

--- a/site/js/almanac.js
+++ b/site/js/almanac.js
@@ -4,7 +4,7 @@
 // the REST history is capped and paged, and the point of the log is to keep going once it ends.
 // Nothing here backfills — the archive starts the day the app was first run, and the panel says
 // so rather than pretending the record is older than it is.
-import { settings, U, num, every, expires } from './app.js';
+import { settings, U, num, every, expires, msToWind } from './app.js';
 import { chart } from './charts.js';
 import { normals, normalFor } from './api.js';
 
@@ -16,7 +16,7 @@ const SRV = window.__WD_SRV || '';
 export function toDisplay(row) {
   const metric = settings().units === 'metric';
   const t = (c) => (c == null ? null : metric ? c : c * 9 / 5 + 32);
-  const wind = (ms) => (ms == null ? null : ms * (metric ? 3.6 : 2.23694));
+  const wind = msToWind;
   const rain = (mm) => (mm == null ? null : mm * (metric ? 1 : 1 / 25.4));
   return {
     day: row.day,

--- a/site/js/api.js
+++ b/site/js/api.js
@@ -262,6 +262,9 @@ export function shapeOm(j, ownTuple = null) {
     wind_direction: H.wind_direction_10m?.[i],
     icon: omIcon(H.weather_code?.[i], true),
     conditions: omWords(H.weather_code?.[i]),
+    // The solar card reads the whole day out of these two, so they travel with the hour.
+    uv: H.uv_index?.[i],
+    solar_radiation: H.shortwave_radiation?.[i],
   }));
 
   const day = cur.is_day == null ? true : !!cur.is_day;

--- a/site/js/api.js
+++ b/site/js/api.js
@@ -1,13 +1,16 @@
 // All remote endpoints live here. Single choke point for token + units.
-import { settings, coords, expires } from './app.js';
+import { settings, coords, expires, windUnit, msToWind, WIND_UNITS } from './app.js';
 
 const SWD = 'https://swd.weatherflow.com/swd/rest';
 
 function unitParams() {
   const s = settings();
-  return s.units === 'metric'
-    ? { units_temp: 'c', units_wind: 'kph', units_pressure: 'mb', units_precip: 'mm', units_distance: 'km' }
-    : { units_temp: 'f', units_wind: 'mph', units_pressure: 'inhg', units_precip: 'in', units_distance: 'mi' };
+  return {
+    ...(s.units === 'metric'
+      ? { units_temp: 'c', units_pressure: 'mb', units_precip: 'mm', units_distance: 'km' }
+      : { units_temp: 'f', units_pressure: 'inhg', units_precip: 'in', units_distance: 'mi' }),
+    units_wind: WIND_UNITS[windUnit()].tempest,
+  };
 }
 
 function qs(obj) {
@@ -97,7 +100,7 @@ export async function metarObs(id) {
     obs: [{
       timestamp: p.timestamp ? Date.parse(p.timestamp) / 1000 : null,
       air_temperature: c == null ? null : (metric ? c : c * 9 / 5 + 32),
-      wind_avg: w == null ? null : (metric ? w : w * 0.621371),
+      wind_avg: msToWind(w == null ? null : w / 3.6),   // NWS reports km/h
       wind_direction: p.windDirection?.value,
       precip_accum_local_day: null, // airports report precip on their own schedule; not comparable
     }],
@@ -134,8 +137,8 @@ export function siToDisplay(obs) {
   const metric = settings().units === 'metric';
   const conv = (o, i, f) => { if (o[i] != null) o[i] = o[i] * f; };
   for (const o of obs) {
-    // wind is m/s in both systems — even metric needs km/h
-    for (const i of [OBS.windLull, OBS.windAvg, OBS.windGust]) conv(o, i, metric ? 3.6 : 2.23694);
+    // wind is m/s on the wire whatever the system, and its unit is separately overridable
+    for (const i of [OBS.windLull, OBS.windAvg, OBS.windGust]) conv(o, i, WIND_UNITS[windUnit()].fromMs);
     if (metric) continue;
     if (o[OBS.temp] != null) o[OBS.temp] = o[OBS.temp] * 9 / 5 + 32;
     conv(o, OBS.press, 0.02953);
@@ -325,7 +328,8 @@ export async function omForecast(lat = coords().lat, lon = coords().lon) {
     daily: 'weather_code,temperature_2m_max,temperature_2m_min,sunrise,sunset,'
       + 'precipitation_probability_max,precipitation_sum',
     forecast_days: 10, timezone: 'auto', timeformat: 'unixtime',
-    ...(imperial ? { temperature_unit: 'fahrenheit', wind_speed_unit: 'mph', precipitation_unit: 'inch' } : {}),
+    wind_speed_unit: WIND_UNITS[windUnit()].om,
+    ...(imperial ? { temperature_unit: 'fahrenheit', precipitation_unit: 'inch' } : {}),
   })}`);
   return shapeOm(j, lastTuple);
 }
@@ -353,7 +357,8 @@ export function multiModel(lat = coords().lat, lon = coords().lon) {
     latitude: lat, longitude: lon, models: MODELS,
     hourly: 'temperature_2m,precipitation,wind_speed_10m',
     forecast_days: 3, timezone: 'auto',
-    ...(imperial ? { temperature_unit: 'fahrenheit', wind_speed_unit: 'mph', precipitation_unit: 'inch' } : {}),
+    wind_speed_unit: WIND_UNITS[windUnit()].om,
+    ...(imperial ? { temperature_unit: 'fahrenheit', precipitation_unit: 'inch' } : {}),
   })}`);
 }
 

--- a/site/js/app.js
+++ b/site/js/app.js
@@ -7,6 +7,8 @@ const DEFAULTS = {
   // in flat country and tens of metres in a valley, which is a barometer's worth of error.
   elevationM: null,
   units: 'imperial', refreshSec: 60,
+  // Empty means "follow the master switch" — see WIND_UNITS.
+  windUnit: '',
   // 'auto' follows the browser locale; the other two are for the screen that lives in a country
   // its OS wasn't set up for.
   clock24: 'auto', places: [], activePlace: null,
@@ -137,9 +139,25 @@ export function coords() {
 
 // --- formatting helpers ---
 
+// Wind is the one unit people override: a sailor wants knots on an otherwise imperial
+// dashboard, a glider pilot m/s. Six files each carried their own copy of the m/s factor, which
+// is six chances for a chart to be plausible and wrong — they all go through here now.
+export const WIND_UNITS = {
+  mph: { fromMs: 2.23694, om: 'mph', tempest: 'mph' },
+  'km/h': { fromMs: 3.6, om: 'kmh', tempest: 'kph' },
+  'm/s': { fromMs: 1, om: 'ms', tempest: 'mps' },
+  kt: { fromMs: 1.94384, om: 'kn', tempest: 'kts' },
+};
+export const windUnit = () =>
+  _settings.windUnit && WIND_UNITS[_settings.windUnit]
+    ? _settings.windUnit
+    : (_settings.units === 'metric' ? 'km/h' : 'mph');
+export const msToWind = (v) => (v == null ? null : v * WIND_UNITS[windUnit()].fromMs);
+export const windToMs = (v) => (v == null ? null : v / WIND_UNITS[windUnit()].fromMs);
+
 export const U = {
   temp: () => (_settings.units === 'metric' ? '°C' : '°F'),
-  wind: () => (_settings.units === 'metric' ? 'km/h' : 'mph'),
+  wind: () => windUnit(),
   precip: () => (_settings.units === 'metric' ? 'mm' : 'in'),
   press: () => (_settings.units === 'metric' ? 'mb' : 'inHg'),
   dist: () => (_settings.units === 'metric' ? 'km' : 'mi'),

--- a/site/js/boot.js
+++ b/site/js/boot.js
@@ -757,6 +757,42 @@ $('btn-edit').onclick = () => {
 };
 applyEdit();
 
+// Shipped starting points. A preset is not a saved layout: it says which panels a screen is for
+// and in what order, and deliberately carries no widths or heights — those belong to the screen
+// they were dragged on, not to a name shipped in the source.
+const PRESETS = {
+  'Wall landscape': ['hero', 'radar', 'gauges', 'daycards', 'alerts', 'ticker'],
+  'Kitchen portrait': ['hero', 'daycards', 'alerts', 'tenday'],
+  'E-ink': ['hero', 'tenday', 'alerts', 'changes'],
+};
+
+// Gauge faces, and the Data and Signals cards, are inside panels of their own — a preset that
+// hid them would empty the gauges block and both other tabs along with it.
+const isDeskPanel = (id) => !/^(g-|data-|sig-)/.test(id);
+
+function applyPreset(name) {
+  const keep = PRESETS[name].slice();
+  // The Desk grid is a panel holding panels: keeping a card inside it while hiding it would show
+  // nothing at all.
+  if (keep.some((id) => document.querySelector(`#desk-grid > [data-panel="${id}"]`))) keep.push('desk-grid');
+  const st = {};
+  for (const id of panelIds().filter(isDeskPanel)) {
+    const i = keep.indexOf(id);
+    if (i === -1) st[id] = { hidden: true };
+    else st[id] = { order: i };
+  }
+  restore(st);
+  renderHiddenPanels();
+  notify({ title: `${name} layout applied`, body: 'Everything else is under Hidden panels in Settings.' });
+}
+
+$('preset-row').innerHTML = Object.keys(PRESETS).map((n, i) => `<button data-preset="${i}"></button>`).join('');
+$('preset-row').querySelectorAll('[data-preset]').forEach((b) => {
+  const n = Object.keys(PRESETS)[+b.dataset.preset];
+  b.textContent = n;
+  b.onclick = () => applyPreset(n);
+});
+
 const layouts = () => load('wd.layouts', {});
 
 function renderLayouts() {

--- a/site/js/boot.js
+++ b/site/js/boot.js
@@ -1,5 +1,5 @@
 // Wire the shell: settings drawer, diagnostics, nav, section modules.
-import { settings, saveSettings, configured, hasSource, hasLocation, initNav, applyTabs, fullscreen, holdScreen, refreshAll, notify, load, store, applyEco, ecoOn, initKiosk, expires, num, U } from './app.js';
+import { settings, saveSettings, configured, hasSource, hasLocation, initNav, applyTabs, fullscreen, holdScreen, refreshAll, notify, load, store, applyEco, ecoOn, initKiosk, expires, num, U, msToWind, windToMs } from './app.js';
 import * as api from './api.js';
 import { initDesk, refreshDesk, refreshObs, refreshAlerts, refreshAqi } from './desk.js';
 import { initIntel, refreshModels, refreshNowcast } from './intel.js';
@@ -138,6 +138,10 @@ function fillDrawer() {
   $('set-clock').value = s.clock24 || 'auto';
   $('set-refresh').value = s.refreshSec;
   $('set-gust').value = s.windGustAlert;
+  $('set-wind-unit').value = s.windUnit || '';
+  // The threshold is a bare number in whatever wind unit is showing, so name that unit next to
+  // it — 30 means something different in knots.
+  $('gust-unit').textContent = U.wind();
   $('set-nearby-radius').value = s.nearbyRadius ?? 0;
   $('set-desk-radar').checked = !!s.deskRadar;
   $('set-eco').value = s.eco || 'auto';
@@ -325,6 +329,7 @@ $('btn-save').onclick = async () => {
     clock24: $('set-clock').value,
     refreshSec: +$('set-refresh').value || 60,
     windGustAlert: +$('set-gust').value || 30,
+    windUnit: $('set-wind-unit').value,
     nearbyRadius: +$('set-nearby-radius').value || 0,
     deskRadar: $('set-desk-radar').checked,
     eco: $('set-eco').value,
@@ -1128,6 +1133,20 @@ if (location.search.includes('selftest')) {
     === '06092, Simsbury, Connecticut, United States', 'geocode label keeps the town');
   console.assert(api.placeLabel({ name: 'Simsbury', city: 'Simsbury', state: 'Connecticut' })
     === 'Simsbury, Connecticut', 'geocode label does not repeat the town');
+
+  // Wind override: six files used to carry their own m/s factor. One knot is 1.94384 m/s, and
+  // the label has to move with the number or the dashboard lies twice.
+  {
+    const held = settings().windUnit;
+    saveSettings({ windUnit: 'kt' });
+    console.assert(U.wind() === 'kt', 'wind override: label follows the setting');
+    console.assert(Math.abs(msToWind(10) - 19.4384) < 1e-3, 'wind override: m/s to knots');
+    console.assert(Math.abs(windToMs(msToWind(7)) - 7) < 1e-9, 'wind override: round trip');
+    saveSettings({ windUnit: '' });
+    console.assert(U.wind() === (settings().units === 'metric' ? 'km/h' : 'mph'),
+      'wind override: empty follows the master switch');
+    saveSettings({ windUnit: held });
+  }
 
   // The fetch deadline every screen depends on, on the browsers that have no AbortSignal.timeout.
   const sig = expires(50);

--- a/site/js/env.js
+++ b/site/js/env.js
@@ -6,6 +6,7 @@
 import { settings, coords, U, num, notify, every, stamp, expires } from './app.js';
 import { forecast as deskForecast } from './desk.js';
 import { OBS } from './api.js';
+import { toDisplay } from './almanac.js';
 
 const $ = (id) => document.getElementById(id);
 const rad = Math.PI / 180;
@@ -102,6 +103,68 @@ async function loadMoon() {
     set: p.moonset?.time ? new Date(p.moonset.time) : null,
   };
   renderSky();
+}
+
+// --- sun strength: UV and solar radiation, for the whole day rather than this minute ---
+//
+// The gauge shows what the sensor reads now, which answers "should I go out" and nothing else.
+// The questions people actually ask of a UV number are when it peaks and how long skin lasts,
+// and both are arithmetic on hours the forecast already carries.
+//
+// Burn time is the standard erythema estimate — roughly 200/(3 × UV) minutes for fair skin that
+// has not been out yet this year. It is a rule of thumb, labelled as one; anything more precise
+// would need a skin type and a sunscreen factor this dashboard has no business asking for.
+const uvBand = (v) => (v < 3 ? 'low' : v < 6 ? 'moderate' : v < 8 ? 'high' : v < 11 ? 'very high' : 'extreme');
+
+export function renderSolar() {
+  const fc = deskForecast();
+  if (!fc) return;
+  const c = fc.current_conditions;
+  const today = new Date().toDateString();
+  const hours = (fc.forecast?.hourly || []).filter((h) => new Date(h.time * 1000).toDateString() === today);
+
+  let peak = null;
+  for (const h of hours) if (h.uv != null && (!peak || h.uv > peak.uv)) peak = h;
+  // Hourly W/m² held for an hour is Wh/m²; the day's total is what a panel or a tomato sees.
+  const energy = hours.reduce((a, h) => a + (h.solar_radiation || 0), 0) / 1000;
+
+  const uv = c.uv;
+  const burn = uv >= 1 ? Math.round(200 / (3 * uv)) : null;
+  const rows = [
+    uv == null ? null : ['UV now', `${num(uv, 1)} · ${uvBand(uv)}`],
+    burn == null ? null : ['Burn time', burn >= 120 ? '2h+' : `${burn} min`],
+    peak ? ['Peak UV today', `${num(peak.uv, 1)} at ${hhmm(new Date(peak.time * 1000))}`] : null,
+    c.solar_radiation == null ? null : ['Solar now', `${num(c.solar_radiation)} W/m²`],
+    energy > 0 ? ['Solar today', `${num(energy, 2)} kWh/m²`] : null,
+  ].filter(Boolean);
+  $('solar').innerHTML = rows.length
+    ? rows.map(([k, v]) => `<div><span>${k}</span><span>${v}</span></div>`).join('')
+    : '<div class="muted">No UV or solar data from this source</div>';
+  stamp('solar', 900);
+}
+
+// --- this day, other years ---
+//
+// The archive already answers this: /history/daily is every day this install has ever recorded,
+// and the almanac downloads all of it anyway. Matching on month and day is the whole feature —
+// no new endpoint, no new query parameter, and it works for a station that has been up for
+// thirteen months as well as one that has been up for ten years.
+async function renderLastYear() {
+  const tz = -new Date().getTimezoneOffset();
+  const r = await fetch(`${window.__WD_SRV || ''}/history/daily?tz=${tz}`, { signal: expires(10000) });
+  if (!r.ok) throw new Error(`${r.status}`);
+  const now = new Date();
+  const md = `-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+  const rows = (await r.json())
+    .filter((d) => d.day.endsWith(md) && d.day.slice(0, 4) !== String(now.getFullYear()))
+    .sort((a, b) => b.day.localeCompare(a.day))
+    .slice(0, 6)
+    .map(toDisplay);
+  $('lastyear').innerHTML = rows.length
+    ? rows.map((d) => `<div><span>${d.day.slice(0, 4)}</span><span>${num(d.tempMax)}° / ${num(d.tempMin)}°`
+        + `${d.rain ? ` · ${num(d.rain, 2)} ${U.precip()}` : ''}</span></div>`).join('')
+    : '<div class="muted">Nothing recorded on this date yet — come back next year.</div>';
+  stamp('lastyear', 3600);
 }
 
 // --- fire weather and dryness ---
@@ -288,7 +351,10 @@ window.addEventListener('wd:device-status', (e) => {
 export function initEnv() {
   renderHealth(lastStatus);
   window.addEventListener('wd:forecast', renderSky);
+  window.addEventListener('wd:forecast', renderSolar);
   renderSky();
+  renderSolar();
+  every('env-lastyear', 21600, () => renderLastYear().catch(() => {}));
   every('env-moon', 21600, () => loadMoon().catch(() => {}));
   every('env-garden', 21600, () => loadGarden().catch(() => {}));
   every('env-season', 3600, () => loadSeason().catch(() => {}));

--- a/site/js/home.js
+++ b/site/js/home.js
@@ -8,7 +8,7 @@
 // HomeKit, Alexa and Google are reached through Home Assistant's own bridges — see README. There
 // is no native code here for them, and there shouldn't be.
 
-import { settings, every, stamp, stormMode, expires } from './app.js';
+import { settings, every, stamp, stormMode, expires, msToWind } from './app.js';
 import { OBS } from './api.js';
 import { mqtt } from './mqtt.js';
 
@@ -132,7 +132,7 @@ function publishObs(obs) {
   const s = settings();
   const gust = obs[OBS.windGust];
   if (gust != null && s.windGustAlert > 0) {
-    const shown = s.units === 'metric' ? gust * 3.6 : gust * 2.23694;
+    const shown = msToWind(gust);
     if (!gustLatched && shown >= s.windGustAlert) {
       gustLatched = true;
       event('gust', { event_type: 'gust', speed: +shown.toFixed(1) });

--- a/site/js/layout.js
+++ b/site/js/layout.js
@@ -55,11 +55,13 @@ const save = () => {
 const entry = (id) => (state[id] ||= {});
 
 // Containers whose direct children are rearrangeable, in the order they appear on the Desk.
-const CONTAINERS = ['desk-stack', 'daycards', 'gauges', 'desk-grid'];
+// The Data and Signals grids were placement targets only — a panel could be sent to them but
+// their own cards were fixed in markup order, which is the wrong way round for the two tabs that
+// hold the most cards.
+const CONTAINERS = ['desk-stack', 'daycards', 'gauges', 'desk-grid', 'data-grid', 'signals-grid'];
 
 // Tabs a panel can be sent to, and the container it lands in. The Desk entry is where a panel
-// goes home to; the others hold cards that were never draggable, so they are placement targets
-// only and their own children are left alone.
+// goes home to.
 export const TABS = { desk: 'desk-grid', data: 'data-grid', signals: 'signals-grid' };
 
 // Every panel's home, captured before anything is moved — otherwise sending a panel to the Data

--- a/site/js/pro.js
+++ b/site/js/pro.js
@@ -1,7 +1,7 @@
 // Desk layout matching myWeatherDesk: sky hero, signal ticker, trend strip,
 // 48h combined chart, day cards, dial gauges. Driven by the wd:forecast event.
 import * as api from './api.js';
-import { settings, coords, U, num, timeStr, deg2compass, every, ecoOn } from './app.js';
+import { settings, coords, U, num, timeStr, deg2compass, every, ecoOn, msToWind, windToMs } from './app.js';
 import { forecast as deskForecast } from './desk.js';
 import * as icon from './icons.js';
 import { initLayout } from './layout.js';
@@ -360,7 +360,7 @@ function renderGauges(fc) {
     `<b>${num(wb)}°</b><span>Air ${num(c.air_temperature)}°</span>`);
 
   const taC = metric ? c.air_temperature : (c.air_temperature - 32) / 1.8;
-  const windMps = c.wind_avg / (metric ? 3.6 : 2.23694);
+  const windMps = windToMs(c.wind_avg);
   const wbgt = wbgtC(taC, c.relative_humidity, c.solar_radiation || 0, windMps);
   const shown = wbgt == null ? null : metric ? wbgt : wbgt * 1.8 + 32;
   $('g-wbgt').innerHTML = gauge(icon.thermometer(((shown ?? 0) - (metric ? 0 : 32)) / (metric ? 35 : 60)),
@@ -471,7 +471,7 @@ const wbgtWord = (f) => (f >= 90 ? 'Extreme' : f >= 88 ? 'Very high' : f >= 85 ?
 function renderLocal(o) {
   const metric = settings().units === 'metric';
   const t = (c) => (c == null ? null : metric ? c : c * 9 / 5 + 32);
-  const w = (mps) => (mps == null ? null : mps * (metric ? 3.6 : 2.23694));
+  const w = msToWind;
   const p = (mb) => (mb == null ? null : metric ? mb : mb * 0.02953);
   const r = (mm) => (mm == null ? null : metric ? mm : mm / 25.4);
 

--- a/site/js/rules.js
+++ b/site/js/rules.js
@@ -6,7 +6,7 @@
 //
 // Fires through notify(), so a rule reaches every channel the banners already reach — the ntfy
 // topic, the webhook, the broker — with no per-channel code here.
-import { settings, saveSettings, notify, num, U } from './app.js';
+import { settings, saveSettings, notify, num, U, msToWind } from './app.js';
 import { OBS } from './api.js';
 
 const $ = (id) => document.getElementById(id);
@@ -31,7 +31,7 @@ export const OPS = { '>': 'above', '<': 'below' };
 
 const metric = () => settings().units === 'metric';
 const toTemp = (c) => (c == null ? null : metric() ? c : c * 9 / 5 + 32);
-const toWind = (ms) => (ms == null ? null : ms * (metric() ? 3.6 : 2.23694));
+const toWind = msToWind;
 const toRain = (mm) => (mm == null ? null : mm * (metric() ? 1 : 1 / 25.4));
 const toPress = (mb) => (mb == null ? null : mb * (metric() ? 1 : 0.02953));
 

--- a/site/js/signals.js
+++ b/site/js/signals.js
@@ -1,10 +1,9 @@
 // 03 Local Signals — nearby public Tempest stations vs yours, plus the live websocket feed.
 import * as api from './api.js';
-import { settings, saveSettings, configured, hasSource, U, num, deg2compass, every, notify, store, load, notifHistory, timeStr } from './app.js';
+import { settings, saveSettings, configured, hasSource, U, num, deg2compass, every, notify, store, load, notifHistory, timeStr, msToWind } from './app.js';
 import { milesBetween } from './boot.js';
 
 const $ = (id) => document.getElementById(id);
-const MPS = { imperial: 2.23694, metric: 3.6 }; // rapid_wind is always m/s
 
 // --- discovery: what is within nearbyRadius of the station ---
 
@@ -179,8 +178,7 @@ export function disconnectWs() {
 }
 
 export function renderRapid(mps, dir) {
-  const f = MPS[settings().units] || MPS.imperial;
-  const v = mps * f;
+  const v = msToWind(mps);   // rapid_wind is always m/s
   $('live-wind').textContent = num(v, 1);
   $('live-wind-unit').textContent = U.wind();
   $('live-dir').textContent = `${deg2compass(dir)} ${num(dir)}°`;


### PR DESCRIPTION
Last of the 3.2.0 frontend batch. Stacked on #57 → #56 → #54.

**Wind unit override** (mph / km/h / m/s / knots, independent of the master switch). Six files each carried their own copy of the m/s factor — six chances for a chart to be plausible and wrong. They all route through `app.js` `msToWind`/`windToMs` now, and the Tempest and open-meteo requests ask for the chosen unit directly rather than converting after the fact. The gust threshold field names the unit it is written in.

**Layout presets** — Wall landscape / Kitchen portrait / E-ink. A preset is not a saved layout: it names which panels a screen is for and in what order, and carries no widths or heights, because those belong to the screen they were dragged on. Gauge faces and the other tabs' cards are left alone.

**Data and Signals cards are draggable.** Both grids were placement targets only — a panel could be sent to them, but their own cards were fixed in markup order, which is the wrong way round for the two tabs holding the most cards. They now reorder, resize and hide like everything else.

**Sun strength** panel: UV now and its band, burn time (the standard 200/(3×UV) rule of thumb, labelled as one), today's peak UV and when, solar now, and the day's energy in kWh/m². The hourly rows keep `uv_index` and `shortwave_radiation` instead of dropping them.

**This day, other years**: `/history/daily` is every day this install has recorded, so matching month and day is the whole feature — no new endpoint, and it reuses the almanac's unit conversion rather than growing a second copy.

The plan's sixth item, the astro panel, is already shipped: `env.js` renders sunrise/sunset, both golden hours, daylight and its day-over-day delta, and moonrise/moonset, with the phase and illumination on the hero. Nothing to add there.

Verified in headless Chrome:
- `?selftest` clean, including new assertions on the knot conversion, the round trip, and the label following the setting
- three preset buttons render; Kitchen portrait keeps `hero/daycards/alerts/tenday` in order and hides the rest, leaving every `g-`, `data-` and `sig-` panel untouched
- 14 Data cards and 3 Signals cards each get a grip and a hide button; no "non-panel child" warnings
- both new panels render against live open-meteo and a stubbed archive: `Peak UV today 4.8 at 3:00 PM`, `Solar today 2.18 kWh/m²`, `2024 80° / 54° · 0.50 in`
- no page errors

CHANGELOG is deliberately untouched — 3.2.0 spans four stacked branches and gets one entry at release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)