### PR TITLE
fix: the Android app on a real phone

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -94,7 +94,8 @@
     border-radius: 8px; padding: 6px 10px; cursor: pointer; font: inherit; }
   main { flex: 1; overflow: hidden; position: relative; }
   section.page { display: none; height: 100%; overflow: auto;
-    padding: var(--gap) var(--gap) calc(var(--gap) + env(safe-area-inset-bottom)); }
+    padding: var(--gap) calc(var(--gap) + env(safe-area-inset-right))
+      calc(var(--gap) + env(safe-area-inset-bottom)) calc(var(--gap) + env(safe-area-inset-left)); }
   section.page.active { display: block; }
 
   /* cap columns so an ultrawide doesn't smear 8 cards into one thin row */
@@ -150,7 +151,10 @@
   /* settings drawer */
   #drawer {
     position: absolute; inset: 0 0 0 auto; width: min(420px, 100%); background: var(--panel);
-    border-left: 1px solid var(--line); padding: var(--gap); overflow: auto;
+    border-left: 1px solid var(--line); overflow: auto;
+    /* the drawer scrolls to the bottom edge of the window, so the gesture bar sits on its last
+       control unless the inset is paid here too */
+    padding: var(--gap) var(--gap) calc(var(--gap) + env(safe-area-inset-bottom));
     transform: translateX(100%); transition: transform .18s ease; z-index: 20;
   }
   #drawer.open { transform: none; }
@@ -172,7 +176,11 @@
   #desk { padding: 0; }
   /* One flat 12-column grid holds every Desk panel, so anything can be dragged anywhere —
      the radar included. Column span is what a horizontal resize edits. */
-  #desk-stack { max-width: 1560px; margin: 0 auto; padding: var(--gap); display: grid;
+  /* #desk pays no padding, so this owes the insets section.page would have paid — without them the
+     last panel sits under the gesture bar, and in landscape the right edge does too. */
+  #desk-stack { max-width: 1560px; margin: 0 auto;
+    padding: var(--gap) calc(var(--gap) + env(safe-area-inset-right))
+      calc(var(--gap) + env(safe-area-inset-bottom)) calc(var(--gap) + env(safe-area-inset-left)); display: grid;
     grid-template-columns: repeat(12, minmax(0, 1fr)); gap: var(--gap); align-items: start; }
   #desk-stack > * { grid-column: span 12; }
   #desk-radar { grid-column: span 6; grid-row: span 2; }
@@ -402,11 +410,17 @@
     body { font-size: 14px; }
     .now-temp { font-size: 52px; }
     .chart { height: 120px; }
-    header { padding: 5px 10px; }
+    /* Tighter, but the insets still have to be paid: a bare padding here overwrote them and put
+       the status bar back on top of the tabs. */
+    header { padding: calc(5px + env(safe-area-inset-top)) calc(10px + env(safe-area-inset-right))
+      5px calc(10px + env(safe-area-inset-left)); }
   }
   /* phone: one column, and saved column spans stop applying — a panel resized to a third of a
      desktop screen is unreadable on a handset, and the layout is per-install, not per-device. */
-  @media (max-width: 720px) {
+  /* A phone is compact in both orientations. Landscape is 780x360 on a modern handset: too wide
+     for a width-only query, and every reason for these rules still holds — no mouse, no room for
+     panel furniture, and saved desktop pixel sizes that do not fit either way. */
+  @media (max-width: 720px), (max-height: 500px) {
     #desk-stack, #desk-stack > *, #desk-radar, #trends, #c48 { grid-column: span 12 !important; }
     #desk-radar { grid-row: span 1; height: 340px !important; min-height: 0; }
     .grid { grid-template-columns: 1fr; }
@@ -456,7 +470,10 @@
     .hero-right { text-align: left; }
     #hero { padding: 12px 14px 16px; }
     #clock-time { font-size: 40px; }
-    #hero-icon { right: 10px; }
+    /* 150px of sun beside a 40px clock is 150px of sun on top of it. Small enough to sit in the
+       corner the stacked hero leaves empty. */
+    #hero-icon { right: 8px; top: 8px; }
+    #hero-icon svg { width: 84px; height: 84px; }
     #hero-temp { font-size: 64px; }
     #hero-cond { font-size: 22px; }
     .hero-now { gap: 12px; }
@@ -464,6 +481,15 @@
     .sig-row { grid-template-columns: 1.5fr .8fr 1fr .9fr 20px; font-size: 12px; }
     .sig-row > span:nth-child(3), .sig-row > span:nth-child(5) { display: none; }
     .sig-row .fail { grid-column: 2 / -2 !important; }
+  }
+  /* A phone in landscape is compact by height, not by width: the hero's two columns fit side by
+     side again, and stacking them there costs the rows below the fold. */
+  @media (min-width: 721px) and (max-height: 500px) {
+    .hero-top { flex-direction: row; }
+    /* the right column runs back under the icon once it is a row again */
+    .hero-right { text-align: right; padding-right: 96px; }
+    #daycards, #gauges { grid-template-columns: repeat(4, 1fr); }
+    .grid { grid-template-columns: 1fr 1fr; }
   }
   .live-wind-wrap { display: flex; align-items: center; gap: 16px; }
   .compass { width: 74px; height: 74px; border: 2px solid var(--line); border-radius: 50%;
@@ -483,7 +509,10 @@
      a severe banner never times out, so a warning hid the sun and moon times for as long as it ran.
      Sticky keeps it on screen while the page scrolls; `:empty` means it costs no space unbannered. */
   #notif-stack { position: sticky; top: 8px; width: min(340px, calc(100% - 16px));
-    margin: 0 8px 0 auto; z-index: 30; }
+    margin: 0 8px 0 auto; z-index: 30;
+    /* In flow it pushes, and four banners are taller than a phone in landscape — the dashboard
+       was off the bottom of the screen behind its own warnings. The stack scrolls instead. */
+    max-height: 45vh; overflow-y: auto; }
   #notif-stack:empty { display: none; }
   .notif { background: var(--panel2); border: 1px solid var(--line); border-left: 3px solid var(--accent);
     border-radius: 8px; padding: 8px 28px 8px 10px; margin-bottom: 6px; position: relative; }

--- a/site/index.html
+++ b/site/index.html
@@ -242,7 +242,10 @@
   /* hero */
   #hero-fx { position: absolute; inset: 0; pointer-events: none; }
   /* the canvas is positioned, so the content has to be too or it paints underneath */
-  #hero > *:not(#hero-fx):not(#hero-icon) { position: relative; z-index: 1; }
+  /* The grip and the resize handles are excluded on purpose: three id selectors outrank
+     `.grip { position: absolute }`, so without this the furniture fell into the flow and the grip
+     painted as a black chip over the clock. They carry their own z-index, above the canvas. */
+  #hero > *:not(#hero-fx):not(#hero-icon):not(.grip):not(.rz) { position: relative; z-index: 1; }
   #hero > #hero-icon { z-index: 1; }
   #hero { padding: 16px 20px 20px; color: var(--hero-text, #fff); overflow: hidden; border-radius: 12px;
     background: linear-gradient(160deg, #1f6fb8, #7fb6e6); }
@@ -373,6 +376,11 @@
   .ginner b { font-size: 26px; font-weight: 600; }
   .ginner small { font-size: 11px; color: var(--muted); }
   .ginner span { font-size: 12px; color: #cdd7e2; max-width: 118px; }
+  /* Every other face is a ring with a hole in it, which is where the readout goes. The thermometer
+     is a solid column up the middle of the same box, so the readout landed on the glass — the
+     column moves to the left of the face and the readout to the right of it. */
+  .gwrap:has(svg.therm) .ginner { align-items: flex-end; text-align: right; padding-right: 6px; }
+  .gwrap:has(svg.therm) .ginner span { max-width: 74px; }
 
   .chart { width: 100%; height: 150px; display: block; }
   #places { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; }
@@ -471,7 +479,12 @@
   #add-station-id { flex: 1; padding: 8px; background: var(--bg); color: var(--text);
     border: 1px solid var(--line); border-radius: 8px; font: inherit; }
   #lab-frame { width: 100%; height: 100%; border: 0; display: block; }
-  #notif-stack { position: absolute; top: 8px; right: 8px; width: min(340px, calc(100% - 16px)); z-index: 30; }
+  /* In flow, not over the top of the page: absolute put the stack on the hero's right column, and
+     a severe banner never times out, so a warning hid the sun and moon times for as long as it ran.
+     Sticky keeps it on screen while the page scrolls; `:empty` means it costs no space unbannered. */
+  #notif-stack { position: sticky; top: 8px; width: min(340px, calc(100% - 16px));
+    margin: 0 8px 0 auto; z-index: 30; }
+  #notif-stack:empty { display: none; }
   .notif { background: var(--panel2); border: 1px solid var(--line); border-left: 3px solid var(--accent);
     border-radius: 8px; padding: 8px 28px 8px 10px; margin-bottom: 6px; position: relative; }
   .notif-severe { border-left-color: var(--bad); }

--- a/site/js/icons.js
+++ b/site/js/icons.js
@@ -195,12 +195,15 @@ export function boltRing(frac, active) {
 export function thermometer(frac, color = '#4fdc8b') {
   const f = clamp01(frac);
   const top = 74 - f * 52;
-  return `<svg viewBox="0 0 100 100">
-    <rect x="43" y="16" width="14" height="60" rx="7" fill="none" stroke="#2b3745" stroke-width="3"/>
-    <rect x="46" y="${top.toFixed(1)}" width="8" height="${(76 - top).toFixed(1)}" rx="4" fill="${color}"/>
-    <circle cx="50" cy="80" r="11" fill="${color}"/>
-    <circle cx="50" cy="80" r="11" fill="none" stroke="#2b3745" stroke-width="3"/>
-    ${[0, 1, 2, 3].map((i) => `<line x1="60" y1="${24 + i * 15}" x2="68" y2="${24 + i * 15}"
+  // Drawn on the left of the box, not through the middle: the readout is centred over a ring face,
+  // and a column up the centre is the one face it cannot be centred over. The class is what the
+  // gauge CSS keys the right-aligned readout off.
+  return `<svg class="therm" viewBox="0 0 100 100">
+    <rect x="17" y="16" width="14" height="60" rx="7" fill="none" stroke="#2b3745" stroke-width="3"/>
+    <rect x="20" y="${top.toFixed(1)}" width="8" height="${(76 - top).toFixed(1)}" rx="4" fill="${color}"/>
+    <circle cx="24" cy="80" r="11" fill="${color}"/>
+    <circle cx="24" cy="80" r="11" fill="none" stroke="#2b3745" stroke-width="3"/>
+    ${[0, 1, 2, 3].map((i) => `<line x1="34" y1="${24 + i * 15}" x2="42" y2="${24 + i * 15}"
       stroke="#3a4655" stroke-width="2"/>`).join('')}
   </svg>`;
 }

--- a/src-tauri/.cargo/config.toml
+++ b/src-tauri/.cargo/config.toml
@@ -1,0 +1,15 @@
+# Android 15 and up can run with 16 KB memory pages, and refuses to load a shared library whose
+# LOAD segments are aligned to the old 4 KB. NDK r27 links this way by default; r26 and the
+# Android Gradle plugin's own toolchain do not, and the only warning is a dialog on the device
+# after install. Harmless where it is already the default.
+[target.aarch64-linux-android]
+rustflags = ["-C", "link-arg=-Wl,-z,max-page-size=16384"]
+
+[target.armv7-linux-androideabi]
+rustflags = ["-C", "link-arg=-Wl,-z,max-page-size=16384"]
+
+[target.i686-linux-android]
+rustflags = ["-C", "link-arg=-Wl,-z,max-page-size=16384"]
+
+[target.x86_64-linux-android]
+rustflags = ["-C", "link-arg=-Wl,-z,max-page-size=16384"]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,10 @@
 
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 pub mod alerts;
+// `api` reads the archive and the diag table and hands back `server::State` — every one of them
+// desktop-only, so it has to carry the same gate. Without it the Android build is the only thing
+// that notices, at link time, in CI, after the tag is already pushed.
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 pub mod api;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 pub mod cwop;


### PR DESCRIPTION
Driven off an S24 Ultra over adb — debug build with the webview inspector attached, both orientations, every tab, then the signed release APK installed back on the phone to confirm.

Supersedes #64 and #66: both are cherry-picked here as their own commits, so this branch is main + the Android build fix + the three panel fixes + the work below. Merge this and close those, or merge them first — either order works.

### 16 KB page size
Android 15 and up refuses to load a shared library whose LOAD segments are 4 KB aligned, and puts a dialog in front of the user on first launch:

> This app isn't 16 KB compatible. ELF alignment check failed. … lib/arm64-v8a/libweatherdesk_lib.so : LOAD segment not aligned

NDK r26 (what the Gradle plugin picks up here) links that way. New `src-tauri/.cargo/config.toml` adds `-Wl,-z,max-page-size=16384` for all four Android targets. `llvm-readelf -l` on the release APK now reports `0x4000` on every LOAD segment.

### A phone in landscape missed the phone stylesheet entirely
It is 780×360, and the query was `max-width: 720px`. So in landscape the app got the desktop treatment: drag grips and resize handles over the panel titles, saved desktop pixel widths, the wordmark eating the tab bar, and 150px of hero icon painted on the clock. The query is now compact by width *or* height, with the grid columns and the hero's two-column top restored for the wide-and-short case.

### Safe-area insets
- The tablet-landscape rule reset `header`'s padding and took the insets with it — status bar back on top of the tabs.
- `#desk-stack` and the settings drawer never paid the bottom inset, so the last panel and the last control sat under the gesture bar.
- In landscape the gesture bar is on the *right*, and nothing paid the horizontal insets at all.

### The notification stack ate the screen
In flow since #66 stopped it covering the hero, and four banners are taller than a phone in landscape — the dashboard was entirely behind its own warnings. It scrolls at `45vh` now.

### Verification
`cargo test` — 39 passed. Release APK built and signed with the upload key, installed over adb, screenshotted in both orientations and on all four tabs: hero legible, no panel furniture, nothing under a system bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)