### PR TITLE
chore: release v3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,66 @@ and the format loosely follows [Keep a Changelog](https://keepachangelog.com/en/
 Every release ships desktop installers (Linux `.deb`, Windows, macOS), an arm64 `.deb` for the
 Raspberry Pi, an Android APK, and the `ghcr.io/d4vid87/weatherdesk` container image.
 
+## [3.2.0] — 2026-08-24
+
+Home Assistant, done properly. The MQTT publisher, the alert engine and the Home Assistant
+read-back all moved off the page and into the server, so they keep working with every window in
+the house closed — which is the one thing an alert cannot depend on a browser for.
+
+Two new repositories ship alongside this release: a
+[HACS integration](https://github.com/d4vid87/ha-weatherdesk) for a weather entity with a forecast
+card, and a [Home Assistant OS add-on](https://github.com/d4vid87/weatherdesk-addons).
+
+### Added
+- **Server-side MQTT publishing.** One Home Assistant device, nineteen entities, discovered with
+  no YAML and no custom component. SI on the wire always — a units switch on the dashboard must
+  never rewrite months of Home Assistant history. `feels_like`, `pressure_trend` as a word,
+  `alert` and `rule` alongside the raw readings; the first fifteen carry `expire_after`, so a
+  station that stops reporting shows as unavailable rather than serving a frozen number.
+- **Server-side alert engine**, mirroring the page's rules latch for latch — same thresholds,
+  hold times, AND conditions and re-arm band — plus the NWS poll. Pushes through ntfy, a webhook
+  and the broker. The page stands down when the server is running, so nothing arrives twice.
+- **Test push channels** in Settings sends one real notification down every configured channel.
+  A test that takes a different path to your phone than the alerts do tests nothing.
+- **Home Assistant entity picker.** The state list is fetched by the server, so the long-lived
+  token never reaches a browser — and `cors_allowed_origins` in `configuration.yaml` is no longer
+  needed, which is what used to make this fail for most people. Read-only, deliberately.
+- **`GET /api/v1`** — named fields, SI, no credentials, and a version number that means it.
+  Everything else this server answers is shaped for the page and free to change with it.
+- **mDNS.** The dashboard announces itself as `_weatherdesk._tcp`, and finds a WeatherLink Live
+  console the same way — the *Find console* button in the wizard and in Settings.
+- **Wind unit override** — mph, km/h, m/s or knots, independent of the master units switch.
+- **Layout presets**: Wall landscape, Kitchen portrait, E-ink. A starting point to drag from.
+- **Data and Signals cards are draggable**, resizable and hideable like every other panel.
+- **Sun strength panel**: UV now and its band, burn time, today's peak UV and when, solar now,
+  and the day's energy in kWh/m².
+- **This day, other years** — what your own station recorded on this date in previous years.
+- **Station elevation**, **three importable Home Assistant blueprints**, and
+  [`docs/homeassistant.md`](docs/homeassistant.md).
+- Ingress support: served behind a path prefix, the page is handed that prefix rather than
+  firing absolute paths at whatever is in front of it.
+
+### Changed
+- The setup wizard leads with the brand of station rather than a Tempest token, and waits for one
+  real reading before it closes — "68.2°F received ✓". A saved setting was never the same thing
+  as a working station.
+- Six files each carried their own copy of the metres-per-second conversion factor. One helper
+  now: six chances for a chart to be plausible and wrong, removed.
+- The Home Assistant settings are one section split into *Publish the station* and *Read entities
+  back*, with a **Test both** button that connects for real and waits for the broker to
+  acknowledge a message — a broker that rejects your password accepts the TCP connection first.
+
+### Fixed
+- The `alert` sensor kept its last headline forever, so an automation asking "is anything out
+  right now" would have been answered by a thunderstorm that ended on Tuesday. It clears on the
+  all-clear.
+- Publishing no longer stops when the last browser tab closes.
+
+### Upgrading
+Publishing used to run in the browser over a WebSocket. Change the broker address from
+`ws://host:9001` to `mqtt://host:1883` — the app says so if you leave the old one there — and you
+can drop `protocol websockets` from mosquitto if nothing else used it.
+
 ## [3.1.1] — 2026-08-23
 
 Three things testers wrote in about, and the elevation setting the barometer always wanted.

--- a/README.md
+++ b/README.md
@@ -450,6 +450,10 @@ or the `docker-compose.yml` in this repo. Then open `http://<host>:8088`.
 broadcast does not cross a bridged Docker network no matter how many ports you publish — without
 host networking the container serves the dashboard but never hears the hub.
 
+**Home Assistant users upgrading from 3.1.x:** publishing moved from the browser into the server,
+so the broker address changes from `ws://host:9001` to `mqtt://host:1883`. The app says so if you
+leave the old one there. See [docs/homeassistant.md](docs/homeassistant.md).
+
 **Upgrading from 3.0.9 or older takes one `chown`.** The container runs as uid 1000 now instead of
 root, and a `./data` directory left by an earlier image is owned by root. The server does not
 complain about that — it starts, serves the dashboard and stores nothing. Once, before you pull:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4930,7 +4930,7 @@ dependencies = [
 
 [[package]]
 name = "weatherdesk"
-version = "3.1.1"
+version = "3.2.0"
 dependencies = [
  "include_dir",
  "mdns-sd",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weatherdesk"
-version = "3.1.1"
+version = "3.2.0"
 description = "Self-hosted WeatherFlow Tempest dashboard"
 authors = ["David May"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "WeatherDesk",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "identifier": "io.github.davidmay87.weatherdesk",
   "build": {
     "frontendDist": "../site"


### PR DESCRIPTION
Version bump, CHANGELOG entry and one README upgrade note. No code changes.

- `Cargo.toml`, `Cargo.lock`, `tauri.conf.json` → 3.2.0
- CHANGELOG entry covering everything in #53, #54, #60 and #62
- README note for Home Assistant users upgrading from 3.1.x: the broker address changes from `ws://host:9001` to `mqtt://host:1883`

39 Rust tests pass, `?selftest` clean.

**Not touched, deliberately:** `PKGBUILD` still says `pkgver=3.0.4`. It has been stale since 3.0.4 and no release commit since has updated it, so fixing it here would be a separate concern riding along in a release PR. Worth its own change if the AUR package is meant to be current.

After merge, the release train runs on the tag:

```
git tag -a v3.2.0 -m "WeatherDesk 3.2.0" && git push origin v3.2.0
```

That builds Linux amd64/arm64 `.deb`, the Android APK, macOS universal, Windows, and the multi-arch container, then opens a **draft** release to publish by hand.

**The add-on repo is waiting on this.** `weatherdesk-addons` builds `FROM ghcr.io/d4vid87/weatherdesk:v3.2.0`, which does not exist until this tag is pushed — the add-on is uninstallable until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)