### PR TITLE
fix: three panels that painted over their own readings

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -242,7 +242,10 @@
   /* hero */
   #hero-fx { position: absolute; inset: 0; pointer-events: none; }
   /* the canvas is positioned, so the content has to be too or it paints underneath */
-  #hero > *:not(#hero-fx):not(#hero-icon) { position: relative; z-index: 1; }
+  /* The grip and the resize handles are excluded on purpose: three id selectors outrank
+     `.grip { position: absolute }`, so without this the furniture fell into the flow and the grip
+     painted as a black chip over the clock. They carry their own z-index, above the canvas. */
+  #hero > *:not(#hero-fx):not(#hero-icon):not(.grip):not(.rz) { position: relative; z-index: 1; }
   #hero > #hero-icon { z-index: 1; }
   #hero { padding: 16px 20px 20px; color: var(--hero-text, #fff); overflow: hidden; border-radius: 12px;
     background: linear-gradient(160deg, #1f6fb8, #7fb6e6); }
@@ -373,6 +376,11 @@
   .ginner b { font-size: 26px; font-weight: 600; }
   .ginner small { font-size: 11px; color: var(--muted); }
   .ginner span { font-size: 12px; color: #cdd7e2; max-width: 118px; }
+  /* Every other face is a ring with a hole in it, which is where the readout goes. The thermometer
+     is a solid column up the middle of the same box, so the readout landed on the glass — the
+     column moves to the left of the face and the readout to the right of it. */
+  .gwrap:has(svg.therm) .ginner { align-items: flex-end; text-align: right; padding-right: 6px; }
+  .gwrap:has(svg.therm) .ginner span { max-width: 74px; }
 
   .chart { width: 100%; height: 150px; display: block; }
   #places { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; }
@@ -471,7 +479,12 @@
   #add-station-id { flex: 1; padding: 8px; background: var(--bg); color: var(--text);
     border: 1px solid var(--line); border-radius: 8px; font: inherit; }
   #lab-frame { width: 100%; height: 100%; border: 0; display: block; }
-  #notif-stack { position: absolute; top: 8px; right: 8px; width: min(340px, calc(100% - 16px)); z-index: 30; }
+  /* In flow, not over the top of the page: absolute put the stack on the hero's right column, and
+     a severe banner never times out, so a warning hid the sun and moon times for as long as it ran.
+     Sticky keeps it on screen while the page scrolls; `:empty` means it costs no space unbannered. */
+  #notif-stack { position: sticky; top: 8px; width: min(340px, calc(100% - 16px));
+    margin: 0 8px 0 auto; z-index: 30; }
+  #notif-stack:empty { display: none; }
   .notif { background: var(--panel2); border: 1px solid var(--line); border-left: 3px solid var(--accent);
     border-radius: 8px; padding: 8px 28px 8px 10px; margin-bottom: 6px; position: relative; }
   .notif-severe { border-left-color: var(--bad); }

--- a/site/js/icons.js
+++ b/site/js/icons.js
@@ -195,12 +195,15 @@ export function boltRing(frac, active) {
 export function thermometer(frac, color = '#4fdc8b') {
   const f = clamp01(frac);
   const top = 74 - f * 52;
-  return `<svg viewBox="0 0 100 100">
-    <rect x="43" y="16" width="14" height="60" rx="7" fill="none" stroke="#2b3745" stroke-width="3"/>
-    <rect x="46" y="${top.toFixed(1)}" width="8" height="${(76 - top).toFixed(1)}" rx="4" fill="${color}"/>
-    <circle cx="50" cy="80" r="11" fill="${color}"/>
-    <circle cx="50" cy="80" r="11" fill="none" stroke="#2b3745" stroke-width="3"/>
-    ${[0, 1, 2, 3].map((i) => `<line x1="60" y1="${24 + i * 15}" x2="68" y2="${24 + i * 15}"
+  // Drawn on the left of the box, not through the middle: the readout is centred over a ring face,
+  // and a column up the centre is the one face it cannot be centred over. The class is what the
+  // gauge CSS keys the right-aligned readout off.
+  return `<svg class="therm" viewBox="0 0 100 100">
+    <rect x="17" y="16" width="14" height="60" rx="7" fill="none" stroke="#2b3745" stroke-width="3"/>
+    <rect x="20" y="${top.toFixed(1)}" width="8" height="${(76 - top).toFixed(1)}" rx="4" fill="${color}"/>
+    <circle cx="24" cy="80" r="11" fill="${color}"/>
+    <circle cx="24" cy="80" r="11" fill="none" stroke="#2b3745" stroke-width="3"/>
+    ${[0, 1, 2, 3].map((i) => `<line x1="34" y1="${24 + i * 15}" x2="42" y2="${24 + i * 15}"
       stroke="#3a4655" stroke-width="2"/>`).join('')}
   </svg>`;
 }


### PR DESCRIPTION
Three display bugs, one root cause each, all reported off a photo of the kiosk.

**The grip on the clock.** `#hero > *:not(#hero-fx):not(#hero-icon)` exists to lift the hero's children above the fx canvas, but `:not(#id)` carries the id's specificity — at (3,0,0) it also outranked `.grip { position: absolute }`. The hero is the only panel with an id rule over its own children, so it was the only panel where the drag grip and the three resize handles fell into normal flow. The grip painted as a dark chip directly on the clock, at full strength on a touchscreen because that matches `hover: none`, and the in-flow furniture padded the hero ~98px taller than it should be. The furniture is excluded from the rule now and keeps its own `position: absolute` and `z-index: 6`.

**The thermometer gauges.** Every other face is a ring, and the readout is centred in its hole. The thermometer is a solid column up the middle of the same box, so the number and the label sat on the glass — wet bulb and WBGT both. The column draws on the left of the viewBox and the readout right-aligns beside it, keyed off a `therm` class on the svg. Rings are untouched.

**The banner over the hero.** `#notif-stack` was `position: absolute; top: 8px; right: 8px` inside `<main>` — exactly where the hero puts sunset, moonrise, the live chip and the battery. Severe banners never time out, so an active warning hid all four for as long as it ran. The stack goes in the flow, right-aligned and sticky, with `:empty` so it costs no space when there are no banners.

### Verification

Measured in a real Chrome against the served page, not asserted in the abstract:

```
before:  grip pos=relative @15,209    hero 1327x322
after:   grip pos=absolute @1292,5    hero 1327x224
```

`rz-e`, `rz-s` and `rz-se` are back on their edges. Screenshots confirm the clock is clear, the banner sits above the hero with the right column readable, and the two thermometer gauges read `78° / Air 92°` and `80° / estimated · Moderate` with nothing overlapping.

CSS only plus the one svg — no Rust, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)