### PR TITLE
Home Assistant guide, three blueprints, and the alert all-clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,56 +231,51 @@ Notes that apply to all of them:
 
 ## Smart home
 
-WeatherDesk publishes the station to your own MQTT broker and reads a few Home Assistant entities
-back. Both halves are dark until you fill them in under Settings → **Smart home**.
+WeatherDesk publishes your station to Home Assistant over MQTT, evaluates your alert rules
+server-side, and reads Home Assistant entities back onto the dashboard. **Full guide:
+[docs/homeassistant.md](docs/homeassistant.md).** The short version:
 
-**Publishing.** Point *MQTT WebSocket URL* at a broker with a WebSocket listener — mosquitto wants
+**Publishing.** Settings → **Home Assistant** → point *MQTT broker* at `mqtt://host:1883`
+(`mqtts://` for TLS) and press **Test both** — it connects for real and waits for the broker to
+acknowledge a message, because a broker that rejects your password accepts the TCP connection
+first. Home Assistant then discovers one device with fifteen sensors under it, plus `feels_like`,
+`pressure_trend` as a word, `alert` and `rule`. Nothing to add to `configuration.yaml`.
 
-```
-listener 9001
-protocol websockets
-```
+Readings are retained on `weatherdesk/<station id>/…`, **in SI units** (°C, m/s, hPa, mm) whatever
+the dashboard displays — a units switch here must never rewrite months of Home Assistant history.
+`weatherdesk/<station id>/status` is `online`/`offline`, the second written by the broker's
+last will.
 
-— and readings arrive on `weatherdesk/<station id>/temp`, `…/wind`, `…/gust`, `…/rain`,
-`…/pressure`, and the rest, retained, **in SI units** (°C, m/s, hPa, mm) whatever the dashboard is
-set to display. Events land on `weatherdesk/<station id>/event/{lightning,rain,gust}` and are not
-retained. `weatherdesk/<station id>/status` is `online`/`offline`, the second written by the
-broker's last-will when the dashboard goes away.
+The server does this, not the page, so it keeps working with every window closed. Leave the
+desktop app or the container running; that is the always-on copy.
 
-Alongside the raw readings it publishes what a HA automation would otherwise have to work out:
-`feels_like`, `pressure_trend` as a word, a `storm` binary sensor, and one binary sensor per alert
-rule you wrote in the drawer.
+> Upgrading from before 3.2.0? Publishing used to run in the browser over a WebSocket. Change the
+> address from `ws://host:9001` to `mqtt://host:1883` — the app says so if you leave the old one
+> there — and you can drop `protocol websockets` from mosquitto if nothing else used it.
 
-Broker topics can also be read *back*: list them under Settings → **Broker topics to show**
-(`topic | label | unit`, one per line) and their values appear on the Home Assistant card. That is
-for the sensors that never went near Home Assistant — a greenhouse probe publishing straight to
-mosquitto.
+**Alerts.** Your alert rules are evaluated by the server too, against the same thresholds, hold
+times and re-arm behaviour the dashboard uses, and pushed through ntfy, a webhook and the broker.
+Severe weather comes off the National Weather Service the same way. A tablet that sleeps at
+midnight used to be a house with no frost warning. **Test push channels** sends one real
+notification down every configured channel.
 
-Home Assistant discovers all of it by itself: the retained `homeassistant/…/config` topics
-materialize one device with every sensor under it, and they survive a Home Assistant restart with
-no dashboard open. Changing your station ID leaves the old device's retained configs behind —
-delete them with `mosquitto_pub -t 'homeassistant/sensor/wd_<old id>_temp/config' -r -n`, one per
-topic, if you care.
+**Reading back.** Paste a Home Assistant URL and a long-lived access token, press **List
+entities**, and tick what you want on the Desk. The list is fetched by the server, so the token
+never reaches a browser and **you no longer need `cors_allowed_origins`** — the request is
+same-origin. Read-only, deliberately: switching things is Home Assistant's job.
 
-**Reading back.** *Home Assistant URL* + a long-lived access token + a comma-separated list of
-entity ids puts their live states on the Desk. Home Assistant has to allow this origin —
-in `configuration.yaml`:
+Broker topics can be read back too — Settings → **Broker topics to show** (`topic | label | unit`,
+one per line), for sensors that never went near Home Assistant, like a greenhouse probe publishing
+straight to mosquitto.
 
-```yaml
-http:
-  cors_allowed_origins:
-    - http://tauri.localhost
-    - http://<the LAN URL in the window title>
-```
+**Blueprints.** Three importable automations in
+[`blueprints/automation/weatherdesk`](blueprints/automation/weatherdesk): a severe alert to a
+critical push, a gust threshold to any action, and skip-irrigation-after-rain.
 
 **HomeKit, Alexa, Google.** Through Home Assistant, which already bridges all three — there is no
 WeatherDesk-specific code for them and there shouldn't be. Add the MQTT integration (the device
 above appears), then Settings → Devices & Services → Add Integration → **HomeKit Bridge** and pick
 it; Alexa and Google go through Home Assistant Cloud or their own manual setups.
-
-Two limits worth knowing: publishing only happens while the dashboard is open somewhere (leave the
-desktop app running — that is the always-on copy), and a browser tab served over `https` cannot
-reach a `ws://` broker at all. The desktop app and the LAN URL are both plain origins, so they can.
 
 ## Quick start
 

--- a/blueprints/automation/weatherdesk/daily-rain-skip-irrigation.yaml
+++ b/blueprints/automation/weatherdesk/daily-rain-skip-irrigation.yaml
@@ -1,0 +1,67 @@
+blueprint:
+  name: WeatherDesk — skip irrigation after rain
+  description: >-
+    Waters at a set time each day, unless your own rain gauge says the garden
+    already got some.
+
+    This is the one automation a weather station pays for itself with. The
+    reading is from the gauge in the garden, not a forecast for the county and
+    not an airport eleven miles away — the shower that soaked one street and
+    missed the next is exactly the case a forecast gets wrong.
+
+    WeatherDesk publishes rain in millimetres whatever the dashboard shows.
+    5 mm is about a fifth of an inch.
+  domain: automation
+  source_url: https://github.com/d4vid87/weatherdesk/blob/main/blueprints/automation/weatherdesk/daily-rain-skip-irrigation.yaml
+  input:
+    rain_sensor:
+      name: Day rain sensor
+      description: The `day rain` sensor on your WeatherDesk device.
+      selector:
+        entity:
+          domain: sensor
+          integration: mqtt
+    water_at:
+      name: Water at
+      default: "06:00:00"
+      selector:
+        time:
+    threshold:
+      name: Skip if it has rained at least
+      description: In the unit the sensor is displayed in.
+      default: 5
+      selector:
+        number:
+          min: 0
+          max: 50
+          step: 0.5
+          mode: box
+    water_actions:
+      name: Watering
+      description: Turn the valve on, run the sprinkler script — whatever waters the garden.
+      selector:
+        action:
+    skip_actions:
+      name: When it is skipped
+      description: Optional — somewhere to hang a notification so a dry week is visible.
+      default: []
+      selector:
+        action:
+
+mode: single
+
+trigger:
+  - platform: time
+    at: !input water_at
+
+action:
+  - choose:
+      - conditions:
+          # `above` treats a missing reading as "not above", so a station that has been
+          # offline all night waters rather than silently skipping. A dead sensor should
+          # cost water, not a dead garden.
+          - condition: numeric_state
+            entity_id: !input rain_sensor
+            above: !input threshold
+        sequence: !input skip_actions
+    default: !input water_actions

--- a/blueprints/automation/weatherdesk/severe-alert-critical-push.yaml
+++ b/blueprints/automation/weatherdesk/severe-alert-critical-push.yaml
@@ -1,0 +1,62 @@
+blueprint:
+  name: WeatherDesk — severe weather alert to a critical push
+  description: >-
+    Sends a critical notification to a phone when WeatherDesk publishes a severe
+    weather alert.
+
+    WeatherDesk writes the headline of the worst warning in force to its `alert`
+    sensor and clears it when nothing is out, so this fires on the transition
+    into a warning rather than repeatedly while one is running.
+
+    A critical notification overrides silent mode and Do Not Disturb on both
+    iOS and Android. That is the point at 3am, and it is also why this blueprint
+    is for tornado-and-hurricane weather rather than for a windy afternoon —
+    use the gust blueprint for that.
+  domain: automation
+  source_url: https://github.com/d4vid87/weatherdesk/blob/main/blueprints/automation/weatherdesk/severe-alert-critical-push.yaml
+  input:
+    alert_sensor:
+      name: WeatherDesk alert sensor
+      description: The `alert` sensor on your WeatherDesk device.
+      selector:
+        entity:
+          domain: sensor
+          integration: mqtt
+    notify_device:
+      name: Phone
+      description: The phone running the Home Assistant companion app.
+      selector:
+        device:
+          integration: mobile_app
+
+mode: queued
+max: 5
+
+trigger:
+  - platform: state
+    entity_id: !input alert_sensor
+
+condition:
+  # An empty sensor is the all-clear, and `unknown`/`unavailable` are a restart or a broker
+  # blip — neither is worth waking anyone for.
+  - condition: template
+    value_template: >-
+      {{ trigger.to_state.state not in ['', 'unknown', 'unavailable', 'none'] }}
+
+action:
+  - device_id: !input notify_device
+    domain: mobile_app
+    type: notify
+    title: Severe weather
+    message: "{{ trigger.to_state.state }}"
+    data:
+      # iOS and Android read different keys for the same idea, and sending both is harmless
+      # on either.
+      push:
+        sound:
+          name: default
+          critical: 1
+          volume: 1.0
+      ttl: 0
+      priority: high
+      channel: Weather

--- a/blueprints/automation/weatherdesk/wind-gust-threshold.yaml
+++ b/blueprints/automation/weatherdesk/wind-gust-threshold.yaml
@@ -1,0 +1,79 @@
+blueprint:
+  name: WeatherDesk — wind gust over a threshold
+  description: >-
+    Runs whatever you like when the gust reading from your own station goes over
+    a number and stays there.
+
+    The hold time is what makes this usable: a single 40 mph spike on an
+    otherwise calm afternoon is a leaf hitting the anemometer, and closing the
+    awning for it every time is how people end up turning the automation off.
+    Two minutes is a reasonable starting point.
+
+    WeatherDesk publishes wind in metres per second, whatever the dashboard is
+    set to display — the unit switch on the dashboard must never rewrite months
+    of Home Assistant history. Type the threshold in the unit the sensor shows
+    in Home Assistant. 10 m/s is about 22 mph or 36 km/h.
+  domain: automation
+  source_url: https://github.com/d4vid87/weatherdesk/blob/main/blueprints/automation/weatherdesk/wind-gust-threshold.yaml
+  input:
+    gust_sensor:
+      name: Gust sensor
+      description: The `gust` sensor on your WeatherDesk device.
+      selector:
+        entity:
+          domain: sensor
+          integration: mqtt
+    threshold:
+      name: Threshold
+      description: In the unit the sensor is displayed in.
+      default: 10
+      selector:
+        number:
+          min: 0
+          max: 60
+          step: 0.5
+          mode: box
+    hold:
+      name: Hold for
+      description: How long the gusts have to stay above the threshold.
+      default:
+        minutes: 2
+      selector:
+        duration:
+    windy_actions:
+      name: When it gets windy
+      selector:
+        action:
+    calm_actions:
+      name: When it calms down again
+      description: >-
+        Optional — runs when the gusts drop back below the threshold. Leave
+        empty if there is nothing to undo.
+      default: []
+      selector:
+        action:
+
+mode: single
+
+trigger:
+  - platform: numeric_state
+    entity_id: !input gust_sensor
+    above: !input threshold
+    for: !input hold
+    id: windy
+  - platform: numeric_state
+    entity_id: !input gust_sensor
+    below: !input threshold
+    for: !input hold
+    id: calm
+
+action:
+  - choose:
+      - conditions:
+          - condition: trigger
+            id: windy
+        sequence: !input windy_actions
+      - conditions:
+          - condition: trigger
+            id: calm
+        sequence: !input calm_actions

--- a/docs/homeassistant.md
+++ b/docs/homeassistant.md
@@ -1,0 +1,208 @@
+# WeatherDesk and Home Assistant
+
+WeatherDesk publishes your station to Home Assistant over MQTT, evaluates your alert rules
+server-side, and reads Home Assistant entities back onto the dashboard. None of it needs a browser
+to be open, and none of it needs a cloud account.
+
+- [What you get](#what-you-get)
+- [Publishing the station](#publishing-the-station)
+- [The entities](#the-entities)
+- [Alerts](#alerts)
+- [Reading Home Assistant back](#reading-home-assistant-back)
+- [Blueprints](#blueprints)
+- [The JSON API](#the-json-api)
+- [When it doesn't work](#when-it-doesnt-work)
+
+## What you get
+
+One Home Assistant device with fifteen sensors under it, discovered automatically, surviving a
+restart of either side. No custom component to install and nothing to add to
+`configuration.yaml` — the discovery topics are retained, so Home Assistant finds the device on
+its own.
+
+**Everything on the wire is SI**: °C, m/s, hPa, mm. Always, whatever the dashboard is set to
+display. A units switch on the dashboard must never rewrite months of Home Assistant history, and
+Home Assistant converts for display anyway.
+
+## Publishing the station
+
+Settings → **Home Assistant** → *Publish the station*.
+
+| Field | What goes in it |
+| --- | --- |
+| MQTT broker | `mqtt://192.168.1.10:1883`, or `mqtts://…` for TLS. A bare hostname works too. |
+| MQTT username / password | Only if your broker asks for them. |
+| Discovery prefix | `homeassistant` unless you changed it in Home Assistant's MQTT settings. |
+
+Then press **Test both**. It connects for real and waits for the broker to acknowledge a
+published message, rather than just checking that the socket opened — a broker that rejects your
+password accepts the TCP connection first, which is why "it connected" was never worth reporting.
+
+Mosquitto with no authentication needs nothing beyond a listener. With authentication, whatever
+user you give WeatherDesk needs write access to `weatherdesk/#` and to your discovery prefix.
+
+> **`ws://` is a different listener.** Older versions of WeatherDesk published from the browser
+> over a WebSocket, so the setting wanted a `ws://` URL and your broker needed
+> `protocol websockets`. Publishing moved into the server, which speaks plain MQTT — if you are
+> upgrading, change the address to `mqtt://` and the port from 9001 to 1883. WeatherDesk says so
+> if you leave a `ws://` address there.
+
+Topics, if you want them directly:
+
+```
+weatherdesk/<station id>/temp          retained, °C
+weatherdesk/<station id>/wind_avg      retained, m/s
+weatherdesk/<station id>/day_rain      retained, mm
+weatherdesk/<station id>/status        online | offline   (offline is the broker's last will)
+homeassistant/sensor/wd_<station id>_temp/config           retained discovery
+```
+
+Discovery is re-sent every fifteen minutes, so a broker that lost its retained set — a fresh
+container, a `mosquitto -c` with no persistence — gets it back without anyone restarting anything.
+
+Changing your station ID leaves the old device's retained configs on the broker. Clear them with
+one `mosquitto_pub -t 'homeassistant/sensor/wd_<old id>_temp/config' -r -n` per topic, if the
+duplicate device bothers you.
+
+## The entities
+
+Fifteen sensors straight off the archive:
+
+`temperature` · `humidity` · `pressure` · `wind` · `gust` · `wind lull` · `wind direction` ·
+`uv` · `solar` · `lux` · `rain` · `day rain` · `battery` · `strikes` · `strike distance`
+
+and four more that Home Assistant would otherwise need a template sensor per house to work out:
+
+| Entity | What it is |
+| --- | --- |
+| `feels_like` | Heat index above 27 °C, wind chill below 10 °C, the plain reading between — the same two formulas the dashboard's hero uses, so they agree. |
+| `pressure_trend` | A word: `falling rapidly`, `falling`, `steady`, `rising`, `rising rapidly`. |
+| `alert` | The headline of the worst NWS warning in force. Empty when nothing is out. |
+| `rule` | The last of your own alert rules to fire, as the text you would have seen on the dashboard. |
+
+The first thirteen carry `expire_after`, so a station that stops reporting shows as unavailable
+rather than serving a frozen number forever. `alert` and `rule` deliberately do not: a quiet
+fortnight is not a fault, and an alert sensor that went unavailable is an automation that silently
+stopped working.
+
+`configuration_url` on the device links back to the dashboard, so the Home Assistant device page
+has a way in.
+
+## Alerts
+
+The rules you write under Settings → **Alert rules** are evaluated by the WeatherDesk server, not
+by the page. That is the whole point: a tablet that sleeps at midnight used to be a house with no
+frost warning.
+
+The server watches the archive, applies the same thresholds, the same hold times, the same
+AND conditions and the same re-arm behaviour the dashboard applies, and pushes through every
+channel you have configured — ntfy, a webhook, and the `rule` topic on the broker. It also polls
+the National Weather Service and pushes severe warnings the same way. The page stops pushing when
+it notices the server is doing it, so nothing arrives twice.
+
+**Test push channels**, in the notifications section of Settings, sends one real notification down
+every configured channel. Real on purpose: a test that takes a different path to your phone than
+the alerts do tests nothing.
+
+Static self-hosts — the site served by a plain web server with no WeatherDesk process behind it —
+have no server to do this, and the page keeps evaluating rules itself while it is open.
+
+## Reading Home Assistant back
+
+Settings → **Home Assistant** → *Read entities back*. Paste the Home Assistant URL and a
+long-lived access token (Home Assistant → your profile → Security → Long-lived access tokens),
+then press **List entities** and tick what you want on the dashboard.
+
+The list is fetched by the WeatherDesk server, which means two things worth knowing:
+
+- The token stays on the server. It is never sent to a browser.
+- **You no longer need `cors_allowed_origins` in `configuration.yaml`.** Home Assistant sends no
+  CORS headers unless its YAML says to, which is why this used to fail for most people until they
+  edited a config file. The request is same-origin now.
+
+A static self-host still takes the old path — the browser calls Home Assistant directly — and
+still needs the CORS block:
+
+```yaml
+http:
+  cors_allowed_origins:
+    - http://tauri.localhost
+    - http://<the LAN address of the dashboard>
+```
+
+This is read-only, deliberately. Turning things on and off is Home Assistant's job; a dashboard on
+a LAN with no authentication that can throw a socket would sink the trust model this app
+documents.
+
+## Blueprints
+
+Three importable automations live in [`blueprints/automation/weatherdesk`](../blueprints/automation/weatherdesk).
+In Home Assistant: Settings → Automations & scenes → Blueprints → **Import blueprint**, and paste
+the URL of the raw file.
+
+| Blueprint | What it does |
+| --- | --- |
+| [`severe-alert-critical-push`](../blueprints/automation/weatherdesk/severe-alert-critical-push.yaml) | Sends a critical notification — one that overrides silent mode and Do Not Disturb — when the `alert` sensor picks up a warning. |
+| [`wind-gust-threshold`](../blueprints/automation/weatherdesk/wind-gust-threshold.yaml) | Runs anything you like when gusts stay over a number, and optionally something else when they drop back. |
+| [`daily-rain-skip-irrigation`](../blueprints/automation/weatherdesk/daily-rain-skip-irrigation.yaml) | Waters at a set time unless your own gauge says the garden already got some. |
+
+Thresholds are typed in the unit the sensor shows in Home Assistant. 10 m/s is about 22 mph;
+5 mm is about a fifth of an inch.
+
+## The JSON API
+
+`GET /api/v1` on the dashboard's own address. Named fields, SI, no credentials, and a version
+number that means it. Everything else this server answers is shaped for the page and free to
+change with it; this one is not.
+
+```json
+{
+  "api": 1,
+  "version": "3.2.0",
+  "units": "si",
+  "station": { "id": "12345", "name": "Home", "source": "", "lat": 41.87, "lon": -72.8 },
+  "current": {
+    "at": 1787537000,
+    "temp": 20.1, "humidity": 54, "pressure": 1013.2,
+    "wind_avg": 2.1, "wind_gust": 4.4, "wind_dir": 190,
+    "uv": 0.4, "solar": 33, "rain": 0, "day_rain": 1.2,
+    "feels_like": 20.1, "pressure_trend": "steady"
+  },
+  "forecast": { "days": [ { "at": 1787529600, "high_c": 27.4, "low_c": 14.1, "precip_chance": 10, "wmo_code": 3 } ] },
+  "health": { "wll": { "at": 1787536980, "ok": true, "what": "ok · waiting for next write slot", "rows": 412 } }
+}
+```
+
+`current` is the newest row of the archive. A field the station does not measure is `null`, not
+missing. The forecast is five days from open-meteo, cached for fifteen minutes.
+
+The dashboard also announces itself on the LAN over mDNS as `_weatherdesk._tcp`, with `version`
+and `path=/api/v1` in its TXT record, so something looking for it does not have to be told an
+address.
+
+## When it doesn't work
+
+**No device appears in Home Assistant.** Check Settings → *Test both* first. If the broker is
+green, check that Home Assistant's own MQTT integration points at the same broker, and that the
+discovery prefix matches on both sides.
+
+**Sensors appear and immediately go unavailable.** That is `expire_after` doing its job: nothing
+has been written to the archive recently. Settings → Diagnostics shows what each station source
+last did.
+
+**Everything is 32 °F / 0 °C, or the numbers look scaled.** Home Assistant is being told SI and
+converting. If a number looks converted twice, check you have not also left the old browser-side
+publisher running — an older WeatherDesk tab open somewhere will publish to the same topics. The
+current version stands down when it sees the server publishing, but a tab from before 3.2.0 will
+not.
+
+**A `mqtts://` broker won't connect.** WeatherDesk uses the system trust store. A self-signed
+broker certificate needs to be trusted by the machine WeatherDesk runs on.
+
+## A note on exposure
+
+WeatherDesk's LAN routes assume a trusted LAN: `/config` serves the settings blob, and
+`/ha/states` will list your Home Assistant entities to anything that can reach the port. That is
+the documented model. `/public` and `/config-public` are the only pair meant for the open
+internet, and a public tunnel needs an access policy in front of it before anything else. See the
+README's self-hosting section.

--- a/src-tauri/src/alerts.rs
+++ b/src-tauri/src/alerts.rs
@@ -385,21 +385,39 @@ fn tick(
     }
 
     let Some(feats) = nws(cfg) else { return };
-    let live: std::collections::HashSet<String> = feats
-        .iter()
-        .filter_map(|f| f.get("properties").map(alert_key))
-        .collect();
     for f in &feats {
         let Some(p) = f.get("properties") else { continue };
-        let key = alert_key(p);
-        if !seen.insert(key) {
+        if !is_new(seen, p) {
             continue;
         }
         let s = |k: &str| p.get(k).and_then(|v| v.as_str()).unwrap_or("").to_string();
         push(cfg, "severe", &s("event"), &s("headline"));
     }
-    // Forget warnings that have expired, so the next one of the same kind chimes again.
+    if expire(seen, &feats) {
+        crate::mqtt::send("alert", "");
+    }
+}
+
+/// Has this warning been announced already? Announcing sets the memory, so a caller that skips is
+/// a caller that has nothing to say.
+fn is_new(seen: &mut std::collections::HashSet<String>, props: &serde_json::Value) -> bool {
+    seen.insert(alert_key(props))
+}
+
+/// Drop warnings that are no longer in the feed, so the next one of the same kind chimes again.
+/// Returns true on the all-clear: the moment the last warning went away.
+///
+/// Without the all-clear the `alert` sensor keeps its last headline forever, and an automation
+/// asking "is anything out right now" gets answered by a thunderstorm that ended on Tuesday.
+/// Only on the transition, so a quiet month is not a message a minute.
+fn expire(seen: &mut std::collections::HashSet<String>, feats: &[serde_json::Value]) -> bool {
+    let live: std::collections::HashSet<String> = feats
+        .iter()
+        .filter_map(|f| f.get("properties").map(alert_key))
+        .collect();
+    let had = !seen.is_empty();
     seen.retain(|k| live.contains(k));
+    had && seen.is_empty()
 }
 
 /// Run the engine for as long as the process lives. Silent until a rule is saved or a warning is
@@ -479,6 +497,35 @@ mod tests {
         let rs = [rule("gust", ">", 30.0, 0.0)];
         let mut st = HashMap::new();
         assert_eq!(evaluate(&m(&[("gust", 40.0)]), &rs, &mut st, 0).len(), 1);
+    }
+
+    fn warning(event: &str, area: &str, sev: &str) -> serde_json::Value {
+        serde_json::json!({ "properties": { "event": event, "areaDesc": area, "severity": sev } })
+    }
+
+    /// NWS mints a fresh id for every continuation of the same warning, so keying the memory on
+    /// the id re-chimed the same tornado warning every five minutes.
+    #[test]
+    fn a_continued_warning_does_not_chime_twice_but_a_worse_one_does() {
+        let mut seen = std::collections::HashSet::new();
+        let w = warning("Tornado Warning", "Hartford", "Severe");
+        assert!(is_new(&mut seen, w.get("properties").unwrap()));
+        assert!(!is_new(&mut seen, w.get("properties").unwrap()), "same warning, continued");
+        let worse = warning("Tornado Warning", "Hartford", "Extreme");
+        assert!(is_new(&mut seen, worse.get("properties").unwrap()), "a severity change is worth a second chime");
+    }
+
+    #[test]
+    fn the_all_clear_fires_once_when_the_last_warning_goes_away() {
+        let mut seen = std::collections::HashSet::new();
+        let w = warning("Flood Warning", "Hartford", "Severe");
+        let x = warning("Wind Advisory", "Hartford", "Moderate");
+        is_new(&mut seen, w.get("properties").unwrap());
+        is_new(&mut seen, x.get("properties").unwrap());
+        assert!(!expire(&mut seen, &[w.clone(), x.clone()]), "both still out");
+        assert!(!expire(&mut seen, std::slice::from_ref(&w)), "one left is not an all-clear");
+        assert!(expire(&mut seen, &[]), "the last one going away is");
+        assert!(!expire(&mut seen, &[]), "and a quiet month says nothing further");
     }
 
     #[test]


### PR DESCRIPTION
## Docs

The README's smart-home section still described the browser-side publisher 3.2.0 retired — a `ws://` broker URL, a mosquitto `protocol websockets` listener, a storm binary sensor and per-rule binary sensors that the Rust publisher does not send, and a `cors_allowed_origins` block that is no longer needed. Rewritten to what the code actually does, with an upgrade note for anyone still on a `ws://` address.

New `docs/homeassistant.md`: publishing, the nineteen entities and which of them carry `expire_after` and why, server-side alerts, reading Home Assistant back, the blueprints, an `/api/v1` reference, a troubleshooting section, and a note that `/ha/states` is LAN-readable like `/config`.

Every label quoted in the docs was checked against `index.html` — *MQTT broker*, *Test both*, *List entities*, *Test push channels*.

## Blueprints

`blueprints/automation/weatherdesk/`:

- **severe-alert-critical-push** — critical notification (overrides silent mode and Do Not Disturb) on the `alert` sensor picking up a warning.
- **wind-gust-threshold** — any action when gusts stay over a number, with an optional calm-down action. The hold time is the point: one 40 mph spike on a calm afternoon is a leaf hitting the anemometer, and closing the awning for it is how people end up disabling the automation.
- **daily-rain-skip-irrigation** — waters at a set time unless your own gauge says the garden already got some. It waters when the reading is missing rather than skipping: a dead sensor should cost water, not a dead garden.

## A bug the docs found

Nothing ever cleared the `alert` sensor. It kept the last headline forever, so an automation asking "is anything out right now" would have been answered by a thunderstorm that ended on Tuesday. The engine now publishes the all-clear on the transition — once, not once a minute for a quiet month. The announce/expire memory came out as two pure functions with tests, covering the continued-warning case (NWS mints a fresh id per continuation, so the memory keys on what the warning *is*) and the severity-change case that should chime again.

## Verified

- All three blueprints validated by a real Home Assistant `stable` container via `check_config` with automations that actually use them. Two render clean; the third fails only on `Unknown device` for the fake device id I passed it, which is the runtime lookup — its triggers, condition template and notify action all rendered.
- 38 Rust tests (2 new), clippy clean apart from the two pre-existing `is_multiple_of` warnings.

Could not exercise the all-clear against the live NWS feed: `api.weather.gov/alerts/active` returned zero features nationwide while I was testing, hence the unit tests on the extracted functions rather than an end-to-end run.

Container and broker torn down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)