### PR TITLE
fix: the Android build, which the api module broke at the tag

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,10 @@
 
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 pub mod alerts;
+// `api` reads the archive and the diag table and hands back `server::State` — every one of them
+// desktop-only, so it has to carry the same gate. Without it the Android build is the only thing
+// that notices, at link time, in CI, after the tag is already pushed.
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 pub mod api;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 pub mod cwop;


### PR DESCRIPTION
**v3.2.0's Android job failed.** This is the cause, and it has been on main since #54.

`src-tauri/src/api.rs` imports `crate::{ingest, server::State, store}` and calls `crate::mqtt`. All four modules are gated `#[cfg(not(any(target_os = "android", target_os = "ios")))]` — a phone is not a server for the rest of the house. `pub mod api;` had no such gate, so the Android target compiled it and found none of what it imports.

Nothing else in the project notices. The desktop build, the container, all 39 tests and clippy have all four modules present, so the only thing that catches it is the Android job in the release workflow — which runs *after* the tag is pushed.

Verified both directions with the toolchain locally:

```
$ cargo check --lib --target aarch64-linux-android --no-default-features   # without the gate
error[E0432]: unresolved imports `crate::ingest`, `crate::server`, `crate::store`
error[E0433]: cannot find `server` in `crate`
error[E0433]: cannot find `mqtt` in `crate`

$ cargo check --lib --target aarch64-linux-android --no-default-features   # with it
    Finished `dev` profile
```

39 tests still pass on the desktop target.

## What this means for v3.2.0

Everything else in the release run succeeded — both container images and the multi-arch manifest are already published as `v3.2.0`, and the draft release exists. Only the APK is missing.

Three ways forward, your call:

1. **Re-tag** — merge this, delete the `v3.2.0` tag and its draft release, tag again. The whole train re-runs and overwrites the ghcr images with identical-but-one-commit-newer builds. Nothing has consumed them yet, so this is clean, and the release comes out complete.
2. **Ship 3.2.1** right behind it, with 3.2.0 published minus an APK.
3. **Publish 3.2.0 without the APK** and fold this into the next release. Android users stay on 3.1.1.

I'd take (1): nothing outside this machine has seen v3.2.0 yet, and a release missing its Android build is the kind of thing that gets reported as a bug for months.

## Worth fixing separately

A cheap `cargo check --lib --target aarch64-linux-android` in the PR CI would have caught this in #54 rather than at the tag. Happy to add it if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)