### PR TITLE
docs: a security policy, and why GHSA-82j2-j2ch-gfr8 is not reachable here

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,32 @@
+name: audit
+
+# Advisories against the locked dependency tree. Scoped to `check advisories` on purpose: a full
+# `cargo deny check` also wants a licence allowlist for ~700 crates, which is a separate job of work.
+#
+# The weekly run is the point of this workflow. A new advisory against a lockfile that nobody has
+# touched arrives with no pull request attached, so a PR-only trigger would never see it.
+on:
+  pull_request:
+    paths:
+      - "src-tauri/Cargo.lock"
+      - "src-tauri/Cargo.toml"
+      - "src-tauri/deny.toml"
+      - ".github/workflows/audit.yml"
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  advisories:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          manifest-path: src-tauri/Cargo.toml
+          command: check advisories

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ and the format loosely follows [Keep a Changelog](https://keepachangelog.com/en/
 Every release ships desktop installers (Linux `.deb`, Windows, macOS), an arm64 `.deb` for the
 Raspberry Pi, an Android APK, and the `ghcr.io/d4vid87/weatherdesk` container image.
 
+## [Unreleased]
+
+### Security
+- **The `rustls-webpki` advisory in our dependency tree is not reachable from WeatherDesk, and there
+  is now a written record of why.** The affected 0.102.8 comes in twice, both times under `rumqttc`,
+  the MQTT publisher; the panic it describes (RUSTSEC-2026-0104 / GHSA-82j2-j2ch-gfr8) is in CRL
+  parsing, code that runs only for a revocation list the application hands it, and WeatherDesk hands
+  it none — TLS is configured in exactly two places, both a bare
+  `Transport::tls_with_default_config()`. No upgrade exists yet: the fix is in 0.103.13, there is no
+  0.102.x backport, and `rumqttc 0.25.1` still asks for `rustls-webpki ^0.102.8`. So
+  [SECURITY.md](SECURITY.md) stands in for the bump until a release moves, and `cargo deny check
+  advisories` now fails if the exception stops being true (#55).
+
+### Documentation
+- A [SECURITY.md](SECURITY.md): where to report something, the LAN trust model in one place instead
+  of only halfway down the README, and the analysis above with the commands to check it yourself.
+
 ## [3.2.0] — 2026-08-24
 
 Home Assistant, done properly. The MQTT publisher, the alert engine and the Home Assistant
@@ -422,7 +439,7 @@ tablet on the LAN — vanilla JS, no build step, no framework, no chart library.
 - Radar from [Hook Echo-WX](https://github.com/d4vid87/hookecho)
 - MIT license
 
-[Unreleased]: https://github.com/d4vid87/weatherdesk/compare/v3.0.9...HEAD
+[Unreleased]: https://github.com/d4vid87/weatherdesk/compare/v3.2.0...HEAD
 [3.0.9]: https://github.com/d4vid87/weatherdesk/compare/v3.0.8...v3.0.9
 [3.0.8]: https://github.com/d4vid87/weatherdesk/compare/v3.0.7...v3.0.8
 [3.0.7]: https://github.com/d4vid87/weatherdesk/compare/v3.0.6...v3.0.7

--- a/README.md
+++ b/README.md
@@ -552,6 +552,15 @@ viewport size. Start there — it separates "my token is wrong" from "NWS is dow
 On Windows, if the tablet can't load the LAN URL, it's the firewall prompt that was dismissed on
 first launch — allow WeatherDesk on private networks.
 
+## Security
+
+`GET /config` serves your station token to anything on the LAN, and any LAN client can write
+settings back. That is deliberate — see [Sharing a read-only dashboard](#sharing-a-read-only-dashboard)
+for what to hand out instead, which is `/public`.
+
+To report something, or to read why the `rustls-webpki` advisory a scanner will find in
+`src-tauri/Cargo.lock` is not reachable from this app, see [SECURITY.md](SECURITY.md).
+
 ## License
 
 MIT. See [LICENSE](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,143 @@
+# Security
+
+WeatherDesk is a LAN dashboard for a house, and its trust model is unusually open on purpose. Read
+the next section before deciding whether something is a bug.
+
+## What this app trusts
+
+Anything that can reach port 8088 can read the whole dashboard config, station token included, and
+can write settings back — `GET /config` serves the unredacted blob deliberately, because that is how
+a second browser in the house configures itself without being set up by hand. `/public` and
+`/config-public` are the redacted view, and `/public` is the only address to put behind a proxy or
+in front of a guest. The README's [Sharing a read-only dashboard][share] section is the long
+version. Assume anyone on your network can read your Tempest token and change any setting — the
+broker address discussed below included.
+
+Only the newest release is supported. The desktop builds update themselves, the container's
+`latest` tag moves on every release, and there are no backport branches.
+
+## Reporting something
+
+Open an issue with the version from Settings, how it is installed (Windows, Docker, Pi, APK), and
+the exact request or setting that triggers it. If you would rather not do that in public, open an
+issue with no detail in it and we will find another channel. Reporters are credited by name in the
+changelog.
+
+## Advisories against crates we ship
+
+This section exists so that "the lockfile contains a crate with an advisory" has a written answer in
+the repository, rather than a new pull request every few weeks. An entry here means the advisory has
+been read, the call path traced, and the finding recorded — not that it has been waved away. Every
+entry is mirrored in `src-tauri/deny.toml`, so `cargo deny check advisories` fails in CI if one
+stops being true.
+
+### RUSTSEC-2026-0104 / GHSA-82j2-j2ch-gfr8 — rustls-webpki panic parsing a CRL
+
+**We ship the affected crate. WeatherDesk cannot reach the code that panics.** Assessed 2026-08-24
+against 3.2.0, with `rumqttc 0.25.1` the newest release on crates.io.
+
+`rustls-webpki 0.102.8` is in `src-tauri/Cargo.lock` twice, both times underneath the MQTT client:
+
+    weatherdesk 3.2.0
+    └── rumqttc 0.24.0
+        ├── rustls-webpki 0.102.8              direct — Cargo.lock:3141
+        └── tokio-rustls 0.25.0                Cargo.lock:3144
+            └── rustls 0.22.4
+                └── rustls-webpki 0.102.8      Cargo.lock:3198
+
+Those are the only two paths. Only `rumqttc 0.24.0` and `rustls 0.22.4` depend on `0.102.8`, only
+`tokio-rustls 0.25.0` depends on that `rustls`, and only WeatherDesk depends on `rumqttc`. Every
+other TLS user in the build is already on the fixed line: the advisory is patched in `0.103.13`,
+and `rustls 0.23.43` and `rustls-platform-verifier 0.7.0` both pull `rustls-webpki 0.103.14`
+(`Cargo.lock:3213` and `:3275`) — which is what `ureq 2.12.1` (all of our own HTTPS) and
+`reqwest 0.13.4` (Tauri and the updater) use. The MQTT publisher is the only thing left on the old
+line.
+
+**The advisory states its own precondition.** From the GHSA:
+
+> CRL checking is opt-in in rustls-webpki. This vulnerability affects only applications that
+> explicitly pass RevocationOptions to verify_for_usage() and load CRL bytes from a source the
+> attacker can influence. The default rustls configuration (no RevocationOptions) is not affected.
+
+RustSec puts it in one line: "Applications that do not use CRLs are not affected." The panic is an
+index underflow in `bit_string_flags()` in the crate's `src/der.rs`, reached from the public
+`BorrowedCertRevocationList::from_der()` when a CRL's `issuingDistributionPoint` extension carries
+an empty BIT STRING with zero padding bits. Nothing calls that entry point except revocation
+checking.
+
+**WeatherDesk configures TLS in exactly two places, identically, and neither passes any
+configuration at all.** In `src-tauri/src/mqtt.rs:307-309`, in the publish loop:
+
+```rust
+if tls {
+    opts.set_transport(rumqttc::Transport::tls_with_default_config());
+}
+```
+
+and the same three lines again at `src-tauri/src/mqtt.rs:410-412`, in `probe()` — the connection
+test behind Settings. Those two are the only `Transport::` or `tls_*` calls anywhere in the crate:
+twelve Rust files, `build.rs` included, and no vendored dependencies. `RevocationOptions`,
+`verify_for_usage`, `CertRevocationList`, `add_parsable_crls`, `RootCertStore`, `ClientConfig`,
+`CertificateDer` and `ServerCertVerifier` do not appear in the source at all; neither does the word
+`crl`, in any case; there is no `danger`-prefixed call; and there is no `.pem`, `.der` or `.crl`
+file in the repository. We build no `ClientConfig` of our own, so there is nowhere to put a
+revocation list even if we had one — root certificates come from the platform store inside
+`tls_with_default_config()`, and platform roots are not CRLs. The twelve `ureq` call sites
+(`cwop.rs`, `store.rs`, `ingest.rs`, `alerts.rs`, `api.rs`, `server.rs`) use `get`, `post`,
+`timeout` and `set` and nothing else — no `AgentBuilder`, no TLS connector, no custom root store.
+`verify_for_usage()` is therefore only ever called by rustls' own default verifier, with
+`RevocationOptions` absent, which is the configuration the advisory names as unaffected.
+
+**The honest part: a hostile server certificate can reach that crate. A hostile CRL cannot.** The
+broker address is a setting. `mqttUrl` is typed into the settings drawer (`site/js/boot.js:459`)
+and written through the LAN settings route (`src-tauri/src/server.rs:174`), which takes no
+credentials by default, and `conf()` in `src-tauri/src/mqtt.rs:88` reads it straight back. Anyone
+who can reach port 8088 can therefore point the MQTT client at a host they control and feed a chain
+of their choosing into `0.102.8`'s chain building. We are not claiming the affected crate never
+sees attacker-controlled bytes. We are claiming the *panicking* path never runs: it is in CRL
+parsing, which executes only for a revocation list the application supplied alongside
+`RevocationOptions` it constructed. Neither of the advisory's two attack paths applies — we are not
+an mTLS server checking client certificates, and we fetch no CRL distribution point to be MITM'd. A
+hostile broker gets what a broken one gets: the handshake fails, the disconnect reason is logged
+without the URL (it can carry a password), and the publish loop retries.
+
+MQTT is also off in a stock install. `conf()` returns `None` until both `mqttUrl` and `stationId`
+are set, and the loop sleeps. On most installs neither call site ever executes.
+
+**There is nothing to upgrade to yet.** The fix ships in `0.103.13`. The `0.102` line ends at
+`0.102.8` and never received a backport, so `cargo update` has nowhere to go, and `0.102 → 0.103`
+is a semver break it cannot cross on its own — the requirement has to come from `rumqttc`. It does
+not: `rumqttc 0.25.1`, the newest release, still declares `rustls-webpki = "^0.102.8"`, a caret on
+the affected line that cannot resolve to `0.103` at all. It does move to `tokio-rustls 0.26`,
+dropping the second path, but the direct dependency keeps the crate in the lockfile and the
+advisory with it. That leaves two ways to remove it outright, both costing more than an unreachable
+panic: `rumqttc`'s `use-native-tls` feature, which drags OpenSSL into the Linux and cross-compiled
+release builds that today need no system TLS at all — there is no `native-tls` anywhere in the
+lockfile, and that is the point — or dropping MQTT TLS, which breaks every `mqtts://` broker.
+
+**What would change this.** A `rumqttc` release that asks for `rustls-webpki 0.103`, directly and
+through whichever `tokio-rustls` it picks up, turns this into a one-line bump in
+`src-tauri/Cargo.toml` plus `cargo update -p rumqttc`, and this entry becomes a changelog line. A
+`0.102.x` backport would be a one-line `cargo update --precise`. Until one of those exists, this
+section is the answer to an advisory PR against `rustls-webpki` in this repository. A pull request
+that performs the upgrade, or that shows the argument above is wrong, is very welcome; one that
+edits unrelated lockfile entries is not.
+
+**Checking this yourself.** With a network, from `src-tauri`:
+
+    cargo tree -i rustls-webpki@0.102.8      # every path in — expect the two above
+    cargo tree -i rustls-webpki@0.103.14     # the patched copy, and everything already using it
+    cargo audit                              # names the advisory and the same two paths
+    cargo deny check advisories              # the same, and enforces the exception recorded here
+
+Offline, the lockfile and the source answer the same questions:
+
+    grep -n 'rustls-webpki 0.102.8' src-tauri/Cargo.lock          # the reverse-dependency list
+    grep -rn 'Transport::\|tls_' --include='*.rs' src-tauri/      # every TLS call site: two
+    grep -rniE 'RevocationOptions|verify_for_usage|CertRevocationList|add_parsable_crls|crl' \
+      --include='*.rs' src-tauri/                                 # no matches at all
+
+`cargo tree` needs the registry index and `cargo audit` the advisory database, so both want a
+network on a cold checkout — `cargo fetch` first. The greps need neither.
+
+[share]: README.md#sharing-a-read-only-dashboard

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -42,6 +42,8 @@ ureq = "2"
 include_dir = "0.7"
 # MQTT for the Home Assistant integration. The blocking client: this binary has no async
 # runtime and does not want one for a publish every ten seconds.
+# Pins us to rustls-webpki 0.102.8, which carries RUSTSEC-2026-0104 — a CRL-parsing panic this app
+# cannot reach, because it passes no RevocationOptions. Read SECURITY.md before "fixing" it.
 rumqttc = "0.24"
 # Advertise the dashboard on the LAN: how Home Assistant's config flow finds this server, and
 # how the setup wizard finds a WeatherLink Live (which advertises the same way).

--- a/src-tauri/deny.toml
+++ b/src-tauri/deny.toml
@@ -1,0 +1,11 @@
+# cargo-deny configuration. Only the advisories check runs in CI (see .github/workflows/audit.yml) —
+# licences, bans and sources are not policed yet, and turning them on needs an allowlist for a
+# ~700-crate tree rather than a one-line change here.
+#
+# Every entry below is written up in ../SECURITY.md. Adding one without the writeup defeats the
+# point: the file exists so an accepted advisory has a reason attached, not so the check goes quiet.
+
+[advisories]
+ignore = [
+  { id = "RUSTSEC-2026-0104", reason = "rustls-webpki 0.102.8 CRL parsing panic (GHSA-82j2-j2ch-gfr8). Reached only through rumqttc's TLS transport, and only by an application that passes RevocationOptions to verify_for_usage() and hands it CRL bytes. This one never constructs RevocationOptions, builds no ClientConfig, and loads no CRL — TLS is configured in exactly two places, both a bare Transport::tls_with_default_config() in src/mqtt.rs. See SECURITY.md for the full path analysis. The fix is in 0.103.13 with no 0.102.x backport, and rumqttc 0.25.1 still requires rustls-webpki ^0.102.8, so there is nothing to upgrade to. Drop this entry the moment a rumqttc release asks for rustls-webpki 0.103." },
+]


### PR DESCRIPTION
Follow-up to #55, which was closed for changing six `windows-sys` lockfile entries and a `rumqttc`
version string while leaving `rustls-webpki` untouched. The upgrade still isn't available, so this
delivers the other thing you said would be welcome: the reachability analysis, written down in the
repository so the next advisory PR can be answered from a file.

Rebased on `main` at 4398d3f (v3.2.0), and every claim below re-derived against that tree rather
than the one #55 was opened against. The release bump shifted nothing structural: the `Cargo.lock`
edit in it was a one-for-one swap of the `weatherdesk` version line, so every line number cited
below still resolves, both TLS call sites are unmoved, and the twelve-Rust-file grep is unchanged.

## The finding

**We ship the affected crate and cannot reach the code that panics.**

- `rustls-webpki 0.102.8` appears twice in `src-tauri/Cargo.lock`, both under `rumqttc 0.24.0`:
  directly (`:3141`) and through `tokio-rustls 0.25.0` → `rustls 0.22.4` (`:3198`). Those are the
  only two paths, and `rumqttc` is the only thing that reaches either.
- Everything else already runs on the fixed line. The advisory is patched in **0.103.13**, and
  `rustls 0.23.43` and `rustls-platform-verifier 0.7.0` both pull `rustls-webpki 0.103.14`
  (`:3213`, `:3275`) — which is what `ureq 2.12.1` (all of our own HTTPS) and `reqwest 0.13.4`
  (Tauri, the updater) use.
- The advisory's own precondition is an application that passes `RevocationOptions` to
  `verify_for_usage()` and loads attacker-influenceable CRL bytes; RustSec's one-liner is
  "Applications that do not use CRLs are not affected." We configure TLS in exactly two places —
  `src-tauri/src/mqtt.rs:307-309` and `:410-412`, both a bare
  `Transport::tls_with_default_config()` — and those are the only `Transport::`/`tls_*` calls in
  twelve Rust files. `RevocationOptions`, `verify_for_usage`, `CertRevocationList`,
  `add_parsable_crls`, `ClientConfig`, `RootCertStore` and `crl` appear nowhere in the source, and
  there is no `.pem`, `.der` or `.crl` in the tree.
- Stated in the writeup rather than buried: a hostile *server certificate* can reach 0.102.8,
  because `mqttUrl` is a setting any LAN client can write (`src-tauri/src/server.rs:174`). The
  panicking path still can't be reached, because it needs a CRL we never supply, and neither of the
  advisory's two attack paths (mTLS client-cert checking, MITM of a fetched CRL distribution point)
  describes this app.

## Why not the upgrade

The `0.102` line ends at `0.102.8` with no backport, and `0.102 → 0.103` is a semver break
`cargo update` can't cross — the requirement has to come from `rumqttc`. It doesn't:
**`rumqttc 0.25.1`, the newest release, still declares `rustls-webpki = "^0.102.8"`** — a caret
pinned to the affected line, so it can't resolve to `0.103` at all. It does move to
`tokio-rustls 0.26`, dropping the second path, but the direct dependency keeps the crate. Checked
against crates.io while writing this; the moment a release asks for `0.103` this is a one-line bump
and the entry becomes a changelog line.

## What changed

- **`SECURITY.md`** (new) — reporting channel, the LAN trust model in one place instead of only
  halfway down the README, and the analysis above with commands to re-verify it.
- **`src-tauri/deny.toml`** (new) — the `RUSTSEC-2026-0104` exception with its reason, so the
  finding is machine-readable and not just prose.
- **`.github/workflows/audit.yml`** (new) — `cargo deny check advisories` on lockfile-touching PRs,
  on `main`, and weekly. Scoped to `advisories` deliberately: a full `cargo deny check` also wants a
  licence allowlist for ~700 crates, which is its own job of work. The weekly run is the real point
  — a new advisory against a lockfile nobody has touched arrives with no PR attached.
- **`README.md`** — a short `## Security` section pointing at it, before `## License`.
- **`CHANGELOG.md`** — a new `## [Unreleased]` with `### Security` and `### Documentation` entries.
  Also retargets the stale `[Unreleased]:` link def, which still pointed at `v3.0.9...HEAD`; adding
  the heading would otherwise have made a wrong link live.
- **`src-tauri/Cargo.toml`** — one comment on `rumqttc`, matching the per-dependency justifications
  already there, so the next person to look sees it before they "fix" it.

## What deliberately didn't change

**No `Cargo.lock` diff, no dependency change, no version pin.** Given what #55 did, that's the
review check worth doing first:

```
git diff --stat main...HEAD          # three markdown files, a comment, and two new config files
git diff main...HEAD -- src-tauri/   # comment + deny.toml only, zero Cargo.lock lines
```

I also left `rumqttc = "0.24"` alone rather than adopting #55's `"0.24.0"` — pinning the patch level
in a caret requirement gains nothing and costs future patch updates.

## Two things worth knowing

**`deny.toml` will not stop the re-filing.** It's read only by `cargo-deny`; #55 came from a
GitHub-advisory-driven bot. Silencing that is Security → Dependabot alerts → the `rustls-webpki`
alert → Dismiss → "Risk is tolerable to this project", ideally with a comment linking to
`SECURITY.md`. No file in a PR can do it.

**This is the repo's first `pull_request` CI job**, since `release.yml` is tags-only — so it changes
the contribution flow, and it's reasonable to want that as a separate decision. Happy to split the
workflow and `deny.toml` out into their own PR and leave this one as pure documentation; say the word.

The reporting section points at the issue tracker rather than the private-advisory form, because
that URL 404s unless private vulnerability reporting is enabled in settings. Enable it and I'll
switch the link.

## To check it

```
grep -rn 'Transport::\|tls_' --include='*.rs' src-tauri/       # two hits, both bare defaults
grep -rniE 'RevocationOptions|verify_for_usage|CertRevocationList|crl' --include='*.rs' src-tauri/  # none
cd src-tauri && cargo tree -i rustls-webpki@0.102.8 && cargo deny check advisories
```

One caveat on my side: I could not run `cargo deny` in my environment, so the workflow has never
executed. Worth watching its first run here — if the ignore entry were wrong it would pass green
either way, which is the failure mode to catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

