### PR TITLE
3.2.1: server-side alert engine, Home Assistant read-back and entity picker

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -969,9 +969,14 @@
       <label><input type="checkbox" data-cat="rule"> My alert rules</label>
       <label><input type="checkbox" data-cat="station"> Station health</label>
     </div>
-    <div class="row"><button id="btn-notif-test">Test notifications</button></div>
+    <div class="row">
+      <button id="btn-notif-test">Test banners</button>
+      <button id="btn-alert-test">Test push channels</button>
+    </div>
+    <div id="alert-test-out" class="muted" style="font-size:12px"></div>
 
     <h2 style="font-size:13px;margin-top:18px">Alert rules</h2>
+    <p id="rule-server" class="muted" style="font-size:12px"></p>
     <div id="rule-list"></div>
     <div class="row" style="margin-top:6px">
       <select id="rule-metric"></select>

--- a/site/index.html
+++ b/site/index.html
@@ -1037,6 +1037,11 @@
     <label>Home Assistant URL</label><input id="set-ha-url" placeholder="http://homeassistant.local:8123">
     <label>Home Assistant token</label><input id="set-ha-token" type="password" placeholder="long-lived access token">
     <label>Entities to show</label><input id="set-ha-entities" placeholder="light.porch, sensor.attic_temp">
+    <div class="row" style="margin-top:6px">
+      <input id="ha-pick-q" placeholder="search entities">
+      <button id="btn-ha-pick" style="flex:0 0 auto">List entities</button>
+    </div>
+    <div id="ha-pick-list" style="max-height:220px;overflow:auto"></div>
     <label>Broker topics to show (one per line: topic | label | unit)</label>
     <textarea id="set-mqtt-subs" rows="3" placeholder="home/greenhouse/temp | Greenhouse | °F"
       style="width:100%;padding:8px;background:var(--bg);color:var(--text);border:1px solid var(--line);border-radius:8px;font:inherit"></textarea>

--- a/site/js/app.js
+++ b/site/js/app.js
@@ -288,7 +288,16 @@ function webNative({ category, title, body }) {
 // Security: the payloads carry the title, the body and the category and nothing else. The
 // Tempest token, the broker password and the station ID are deliberately absent — ntfy.sh is a
 // public relay by default and a webhook goes wherever the user pointed it.
+// The server runs the same rules engine and the same NWS poll (src-tauri/src/alerts.rs), and it
+// runs them whether or not a browser is open — which is the whole point. When it is doing that,
+// this page must not push as well: one ntfy topic and two engines means every alert arrives
+// twice, and the second copy always looks like a bug in the first.
+let serverAlerts = false;
+export const setServerAlerts = (on) => { serverAlerts = on; };
+export const alertsAreServerSide = () => serverAlerts;
+
 function push({ category, title, body }) {
+  if (serverAlerts) return;
   const s = _settings;
   if (s.ntfyTopic) {
     fetch(`${s.ntfyUrl || 'https://ntfy.sh'}/${encodeURIComponent(s.ntfyTopic)}`, {

--- a/site/js/boot.js
+++ b/site/js/boot.js
@@ -255,6 +255,62 @@ $('btn-alert-test').onclick = async () => {
   }
 };
 
+// The entity picker. Home Assistant ids are typed by hand today, which means a typo shows up
+// three days later as a row that says 404 — and it means opening Home Assistant in another tab
+// to go and read them. The list comes from the server, which is the only thing here holding a
+// token that can ask for it.
+//
+// Read-only, deliberately: this picks what to display. Turning things on and off is Home
+// Assistant's job, and the moment a dashboard on a LAN with no auth can switch a socket, the
+// LAN-trust model this app documents stops being defensible.
+let haEntities = null;
+
+function renderHaPick() {
+  const box = $('ha-pick-list');
+  if (!haEntities) return;
+  const q = $('ha-pick-q').value.trim().toLowerCase();
+  const chosen = new Set($('set-ha-entities').value.split(/[\s,]+/).filter(Boolean));
+  const hits = haEntities
+    .filter((e) => !q || e.id.toLowerCase().includes(q) || e.name.toLowerCase().includes(q))
+    .slice(0, 200);
+  box.innerHTML = hits.length
+    ? hits.map((e, i) => `<label style="display:flex;gap:6px;align-items:center;font-size:12px;padding:2px 0">
+        <input type="checkbox" data-ent="${i}"${chosen.has(e.id) ? ' checked' : ''}>
+        <span style="flex:1"></span><span class="muted"></span></label>`).join('')
+    : '<div class="muted" style="font-size:12px">nothing matches</div>';
+  // Names and states are Home Assistant's text, not ours: written in, never interpolated into
+  // markup.
+  box.querySelectorAll('[data-ent]').forEach((cb) => {
+    const e = hits[+cb.dataset.ent];
+    const [name, state] = cb.parentElement.querySelectorAll('span');
+    name.textContent = `${e.name} · ${e.id}`;
+    state.textContent = `${e.state}${e.unit ? ` ${e.unit}` : ''}`;
+    cb.onchange = () => {
+      const set = new Set($('set-ha-entities').value.split(/[\s,]+/).filter(Boolean));
+      if (cb.checked) set.add(e.id); else set.delete(e.id);
+      $('set-ha-entities').value = [...set].join(', ');
+    };
+  });
+}
+
+$('btn-ha-pick').onclick = async () => {
+  const box = $('ha-pick-list');
+  box.innerHTML = '<div class="muted" style="font-size:12px">asking Home Assistant…</div>';
+  // The URL and token have to be on disk before the server can use them.
+  saveSettings({ haUrl: $('set-ha-url').value.trim(), haToken: $('set-ha-token').value.trim() });
+  await pushConfig();
+  try {
+    const j = await (await fetch(`${SRV}/ha/states`, { signal: expires(30000) })).json();
+    if (j.error) { box.innerHTML = `<div class="fail" style="font-size:12px">${j.error}</div>`; return; }
+    haEntities = j.entities;
+    renderHaPick();
+  } catch {
+    box.innerHTML = '<div class="muted" style="font-size:12px">this build has no server to ask — '
+      + 'type the ids from Home Assistant\'s own developer tools</div>';
+  }
+};
+$('ha-pick-q').oninput = renderHaPick;
+
 // A panel's own heading, so the lists read the way the page does. Falls back to the id for a
 // panel that has no heading — better than a blank button.
 function panelTitle(id) {

--- a/site/js/boot.js
+++ b/site/js/boot.js
@@ -1,5 +1,5 @@
 // Wire the shell: settings drawer, diagnostics, nav, section modules.
-import { settings, saveSettings, configured, hasSource, hasLocation, initNav, applyTabs, fullscreen, holdScreen, refreshAll, notify, load, store, applyEco, ecoOn, initKiosk, expires, num, U, msToWind, windToMs } from './app.js';
+import { settings, saveSettings, configured, hasSource, hasLocation, initNav, applyTabs, fullscreen, holdScreen, refreshAll, notify, load, store, applyEco, ecoOn, initKiosk, expires, num, U, msToWind, windToMs, setServerAlerts, alertsAreServerSide, every } from './app.js';
 import * as api from './api.js';
 import { initDesk, refreshDesk, refreshObs, refreshAlerts, refreshAqi } from './desk.js';
 import { initIntel, refreshModels, refreshNowcast } from './intel.js';
@@ -221,6 +221,39 @@ function renderDiag() {
     })
     .catch(() => { el.innerHTML = ''; });
 }
+
+// Does this install have a server running the alert engine? Asked here rather than in app.js
+// because /diag is a LAN-server route and app.js has no idea whether it is talking to one.
+async function probeServerAlerts() {
+  try {
+    const d = await (await fetch(`${SRV}/diag`, { signal: expires(5000) })).json();
+    setServerAlerts(!!d.alerts?.ok);
+  } catch {
+    setServerAlerts(false);
+  }
+  const el = $('rule-server');
+  if (el) {
+    el.textContent = alertsAreServerSide()
+      ? 'The server is evaluating these rules and sending the pushes, so they keep working with every window closed.'
+      : 'These rules are evaluated by this page, so they only fire while it is open. The desktop app and the Docker image evaluate them on the server instead.';
+  }
+}
+
+// The banner test above exercises the page's own pipe. This one asks the server to send a real
+// notification down every channel that is configured — the credentials never leave it, and what
+// arrives on the phone took exactly the path a 3am wind warning will take.
+$('btn-alert-test').onclick = async () => {
+  const out = $('alert-test-out');
+  out.textContent = 'sending…';
+  try {
+    const r = await (await fetch(`${SRV}/alerts/test`, { signal: expires(30000) })).json();
+    out.textContent = r.sent
+      ? `sent to ${r.channels.join(', ')} — check the phone`
+      : 'nothing to send to: set an ntfy topic, a webhook or a broker above';
+  } catch {
+    out.textContent = 'this build has no server to send from — the page pushes while it is open';
+  }
+};
 
 // A panel's own heading, so the lists read the way the page does. Falls back to the id for a
 // panel that has no heading — better than a blank button.
@@ -1141,6 +1174,7 @@ if (!hasSource() && !PUBLIC) {
 hydrateStation().then(() => {
   loadDeskRadar();
   initDesk(); initIntel(); initSignals(); initBoards(); initAlmanac(); initEnv(); initPro(); initUdp(); initHome();
+  every('server-alerts', 300, probeServerAlerts);
 });
 
 // ponytail-lite self-check: `?selftest` asserts the site maths and the link the viewer is handed.

--- a/site/js/home.js
+++ b/site/js/home.js
@@ -267,8 +267,43 @@ function renderSubs() {
 
 // --- Home Assistant read-back ---
 
-// One GET per entity id. A picker would mean pulling the whole state list and rendering a tree;
-// the ids are copy-paste from Home Assistant's own UI.
+// The server reads Home Assistant when there is a server: one request for the whole state list
+// instead of one per entity, the long-lived token stays out of the browser, and the CORS block
+// most installs never edited their YAML for stops mattering — the fetch is same-origin.
+//
+// A static self-host has no server to ask, so the direct path stays as the fallback. That one
+// does need `cors_allowed_origins` in Home Assistant's configuration.yaml, and always did.
+async function haRows(ids) {
+  try {
+    const j = await (await fetch(`${window.__WD_SRV || ''}/ha/states`, { signal: expires(20000) })).json();
+    if (j.error) throw new Error(j.error);
+    const by = new Map(j.entities.map((e) => [e.id, e]));
+    return ids.map((id) => {
+      const e = by.get(id);
+      return e
+        ? { id, name: e.name, value: `${e.state}${e.unit ? ` ${e.unit}` : ''}`, ok: true }
+        : { id, name: id, value: 'not in Home Assistant', ok: false };
+    });
+  } catch {
+    const s = settings();
+    const url = s.haUrl.replace(/\/+$/, '');
+    return Promise.all(ids.map(async (id) => {
+      try {
+        const r = await fetch(`${url}/api/states/${encodeURIComponent(id)}`, {
+          signal: expires(15000),
+          headers: { Authorization: `Bearer ${s.haToken}` },
+        });
+        if (!r.ok) throw new Error(`${r.status}`);
+        const j = await r.json();
+        const u = j.attributes?.unit_of_measurement;
+        return { id, name: j.attributes?.friendly_name || id, value: `${j.state}${u ? ` ${u}` : ''}`, ok: true };
+      } catch (e) {
+        return { id, name: id, value: e.message, ok: false };
+      }
+    }));
+  }
+}
+
 function initHaPanel() {
   const panel = $('ha-panel');
   if (!panel) return;
@@ -277,22 +312,16 @@ function initHaPanel() {
   panel.style.display = s.haUrl && ids.length ? '' : 'none';
   if (!s.haUrl || !ids.length) return;
   every('ha-states', 30, async () => {
-    const url = s.haUrl.replace(/\/+$/, '');
-    const rows = await Promise.all(ids.map(async (id) => {
-      try {
-        const r = await fetch(`${url}/api/states/${encodeURIComponent(id)}`, {
-          signal: expires(15000),
-          headers: { Authorization: `Bearer ${s.haToken}` },
-        });
-        if (!r.ok) throw new Error(`${r.status}`);
-        const j = await r.json();
-        return `<div><span>${j.attributes?.friendly_name || id}</span>`
-          + `<span class="ok">${j.state}${j.attributes?.unit_of_measurement ? ' ' + j.attributes.unit_of_measurement : ''}</span></div>`;
-      } catch (e) {
-        return `<div><span>${id}</span><span class="fail">${e.message}</span></div>`;
-      }
-    }));
-    $('ha-rows').innerHTML = rows.join('');
+    const rows = await haRows(ids);
+    // Home Assistant's own text, written in rather than interpolated: a friendly name is
+    // whatever somebody typed into another application.
+    $('ha-rows').innerHTML = rows.map(() => '<div><span></span><span></span></div>').join('');
+    [...$('ha-rows').children].forEach((el, i) => {
+      const [name, value] = el.querySelectorAll('span');
+      name.textContent = rows[i].name;
+      value.textContent = rows[i].value;
+      value.className = rows[i].ok ? 'ok' : 'fail';
+    });
     stamp('ha-stamp', 90);
   });
 }

--- a/src-tauri/src/alerts.rs
+++ b/src-tauri/src/alerts.rs
@@ -1,0 +1,504 @@
+//! Alert rules and NWS watches, evaluated by the server rather than by whatever browser happens
+//! to be open.
+//!
+//! `site/js/rules.js` has always done this well — but only while a tab is alive, which is the
+//! one thing an alert must not depend on. A tablet that sleeps at midnight is a house with no
+//! frost warning. Everything here mirrors that file deliberately, latch for latch, so the two
+//! never disagree about whether a rule has fired; the page stands down (see `/diag`) when this
+//! is running, because two engines on one ntfy topic means every alert arrives twice.
+//!
+//! The archive is SI. Rules are written in whatever the dashboard shows, so the readings are
+//! converted here exactly as `app.js` converts them — a "below 32" rule typed against °F must
+//! not fire at 32 °C.
+
+use crate::store;
+use std::collections::HashMap;
+use std::time::Duration;
+
+/// One pass a minute. The archive gains a row a minute at best, and a rule with a duration is
+/// measured in minutes by construction.
+const TICK: Duration = Duration::from_secs(60);
+
+/// A rule as the page writes it into the config blob. Every field past `metric`/`op`/`value` is
+/// optional because rules saved before v3 have none of them — which is also why this is read
+/// field by field rather than derived: a missing key must be a default, never a dropped rule.
+#[derive(Debug, Clone)]
+pub struct Rule {
+    pub metric: String,
+    pub op: String,
+    pub value: f64,
+    pub dur_min: f64,
+    pub metric2: Option<String>,
+    pub op2: Option<String>,
+    pub value2: Option<f64>,
+}
+
+impl Rule {
+    fn from_json(v: &serde_json::Value) -> Option<Rule> {
+        let s = |k: &str| v.get(k).and_then(|x| x.as_str()).map(String::from);
+        let f = |k: &str| v.get(k).and_then(|x| x.as_f64());
+        Some(Rule {
+            metric: s("metric")?,
+            op: s("op").unwrap_or_else(|| ">".into()),
+            value: f("value")?,
+            dur_min: f("durMin").unwrap_or(0.0),
+            metric2: s("metric2"),
+            op2: s("op2"),
+            value2: f("value2"),
+        })
+    }
+}
+
+/// Per-rule latch state, keyed by the rule's index in the saved list — the same key `rules.js`
+/// uses, and cleared for the same reason when the list changes.
+#[derive(Default, Clone, Copy)]
+pub struct Latch {
+    pub since: Option<i64>,
+    pub latched: bool,
+}
+
+/// The metric keys `rules.js` offers, and nothing else: a saved rule naming a metric that no
+/// longer exists is skipped rather than treated as zero.
+pub const METRICS: [&str; 9] =
+    ["temp", "dew", "gust", "wind", "rh", "rain", "uv", "strikes3h", "press3h"];
+
+fn holds(v: f64, op: &str, target: f64) -> bool {
+    if op == "<" { v < target } else { v > target }
+}
+
+/// Re-arm at 90% of the threshold (110% for a "below" rule). Without it a gust hovering on
+/// 30 mph notifies on every single report.
+fn rearmed(v: f64, op: &str, target: f64) -> bool {
+    if op == "<" { v > target * 1.1 } else { v < target * 0.9 }
+}
+
+fn second(m: &HashMap<&str, f64>, r: &Rule) -> bool {
+    let Some(k) = r.metric2.as_deref() else { return true };
+    if !METRICS.contains(&k) {
+        return false;
+    }
+    let (Some(v), Some(t)) = (m.get(k), r.value2) else { return false };
+    holds(*v, r.op2.as_deref().unwrap_or(">"), t)
+}
+
+/// Which rules fire on this reading. Pure, so the parity tests can drive it directly with the
+/// same numbers `rules.js` asserts on.
+pub fn evaluate(
+    m: &HashMap<&str, f64>,
+    rules: &[Rule],
+    state: &mut HashMap<usize, Latch>,
+    now: i64,
+) -> Vec<(usize, f64)> {
+    let mut fired = Vec::new();
+    for (i, r) in rules.iter().enumerate() {
+        if !METRICS.contains(&r.metric.as_str()) {
+            continue;
+        }
+        let Some(&v) = m.get(r.metric.as_str()) else { continue };
+        if v.is_nan() {
+            continue;
+        }
+        let st = state.entry(i).or_default();
+        if !holds(v, &r.op, r.value) || !second(m, r) {
+            st.since = None;
+            if st.latched && rearmed(v, &r.op, r.value) {
+                st.latched = false;
+            }
+            continue;
+        }
+        st.since.get_or_insert(now);
+        if !st.latched && now - st.since.unwrap() >= (r.dur_min * 60.0) as i64 {
+            st.latched = true;
+            fired.push((i, v));
+        }
+    }
+    fired
+}
+
+// --- reading the archive in the units the rule was written in ---
+
+fn imperial(cfg: &std::path::Path) -> bool {
+    crate::setting(cfg, "units").unwrap_or_default().trim_matches('"') != "metric"
+}
+
+/// m/s to whatever the wind is displayed in — the dashboard's wind unit is separately
+/// overridable, so this is not simply "metric or not".
+fn wind_factor(cfg: &std::path::Path) -> f64 {
+    let unit = crate::setting(cfg, "windUnit").unwrap_or_default().trim_matches('"').to_string();
+    match unit.as_str() {
+        "km/h" => 3.6,
+        "m/s" => 1.0,
+        "kt" => 1.94384,
+        "mph" => 2.23694,
+        _ if imperial(cfg) => 2.23694,
+        _ => 3.6,
+    }
+}
+
+/// The newest row as the metric map `evaluate` wants, in display units.
+///
+/// `dew` is absent: the archive holds no dew point column, and `rules.js` leaves it null on the
+/// live-tuple path for the same reason. A dew rule simply never fires here, which is what it
+/// already does for every non-Tempest station.
+fn metrics(conn: &rusqlite::Connection, cfg: &std::path::Path) -> Option<(i64, HashMap<&'static str, f64>)> {
+    let imp = imperial(cfg);
+    let w = wind_factor(cfg);
+    let (ts, gust, wind, rh, temp, uv, rain, interval, press): (
+        i64,
+        Option<f64>,
+        Option<f64>,
+        Option<f64>,
+        Option<f64>,
+        Option<f64>,
+        Option<f64>,
+        Option<f64>,
+        Option<f64>,
+    ) = conn
+        .query_row(
+            "SELECT ts, wind_gust, wind_avg, humidity, temp, uv, rain, report_interval, pressure
+             FROM obs ORDER BY ts DESC LIMIT 1",
+            [],
+            |r| {
+                Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?, r.get(5)?, r.get(6)?, r.get(7)?, r.get(8)?))
+            },
+        )
+        .ok()?;
+
+    let mut m: HashMap<&'static str, f64> = HashMap::new();
+    let mut put = |k: &'static str, v: Option<f64>| {
+        if let Some(v) = v {
+            m.insert(k, v);
+        }
+    };
+    put("temp", temp.map(|c| if imp { c * 9.0 / 5.0 + 32.0 } else { c }));
+    put("gust", gust.map(|v| v * w));
+    put("wind", wind.map(|v| v * w));
+    put("rh", rh);
+    put("uv", uv);
+    // The archive holds the accumulation for one report interval; the rule is written per hour.
+    let mins = interval.filter(|v| *v > 0.0).unwrap_or(1.0);
+    put("rain", rain.map(|v| v * (60.0 / mins) * if imp { 1.0 / 25.4 } else { 1.0 }));
+
+    // Three hours back, for the two metrics that are a change rather than a reading.
+    let then: Option<f64> = conn
+        .query_row(
+            "SELECT pressure FROM obs WHERE ts <= ?1 AND pressure IS NOT NULL ORDER BY ts DESC LIMIT 1",
+            [ts - 3 * 3600],
+            |r| r.get(0),
+        )
+        .ok();
+    if let (Some(now), Some(then)) = (press, then) {
+        put("press3h", Some((now - then) * if imp { 0.02953 } else { 1.0 }));
+    }
+    // Strikes are reported per interval, so three hours' worth is a sum, not a difference.
+    let strikes: Option<f64> = conn
+        .query_row("SELECT SUM(strikes) FROM obs WHERE ts > ?1", [ts - 3 * 3600], |r| r.get(0))
+        .ok()
+        .flatten();
+    put("strikes3h", strikes);
+    Some((ts, m))
+}
+
+// --- the channels ---
+
+/// Discord and Telegram reject the generic payload; both are recognised from the URL the user
+/// pasted, exactly as `app.js webhookBody` does. Public so the parity test can assert the shape.
+pub fn webhook_body(url: &str, title: &str, body: &str, category: &str) -> serde_json::Value {
+    let text = if body.is_empty() { title.to_string() } else { format!("{title}\n{body}") };
+    if url.contains("discord.com/api/webhooks/") || url.contains("discordapp.com/api/webhooks/") {
+        return serde_json::json!({ "content": text });
+    }
+    if url.contains("api.telegram.org/bot") {
+        return serde_json::json!({ "text": text });
+    }
+    serde_json::json!({ "title": title, "body": body, "category": category })
+}
+
+/// Off the machine. The payloads carry the title, the body and the category and nothing else:
+/// ntfy.sh is a public relay by default and a webhook goes wherever it was pointed.
+fn push(cfg: &std::path::Path, category: &str, title: &str, body: &str) {
+    let get = |k: &str| crate::setting(cfg, k).unwrap_or_default().trim_matches('"').to_string();
+    let topic = get("ntfyTopic");
+    if !topic.is_empty() {
+        let base = {
+            let u = get("ntfyUrl");
+            if u.is_empty() { "https://ntfy.sh".to_string() } else { u }
+        };
+        // A header value cannot contain a line break, and NWS headlines do.
+        let head: String = title.replace(['\r', '\n'], " ").chars().take(200).collect();
+        let r = ureq::post(&format!("{}/{}", base.trim_end_matches('/'), urlencode(&topic)))
+            .timeout(Duration::from_secs(15))
+            .set("Title", &head)
+            .set("Tags", category)
+            .send_string(if body.is_empty() { title } else { body });
+        if let Err(e) = r {
+            // Never the error's Display: an ntfy URL is a credential in its own right.
+            eprintln!("weatherdesk: ntfy push failed ({})", err_kind(&e));
+        }
+    }
+    let hook = get("webhookUrl");
+    if !hook.is_empty() {
+        let r = ureq::post(&hook)
+            .timeout(Duration::from_secs(15))
+            .set("Content-Type", "application/json")
+            .send_string(&webhook_body(&hook, title, body, category).to_string());
+        if let Err(e) = r {
+            eprintln!("weatherdesk: webhook push failed ({})", err_kind(&e));
+        }
+    }
+    crate::mqtt::send(if category == "rule" { "rule" } else { "alert" }, title);
+}
+
+fn err_kind(e: &ureq::Error) -> String {
+    match e {
+        ureq::Error::Status(code, _) => format!("HTTP {code}"),
+        ureq::Error::Transport(_) => "no answer".into(),
+    }
+}
+
+fn urlencode(s: &str) -> String {
+    s.bytes()
+        .map(|b| match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => (b as char).to_string(),
+            _ => format!("%{b:02X}"),
+        })
+        .collect()
+}
+
+/// Fire one real notification through every configured channel. The point is that it is real —
+/// a test that takes a different path to the phone tests nothing.
+pub fn test_push(cfg: &std::path::Path) -> String {
+    let get = |k: &str| crate::setting(cfg, k).unwrap_or_default().trim_matches('"').to_string();
+    let channels: Vec<&str> = [
+        (!get("ntfyTopic").is_empty()).then_some("ntfy"),
+        (!get("webhookUrl").is_empty()).then_some("webhook"),
+        (!get("mqttUrl").is_empty()).then_some("broker"),
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
+    push(cfg, "info", "WeatherDesk test alert", "If this reached you, alerts work.");
+    serde_json::json!({
+        "sent": !channels.is_empty(),
+        "channels": channels,
+    })
+    .to_string()
+}
+
+// --- NWS ---
+
+/// The dedupe key `desk.js` settled on: NWS mints a fresh id for every continuation of the same
+/// warning, so keying on the id re-chimed the same tornado warning every five minutes. Key on
+/// what the warning IS — a severity change still gets through, which is the one update worth a
+/// second chime.
+fn alert_key(p: &serde_json::Value) -> String {
+    let s = |k: &str| p.get(k).and_then(|v| v.as_str()).unwrap_or("");
+    format!("{}|{}|{}", s("event"), s("areaDesc"), s("severity"))
+}
+
+fn nws(cfg: &std::path::Path) -> Option<Vec<serde_json::Value>> {
+    let num = |k: &str| crate::setting(cfg, k)?.trim_matches('"').parse::<f64>().ok();
+    let (lat, lon) = (num("lat")?, num("lon")?);
+    let url = format!("https://api.weather.gov/alerts/active?point={lat:.4},{lon:.4}");
+    let body = ureq::get(&url)
+        .timeout(Duration::from_secs(20))
+        .set("User-Agent", concat!("WeatherDesk/", env!("CARGO_PKG_VERSION")))
+        .call();
+    let body = match body {
+        Ok(r) => r.into_string().ok()?,
+        Err(e) => {
+            eprintln!("weatherdesk: NWS alert poll failed ({})", err_kind(&e));
+            return None;
+        }
+    };
+    let v: serde_json::Value = serde_json::from_str(&body).ok()?;
+    Some(v.get("features")?.as_array()?.clone())
+}
+
+// --- the loop ---
+
+fn rules(cfg: &std::path::Path) -> Vec<Rule> {
+    crate::setting(cfg, "rules")
+        .and_then(|s| serde_json::from_str::<Vec<serde_json::Value>>(&s).ok())
+        .unwrap_or_default()
+        .iter()
+        .filter_map(Rule::from_json)
+        .collect()
+}
+
+/// Label, unit and decimals for the notification text, so a server-sent alert reads exactly like
+/// the banner the page would have shown.
+fn describe(metric: &str, cfg: &std::path::Path) -> (&'static str, String, usize) {
+    let imp = imperial(cfg);
+    let wind = crate::setting(cfg, "windUnit")
+        .unwrap_or_default()
+        .trim_matches('"')
+        .to_string();
+    let wind = if wind.is_empty() {
+        if imp { "mph".to_string() } else { "km/h".to_string() }
+    } else {
+        wind
+    };
+    let temp = if imp { "°F" } else { "°C" };
+    let press = if imp { "inHg" } else { "mb" };
+    let precip = if imp { "in/h" } else { "mm/h" };
+    match metric {
+        "temp" => ("Temperature", temp.into(), 1),
+        "dew" => ("Dew point", temp.into(), 1),
+        "gust" => ("Wind gust", wind, 1),
+        "wind" => ("Wind average", wind, 1),
+        "rh" => ("Humidity", "%".into(), 0),
+        "rain" => ("Rain rate", precip.into(), 2),
+        "uv" => ("UV index", String::new(), 1),
+        "strikes3h" => ("Lightning strikes · 3h", String::new(), 0),
+        "press3h" => ("Pressure change · 3h", press.into(), 2),
+        _ => ("Reading", String::new(), 1),
+    }
+}
+
+fn tick(
+    data_dir: &std::path::Path,
+    cfg: &std::path::Path,
+    state: &mut HashMap<usize, Latch>,
+    seen: &mut std::collections::HashSet<String>,
+    last_rules: &mut String,
+) {
+    // A changed rule list shifts every index, and a stale latch would then belong to the wrong
+    // rule — the same reason the page clears its map when a rule is deleted.
+    let raw = crate::setting(cfg, "rules").unwrap_or_default();
+    if raw != *last_rules {
+        state.clear();
+        *last_rules = raw;
+    }
+
+    let rs = rules(cfg);
+    if !rs.is_empty() {
+        if let Ok(conn) = store::open(&store::db_path(data_dir)) {
+            if let Some((ts, m)) = metrics(&conn, cfg) {
+                for (i, v) in evaluate(&m, &rs, state, ts) {
+                    let r = &rs[i];
+                    let (label, unit, digits) = describe(&r.metric, cfg);
+                    let op = if r.op == "<" { "below" } else { "above" };
+                    let title = format!("{label} {op} {:.*}{unit}", digits, r.value);
+                    let mut body = format!("Now {:.*}{unit}", digits, v);
+                    if r.dur_min > 0.0 {
+                        body.push_str(&format!(" for {} min", r.dur_min as i64));
+                    }
+                    push(cfg, "rule", &title, &body);
+                }
+            }
+        }
+    }
+
+    let Some(feats) = nws(cfg) else { return };
+    let live: std::collections::HashSet<String> = feats
+        .iter()
+        .filter_map(|f| f.get("properties").map(alert_key))
+        .collect();
+    for f in &feats {
+        let Some(p) = f.get("properties") else { continue };
+        let key = alert_key(p);
+        if !seen.insert(key) {
+            continue;
+        }
+        let s = |k: &str| p.get(k).and_then(|v| v.as_str()).unwrap_or("").to_string();
+        push(cfg, "severe", &s("event"), &s("headline"));
+    }
+    // Forget warnings that have expired, so the next one of the same kind chimes again.
+    seen.retain(|k| live.contains(k));
+}
+
+/// Run the engine for as long as the process lives. Silent until a rule is saved or a warning is
+/// issued, which is most days.
+pub fn start(data_dir: std::path::PathBuf, cfg_path: std::path::PathBuf) {
+    std::thread::spawn(move || {
+        let mut state: HashMap<usize, Latch> = HashMap::new();
+        let mut seen = std::collections::HashSet::new();
+        let mut last_rules = String::new();
+        // The page checks `/diag` to decide whether to run its own engine; say so before the
+        // first tick, not after it.
+        crate::ingest::note("alerts", true, "watching", false);
+        loop {
+            tick(&data_dir, &cfg_path, &mut state, &mut seen, &mut last_rules);
+            std::thread::sleep(TICK);
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rule(metric: &str, op: &str, value: f64, dur_min: f64) -> Rule {
+        Rule { metric: metric.into(), op: op.into(), value, dur_min, metric2: None, op2: None, value2: None }
+    }
+
+    fn m(pairs: &[(&'static str, f64)]) -> HashMap<&'static str, f64> {
+        pairs.iter().copied().collect()
+    }
+
+    // The same numbers `site/js/rules.js` asserts on. If these two ever disagree, one of the two
+    // engines is telling somebody their greenhouse is fine when it isn't.
+    #[test]
+    fn the_latch_matches_the_page_latch() {
+        let rs = [rule("gust", ">", 30.0, 0.0)];
+        let mut st = HashMap::new();
+        assert_eq!(evaluate(&m(&[("gust", 40.0)]), &rs, &mut st, 0).len(), 1);
+        assert_eq!(evaluate(&m(&[("gust", 40.0)]), &rs, &mut st, 60).len(), 0, "latched");
+        assert_eq!(evaluate(&m(&[("gust", 29.0)]), &rs, &mut st, 120).len(), 0, "inside the re-arm band");
+        assert_eq!(evaluate(&m(&[("gust", 20.0)]), &rs, &mut st, 180).len(), 0, "re-arm is not a fire");
+        assert_eq!(evaluate(&m(&[("gust", 40.0)]), &rs, &mut st, 240).len(), 1, "fires again");
+    }
+
+    #[test]
+    fn a_duration_holds_the_rule_back() {
+        let rs = [rule("temp", "<", 32.0, 10.0)];
+        let mut st = HashMap::new();
+        assert_eq!(evaluate(&m(&[("temp", 30.0)]), &rs, &mut st, 0).len(), 0);
+        assert_eq!(evaluate(&m(&[("temp", 30.0)]), &rs, &mut st, 599).len(), 0);
+        assert_eq!(evaluate(&m(&[("temp", 30.0)]), &rs, &mut st, 600).len(), 1);
+    }
+
+    #[test]
+    fn a_missing_reading_never_fires() {
+        let rs = [rule("temp", "<", 32.0, 10.0)];
+        let mut st = HashMap::new();
+        assert_eq!(evaluate(&m(&[]), &rs, &mut st, 0).len(), 0);
+    }
+
+    #[test]
+    fn an_and_rule_needs_both_halves() {
+        let mut r = rule("gust", ">", 25.0, 0.0);
+        r.metric2 = Some("rh".into());
+        r.op2 = Some("<".into());
+        r.value2 = Some(40.0);
+        let rs = [r];
+        let mut st = HashMap::new();
+        assert_eq!(evaluate(&m(&[("gust", 30.0), ("rh", 50.0)]), &rs, &mut st, 0).len(), 0);
+        assert_eq!(evaluate(&m(&[("gust", 30.0), ("rh", 30.0)]), &rs, &mut st, 60).len(), 1);
+        let mut st = HashMap::new();
+        assert_eq!(evaluate(&m(&[("gust", 30.0)]), &rs, &mut st, 0).len(), 0, "missing second reading");
+    }
+
+    #[test]
+    fn a_rule_saved_before_v3_still_fires() {
+        let rs = [rule("gust", ">", 30.0, 0.0)];
+        let mut st = HashMap::new();
+        assert_eq!(evaluate(&m(&[("gust", 40.0)]), &rs, &mut st, 0).len(), 1);
+    }
+
+    #[test]
+    fn the_two_webhooks_that_reject_the_generic_shape() {
+        let d = webhook_body("https://discord.com/api/webhooks/1/abc", "Tornado", "take cover", "severe");
+        assert!(d["content"].as_str().unwrap().contains("Tornado"));
+        let t = webhook_body("https://api.telegram.org/bot1:abc/sendMessage?chat_id=2", "Tornado", "take cover", "severe");
+        assert!(t["text"].as_str().unwrap().contains("cover"));
+        let g = webhook_body("https://example.com/hook", "Tornado", "take cover", "severe");
+        assert_eq!(g["category"], "severe");
+    }
+
+    #[test]
+    fn a_ntfy_topic_with_a_slash_cannot_escape_its_url() {
+        assert_eq!(urlencode("my topic/../admin"), "my%20topic%2F..%2Fadmin");
+    }
+}

--- a/src-tauri/src/alerts.rs
+++ b/src-tauri/src/alerts.rs
@@ -143,17 +143,11 @@ fn wind_factor(cfg: &std::path::Path) -> f64 {
 fn metrics(conn: &rusqlite::Connection, cfg: &std::path::Path) -> Option<(i64, HashMap<&'static str, f64>)> {
     let imp = imperial(cfg);
     let w = wind_factor(cfg);
-    let (ts, gust, wind, rh, temp, uv, rain, interval, press): (
-        i64,
-        Option<f64>,
-        Option<f64>,
-        Option<f64>,
-        Option<f64>,
-        Option<f64>,
-        Option<f64>,
-        Option<f64>,
-        Option<f64>,
-    ) = conn
+    /// ts, then the eight readings a rule can name, each of which any station is free to be
+    /// missing.
+    type Row = (i64, Opt, Opt, Opt, Opt, Opt, Opt, Opt, Opt);
+    type Opt = Option<f64>;
+    let (ts, gust, wind, rh, temp, uv, rain, interval, press): Row = conn
         .query_row(
             "SELECT ts, wind_gust, wind_avg, humidity, temp, uv, rain, report_interval, pressure
              FROM obs ORDER BY ts DESC LIMIT 1",

--- a/src-tauri/src/api.rs
+++ b/src-tauri/src/api.rs
@@ -163,6 +163,82 @@ pub fn test_smart_home(cfg: &std::path::Path) -> String {
     .to_string()
 }
 
+/// Every entity Home Assistant knows about, slimmed to what a picker and a read-back panel need.
+///
+/// This exists so the browser never holds the long-lived token. It also retires the CORS block
+/// people hit here — Home Assistant does not send CORS headers unless its YAML says to, so the
+/// old direct-from-the-page fetch failed for most installs until they edited a config file. The
+/// page still falls back to that path on a static host, which has no server to ask.
+///
+/// Cached briefly: a house with four dashboards open should be four reads of this, not four
+/// reads of Home Assistant.
+pub fn ha_states(cfg: &std::path::Path) -> String {
+    let now = crate::server::epoch();
+    if let Ok(c) = states_cache().lock() {
+        if let Some((at, body)) = c.as_ref() {
+            if now.saturating_sub(*at) < STATES_TTL {
+                return body.clone();
+            }
+        }
+    }
+    let get = |k: &str| crate::setting(cfg, k).unwrap_or_default().trim_matches('"').to_string();
+    let (url, token) = (get("haUrl"), get("haToken"));
+    if url.is_empty() {
+        return r#"{"error":"no Home Assistant URL set"}"#.to_string();
+    }
+    let base = url.trim_end_matches('/');
+    let body = match ureq::get(&format!("{base}/api/states"))
+        .set("Authorization", &format!("Bearer {token}"))
+        .timeout(Duration::from_secs(20))
+        .call()
+    {
+        Ok(r) => r.into_string().unwrap_or_default(),
+        // Codes and fixed words only: a Home Assistant error page can echo back the request that
+        // carried the token.
+        Err(ureq::Error::Status(401 | 403, _)) => return r#"{"error":"token rejected"}"#.to_string(),
+        Err(ureq::Error::Status(code, _)) => {
+            return serde_json::json!({ "error": format!("HTTP {code}") }).to_string()
+        }
+        Err(_) => return r#"{"error":"no answer"}"#.to_string(),
+    };
+    let Ok(list) = serde_json::from_str::<Vec<serde_json::Value>>(&body) else {
+        return r#"{"error":"unexpected answer"}"#.to_string();
+    };
+    let out: Vec<serde_json::Value> = list
+        .iter()
+        .filter_map(|e| {
+            let id = e.get("entity_id")?.as_str()?;
+            let attrs = e.get("attributes");
+            Some(serde_json::json!({
+                "id": id,
+                "name": attrs
+                    .and_then(|a| a.get("friendly_name"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or(id),
+                "state": e.get("state").and_then(|v| v.as_str()).unwrap_or(""),
+                "unit": attrs
+                    .and_then(|a| a.get("unit_of_measurement"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or(""),
+            }))
+        })
+        .collect();
+    let body = serde_json::json!({ "entities": out }).to_string();
+    if let Ok(mut c) = states_cache().lock() {
+        *c = Some((now, body.clone()));
+    }
+    body
+}
+
+fn states_cache() -> &'static Mutex<Option<(u64, String)>> {
+    static C: OnceLock<Mutex<Option<(u64, String)>>> = OnceLock::new();
+    C.get_or_init(|| Mutex::new(None))
+}
+
+/// Long enough that a wall of dashboards is one read, short enough that a light switch shows up
+/// on the panel while somebody is still standing next to it.
+const STATES_TTL: u64 = 15;
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@
 // the Docker image, a dashboard for a house with no desktop in it.
 
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
+pub mod alerts;
 pub mod api;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 pub mod cwop;
@@ -76,6 +77,7 @@ pub fn start_services(data_dir: PathBuf, cfg_path: PathBuf) -> (std::sync::Arc<s
     cwop::start_relay(state.data_dir.clone(), state.cfg_path.clone());
     ingest::start_pollers(state.clone());
     mqtt::start(state.data_dir.clone(), state.cfg_path.clone());
+    alerts::start(state.data_dir.clone(), state.cfg_path.clone());
     let port = server::serve(state.clone(), want);
     discover::start(port);
     (state, port)

--- a/src-tauri/src/mqtt.rs
+++ b/src-tauri/src/mqtt.rs
@@ -11,7 +11,25 @@
 
 use crate::store;
 use rumqttc::{Client, LastWill, MqttOptions, QoS};
+use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
+
+/// Text the alert engine wants on the broker. It runs on its own thread and must not open a
+/// second connection to say one sentence, so it leaves messages here and the live session picks
+/// them up on its next tick. Bounded: a broker that is down for a week must not become a leak.
+fn outbox() -> &'static Mutex<Vec<(String, String)>> {
+    static O: OnceLock<Mutex<Vec<(String, String)>>> = OnceLock::new();
+    O.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+/// Queue one retained message for `weatherdesk/<station>/<suffix>`.
+pub fn send(suffix: &str, payload: &str) {
+    let mut q = outbox().lock().unwrap();
+    if q.len() >= 64 {
+        q.remove(0);
+    }
+    q.push((suffix.to_string(), payload.to_string()));
+}
 
 /// How often we look for a new row. The archive gains one a minute at best, so this is mostly
 /// a cheap "has anything changed" query.
@@ -47,9 +65,14 @@ const FIELDS: [(&str, &str, Option<&str>, &str, &str); 15] = [
 /// Assistant can't derive these itself without a template sensor per house.
 /// name, device_class, unit, state_class — each optional, because a trend has none of them.
 type Derived = (&'static str, Option<&'static str>, Option<&'static str>, Option<&'static str>);
-const DERIVED: [Derived; 2] = [
+const DERIVED: [Derived; 4] = [
     ("feels_like", Some("temperature"), Some("°C"), Some("measurement")),
     ("pressure_trend", None, None, None),
+    // Written by the alert engine rather than by a row of the archive: the headline of the
+    // worst NWS alert in force, and the last user rule to fire. Both are text, and both are
+    // retained, so a Home Assistant that restarts still knows what is out.
+    ("alert", None, None, None),
+    ("rule", None, None, None),
 ];
 
 struct Conf {
@@ -148,8 +171,13 @@ fn announce(client: &Client, c: &Conf) {
             "name": name.replace('_', " "),
             "unique_id": format!("wd_{}_{}", c.station, name),
             "state_topic": format!("weatherdesk/{}/{}", c.station, name),
-            "expire_after": EXPIRE_AFTER,
         });
+        // Everything driven by a row of the archive expires, so a dead poller shows up as dead.
+        // The two the alert engine writes must not: a quiet fortnight is not a fault, and an
+        // alert sensor that went unavailable is an automation that silently stopped working.
+        if !matches!(name, "alert" | "rule") {
+            cfg["expire_after"] = EXPIRE_AFTER.into();
+        }
         if let Some(dc) = dc {
             cfg["device_class"] = dc.into();
         }
@@ -327,6 +355,16 @@ fn session(data_dir: &std::path::Path, cfg_path: &std::path::Path, c: &Conf) {
                 let _ = client.disconnect();
                 return;
             }
+        }
+        // Anything the alert engine left for us, before the row: an alert is the message
+        // people built the automation for.
+        for (suffix, payload) in outbox().lock().unwrap().drain(..) {
+            let _ = client.publish(
+                format!("weatherdesk/{}/{}", c.station, suffix),
+                QoS::AtLeastOnce,
+                true,
+                payload,
+            );
         }
         if last_announce.elapsed() >= REANNOUNCE {
             announce(&client, c);

--- a/src-tauri/src/server.rs
+++ b/src-tauri/src/server.rs
@@ -367,6 +367,10 @@ fn handle(state: &Arc<State>, mut req: Request) {
         // One real notification down every configured channel. Real on purpose: a test that
         // takes a different path to the phone from the alerts tests nothing.
         "/alerts/test" => json(crate::alerts::test_push(&state.cfg_path)),
+        // Home Assistant's entity list, read with the token this process holds. The browser
+        // never sees the token, and the CORS configuration most installs never edited stops
+        // mattering — the fetch is same-origin now.
+        "/ha/states" => json(crate::api::ha_states(&state.cfg_path)),
         "/discover/wll" => {
             let hosts = crate::discover::wll_hosts();
             json(serde_json::json!(hosts

--- a/src-tauri/src/server.rs
+++ b/src-tauri/src/server.rs
@@ -364,6 +364,9 @@ fn handle(state: &Arc<State>, mut req: Request) {
         // Try the broker and Home Assistant for real, and report in words. The credentials stay
         // in this process — the page never holds the token to make this call.
         "/ha/test" => json(crate::api::test_smart_home(&state.cfg_path)),
+        // One real notification down every configured channel. Real on purpose: a test that
+        // takes a different path to the phone from the alerts tests nothing.
+        "/alerts/test" => json(crate::alerts::test_push(&state.cfg_path)),
         "/discover/wll" => {
             let hosts = crate::discover::wll_hosts();
             json(serde_json::json!(hosts


### PR DESCRIPTION
Stacked on #58 → #57 → #56 → #54.

## Server-side alert engine (`src-tauri/src/alerts.rs`)

`site/js/rules.js` has always done this well, but only while a tab is alive — the one thing an alert must not depend on. A tablet that sleeps at midnight is a house with no frost warning.

The Rust engine mirrors that file deliberately, latch for latch: same re-arm band, same duration gate, same AND handling, same pre-v3 rule shape, same NWS dedupe key (`event|areaDesc|severity`, because NWS mints a fresh id for every continuation). Its tests assert on the numbers `rules.js` asserts on, so the two cannot drift quietly.

Rules are written in display units, so the SI archive is converted exactly as `app.js` converts it — including the new wind-unit override, since "gust above 30" means four different things.

**The page stands down** when the server is running (detected via `/diag`): one ntfy topic and two engines means every alert arrives twice. Banners still come from the page, so the dashboard stays instant.

**Test push channels** sends one real notification down every configured channel. Real on purpose — a test that takes a different path to the phone tests nothing.

MQTT gained `alert` and `rule` text entities, fed by a bounded outbox so the engine never opens a second broker connection. Neither carries `expire_after`: a quiet fortnight is not a fault.

## Home Assistant read-back and entity picker

`GET /ha/states` reads the state list with the token this process holds. That retires the CORS block most installs hit — HA sends no CORS headers unless its YAML says to, so the old direct-from-the-page fetch failed until somebody edited a config file. Now it is same-origin, one request instead of one per entity, and the token never reaches a browser. Static self-hosts keep the direct path as fallback.

The picker is read-only on purpose: switching things is HA's job, and a dashboard on an unauthenticated LAN that can throw a socket would sink the documented trust model.

Names and states are HA's text — written into the DOM, never interpolated into markup.

**Deviation from the plan, flagged:** the plan said push HA values over SSE. The page already polls this panel every 30 s; pointing that poll at our own server achieves the same three goals (CORS gone, token server-side, one request) with no new plumbing. Say the word if you want the SSE path anyway.

**Note on exposure:** `/ha/states` is LAN-readable, like `/config`. Same documented model — `/public` and `/config-public` remain the only internet-safe pair, and a public tunnel still needs the Cloudflare Access policy first.

## Verified

Against a real archive, real sinks and a real broker, not mocks:

- a 20 m/s gust row fired `Wind gust above 30.0mph` / `Now 44.7mph` down ntfy and the webhook, correctly converted; the °F temp rule correctly did not fire
- the latch held across the next tick (one alert, not one a minute), then a calm row re-armed it and a 22 m/s row fired again at `49.2mph`
- ntfy topic path-encoded: `my topic/weather` → `/my%20topic%2Fweather`, with a unit test that a `../` topic cannot escape its URL
- `/alerts/test` → `{"channels":["ntfy","webhook"],"sent":true}` and the notification arrived
- Mosquitto: `weatherdesk/<sid>/rule` retained, and the discovery config for the alert sensor carries no `expire_after`
- browser: the rules section explains the server is evaluating them; the test button reports all three channels
- `/ha/states` returns the slim list on a good token and `{"error":"token rejected"}` on a bad one, with no error body echoed
- picker lists, searches and toggles into the ids field; a friendly name containing `<b>` renders as text, not HTML
- 36 Rust tests (7 new), clippy clean apart from the two pre-existing `is_multiple_of` warnings, `?selftest` clean, no page errors

Test rig fully torn down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)