### PR TITLE
3.2.1: AppImage + working Linux updater, #37, WeeWX docs, default layout, click-to-detail

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,8 +46,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # x86_64 gets the AppImage too — Tauri's Linux updater can only install an
+          # AppImage, and the bundler is x86_64-only, so the bundle list is explicit per arch.
           - platform: ubuntu-22.04
-            args: ""
+            args: "--bundles deb,appimage"
             targets: ""
           # One universal APK: arm64 for anything current, armv7 so a 32-bit Fire tablet still
           # installs it. Signed with the upload key held in repo secrets — same key forever, or
@@ -59,7 +61,7 @@ jobs:
           # Raspberry Pi 4/5 on 64-bit Pi OS. Native arm64 runner, not a cross-compile:
           # WebKitGTK doesn't cross-link cleanly and the runner is free for public repos.
           - platform: ubuntu-22.04-arm
-            args: ""
+            args: "--bundles deb"
             targets: ""
           - platform: windows-latest
             args: ""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ Raspberry Pi, an Android APK, and the `ghcr.io/d4vid87/weatherdesk` container im
 
 ## [Unreleased]
 
+## [3.2.1] - 2026-08-30
+
+### Added
+- **A Linux AppImage, and with it a Linux updater that actually works.** The in-app updater can
+  only install an AppImage on Linux, and no release shipped one — every "check for updates"
+  click on Linux was a path that could not complete. x86_64 releases now bundle an AppImage and
+  `latest.json` points the updater at it. On a `.deb` (or any non-AppImage) install the updater
+  now says to update through the package manager instead of failing.
+- **A designed default layout.** A fresh install, a new browser and the reset button all land on
+  a designed arrangement — current conditions, gauges, day cards, radar, then the core four
+  cards — instead of raw markup order. Saved arrangements still win; only the starting point
+  changed.
+- **`--version` and `--check`.** `weatherdesk --check` asks the running server for its source
+  and the age of the last reading, and exits non-zero if nothing has landed — a headless Pi
+  install no longer needs a browser to be verified.
+- **WeeWX, documented.** WeeWX's Weather Underground uploader pointed at
+  `/updateweatherstation.php` feeds WeatherDesk today; [docs/weewx.md](docs/weewx.md) has the
+  five-line stanza (#47).
+
+### Fixed
+- **Switching station brands now really leaves Tempest behind (#37).** Choosing a non-Tempest
+  brand cleared the device ID but left the token and station ID, so the forecast kept coming
+  from WeatherFlow. All three are cleared on a brand switch, and the forecast routes to
+  open-meteo whenever a non-Tempest source is set, even over a stale token.
+- **A public Tempest station that returns 401 says why (#38).** WeatherFlow only serves a
+  station's data to its owner's token; the wizard and diagnostics now say so where the ID was
+  typed, instead of a bare 401.
+
 ### Security
 - **The `rustls-webpki` advisory in our dependency tree is not reachable from WeatherDesk, and there
   is now a written record of why.** The affected 0.102.8 comes in twice, both times under `rumqttc`,

--- a/README.md
+++ b/README.md
@@ -295,7 +295,11 @@ tab don't share settings.
 Grab the installer for your OS from [Releases](https://github.com/d4vid87/weatherdesk/releases) and
 double-click it. What changed in each version is in [CHANGELOG.md](CHANGELOG.md). The app opens in its own window *and* serves the same dashboard to the rest of your
 network on port 8088 — the wall tablet just opens the URL shown in the window title. Nothing else to
-install; leave the app running.
+install; leave the app running. On Linux, the `.AppImage` runs on any distro and is the build
+the in-app updater can update in place; the `.deb` updates through `apt` instead.
+
+Already running [WeeWX](https://weewx.com)? It can feed WeatherDesk with a five-line config
+stanza — see [docs/weewx.md](docs/weewx.md).
 
 **One config for the whole house.** The desktop app also keeps your settings and dashboard layout
 on the host computer. Any browser that opens the LAN URL loads that configuration — no re-typing the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -141,3 +141,41 @@ Offline, the lockfile and the source answer the same questions:
 network on a cold checkout — `cargo fetch` first. The greps need neither.
 
 [share]: README.md#sharing-a-read-only-dashboard
+
+### The 2026-08 advisory batch — three more rustls-webpki findings, and a wall of "unmaintained"
+
+The advisories run on `main` started failing on 2026-08-26 when the RustSec database grew a
+batch of new entries against crates this tree already shipped. Every one is recorded in
+`src-tauri/deny.toml` with a reason; the summary:
+
+**rustls-webpki 0.102.8, again** (RUSTSEC-2026-0049, -0098, -0099). Same crate, same tree and
+same constraint as RUSTSEC-2026-0104 above: the fixes are in 0.103.x, there is no 0.102.x
+backport, and `rumqttc 0.25.1` still requires `^0.102.8`, so there is nothing to upgrade to.
+Reachability differs per advisory:
+
+- **-0049 (CRL Distribution Point matching):** unreachable for the same reason as -0104 — this
+  application loads no CRLs, so all CRL handling is dead code here.
+- **-0098 / -0099 (name-constraint acceptance for URI and wildcard names):** these sit in
+  certificate validation proper, which *does* run when MQTT-over-TLS is configured. The exposure
+  requires the user's broker to present a certificate chained through a CA that issues
+  name-constrained certificates that a correct validator would reject. The deployment this app
+  supports — a LAN broker with a self-signed or private-CA certificate — has no such chain, and
+  a public-CA chain abusing this needs a misissuing CA, which is a browser-ecosystem event, not
+  a WeatherDesk one. Accepted as low risk; both entries are dropped the moment a rumqttc release
+  moves to rustls-webpki 0.103.
+
+**Unmaintained, not vulnerable.** The rest of the batch is maintenance-status advisories, all
+arriving through Tauri v2's own dependency tree:
+
+- **gtk-rs GTK3 bindings** (RUSTSEC-2024-0411 through -0420): Tauri v2 renders through
+  WebKitGTK on GTK3 on Linux. Moving to GTK4 is Tauri's roadmap, not something a dependent
+  application can do; these leave the list with Tauri v3.
+- **proc-macro-error** (RUSTSEC-2024-0370): build-time proc-macro helper, no runtime code.
+- **rustls-pemfile** (RUSTSEC-2025-0134): PEM parsing was folded into rustls upstream; rumqttc
+  still pulls the standalone crate. It parses local PEM files only.
+- **the unic block** (RUSTSEC-2025-0075, -0080, -0081, -0098, -0100): compile-time Unicode
+  identifier tables under `tauri-utils`.
+
+None of these change what the application does at runtime. The rule from the top of this
+section still holds: each entry exists in `deny.toml` only alongside this writeup, and the
+check goes red again the moment an entry stops being true.

--- a/docs/weewx.md
+++ b/docs/weewx.md
@@ -1,0 +1,38 @@
+# Feeding WeatherDesk from WeeWX
+
+WeeWX already speaks a protocol WeatherDesk already listens for: the Weather Underground
+uploader. Point it at WeatherDesk instead of wunderground.com and every archive interval lands
+in the same archive as any other station brand — no driver, no extension, no code.
+
+## weewx.conf
+
+In `[StdRESTful]`:
+
+```ini
+[[Wunderground]]
+    enable = true
+    station = anything          # becomes the ID= field; WeatherDesk ignores it unless an
+                                # ingest key is set (below)
+    password = anything
+    server_url = http://<weatherdesk-host>:8088/updateweatherstation.php
+    rapidfire = false
+```
+
+Restart WeeWX (`sudo systemctl restart weewx`). Within one archive interval a reading appears —
+verify with `weatherdesk --check` on the host, or open the dashboard and watch the age chip.
+
+In WeatherDesk's Settings, set **Station brand** to *Weather Underground protocol* so the
+dashboard knows where its readings come from.
+
+## With an ingest key
+
+On a network you don't fully trust, set an ingest key in WeatherDesk's Settings and use it as
+the WeeWX `password`; WeatherDesk checks the `PASSWORD=` field on the WU path. Readings without
+it are refused.
+
+## What maps
+
+The WU uploader sends temperature, humidity, dew point, barometer, wind (speed, gust,
+direction), rain (rate and daily), solar radiation and UV — everything the dashboard's gauges
+and archive use. Anything WeeWX computes that the protocol has no field for (inside
+temperature, extra sensors) stays in WeeWX.

--- a/site/index.html
+++ b/site/index.html
@@ -158,6 +158,16 @@
     transform: translateX(100%); transition: transform .18s ease; z-index: 20;
   }
   #drawer.open { transform: none; }
+  /* the detail slide-over: same dialog contract as the drawer, same look */
+  #detail {
+    position: fixed; inset: 0 0 0 auto; width: min(420px, 100%); background: var(--panel);
+    border-left: 1px solid var(--line); overflow: auto; z-index: 1002;
+    padding: var(--gap) var(--gap) calc(var(--gap) + env(safe-area-inset-bottom));
+    transform: translateX(100%); transition: transform .2s;
+  }
+  #detail.open { transform: none; }
+  #detail #detail-close { float: right; }
+  [data-metric] { cursor: pointer; }
   #drawer label { display: block; margin: 10px 0 4px; font-size: 12px; color: var(--muted); }
   #drawer input, #drawer select {
     width: 100%; padding: 8px; background: var(--bg); color: var(--text);
@@ -638,7 +648,7 @@
       <div id="hero-icon"></div>
       <div id="hero-feels" class="hero-dim"></div>
       <div class="hero-now">
-        <div id="hero-temp">--°</div>
+        <div id="hero-temp" data-metric="temp">--°</div>
         <div>
           <div id="hero-cond"></div>
           <div id="hero-hilo" class="hero-dim"></div>
@@ -678,13 +688,13 @@
     <div id="daycards" data-panel="daycards"></div>
 
     <div id="gauges" data-panel="gauges">
-      <div class="gauge" data-panel="g-wind"><h3>Wind</h3><div id="g-wind"></div></div>
-      <div class="gauge" data-panel="g-rain"><h3>Rain</h3><div id="g-rain"></div></div>
-      <div class="gauge" data-panel="g-hum"><h3>Humidity</h3><div id="g-hum"></div></div>
-      <div class="gauge" data-panel="g-press"><h3>Pressure</h3><div id="g-press"></div></div>
+      <div class="gauge" data-panel="g-wind" data-metric="windAvg"><h3>Wind</h3><div id="g-wind"></div></div>
+      <div class="gauge" data-panel="g-rain" data-metric="rain"><h3>Rain</h3><div id="g-rain"></div></div>
+      <div class="gauge" data-panel="g-hum" data-metric="rh"><h3>Humidity</h3><div id="g-hum"></div></div>
+      <div class="gauge" data-panel="g-press" data-metric="press"><h3>Pressure</h3><div id="g-press"></div></div>
       <div class="gauge" data-panel="g-dew"><h3>Dew point</h3><div id="g-dew"></div></div>
-      <div class="gauge" data-panel="g-uv"><h3>UV / solar</h3><div id="g-uv"></div></div>
-      <div class="gauge" data-panel="g-ltg"><h3>Lightning</h3><div id="g-ltg"></div></div>
+      <div class="gauge" data-panel="g-uv" data-metric="uv"><h3>UV / solar</h3><div id="g-uv"></div></div>
+      <div class="gauge" data-panel="g-ltg" data-metric="strikes"><h3>Lightning</h3><div id="g-ltg"></div></div>
       <div class="gauge" data-panel="g-wet"><h3>Wet bulb</h3><div id="g-wet"></div></div>
       <div class="gauge" data-panel="g-wbgt"><h3 title="Estimated from temperature, humidity and solar — not a measured WBGT">WBGT</h3><div id="g-wbgt"></div></div>
     </div>

--- a/site/js/api.js
+++ b/site/js/api.js
@@ -163,7 +163,8 @@ export async function localObs(hours = 3) {
 // of open-meteo, which this app already leans on for six other panels, and every consumer stays
 // unaware. See `shapeOm`.
 export function betterForecast(stationId = settings().stationId) {
-  if (!settings().token) return omForecast();
+  // A non-Tempest source routes to open-meteo even if a stale token survives in the config (#37).
+  if (!settings().token || settings().stationSource) return omForecast();
   return getJSON(`${SWD}/better_forecast?${qs({
     station_id: stationId, token: settings().token, ...unitParams(),
   })}`);

--- a/site/js/boards.js
+++ b/site/js/boards.js
@@ -134,13 +134,13 @@ function drawExtremes() {
   const strikes = col(I.strikes).reduce((a, b) => a + b, 0);
   const avg = (a) => a.reduce((x, y) => x + y, 0) / a.length;
   $('extremes').innerHTML = [
-    ['High', `${num(Math.max(...t), 1)}${U.temp()}`],
-    ['Low', `${num(Math.min(...t), 1)}${U.temp()}`],
-    ['Mean', `${num(avg(t), 1)}${U.temp()}`],
-    ['Peak gust', `${num(Math.max(...g), 1)} ${U.wind()}`],
-    ['Lightning strikes', num(strikes)],
+    ['High', `${num(Math.max(...t), 1)}${U.temp()}`, 'temp'],
+    ['Low', `${num(Math.min(...t), 1)}${U.temp()}`, 'temp'],
+    ['Mean', `${num(avg(t), 1)}${U.temp()}`, 'temp'],
+    ['Peak gust', `${num(Math.max(...g), 1)} ${U.wind()}`, 'windGust'],
+    ['Lightning strikes', num(strikes), 'strikes'],
     ['Samples', num(history.length)],
-  ].map(([k, v]) => `<div><span>${k}</span><span>${v}</span></div>`).join('');
+  ].map(([k, v, m]) => `<div${m ? ` data-metric="${m}" role="button" tabindex="0"` : ''}><span>${k}</span><span>${v}</span></div>`).join('');
 }
 
 async function drawModels() {

--- a/site/js/boot.js
+++ b/site/js/boot.js
@@ -14,6 +14,7 @@ import { initLayout, snapshot, restore, hiddenPanels, unhide, panelIds, tabOf, s
 import { initUdp } from './udp.js';
 import { initHome } from './home.js';
 import { initOutlook } from './outlook.js';
+import { initDetail } from './detail.js';
 
 const $ = (id) => document.getElementById(id);
 
@@ -444,9 +445,10 @@ $('btn-save').onclick = async () => {
     pwsKey: $('set-pws-key').value.trim(),
     elevationM: elevMetres(),
     stationSource: $('set-source').value,
-    // Switching to a non-Tempest brand: the old WeatherFlow device id has to go with it, or
-    // history and the age chip keep asking WeatherFlow about a station that isn't there.
-    ...($('set-source').value ? { deviceId: '' } : {}),
+    // Switching to a non-Tempest brand: the old WeatherFlow device id, token and station id all
+    // have to go with it, or the forecast and history keep asking WeatherFlow about a station
+    // that isn't there (#37).
+    ...($('set-source').value ? { deviceId: '', token: '', stationId: '' } : {}),
     wllHost: $('set-wll').value.trim(),
     awnApiKey: $('set-awn-api').value.trim(),
     awnAppKey: $('set-awn-app').value.trim(),
@@ -487,7 +489,7 @@ $('btn-save').onclick = async () => {
   }
   loadDeskRadar();
   initDesk(); // idempotent: every() replaces existing jobs
-  initIntel(); initSignals(); initBoards(); initAlmanac(); initEnv(); initPro(); initLayout(); initUdp(); initHome(); initOutlook();
+  initIntel(); initSignals(); initBoards(); initAlmanac(); initEnv(); initPro(); initLayout(); initDetail(); initUdp(); initHome(); initOutlook();
 };
 
 // station meta fills name/lat/lon and the Tempest device id when blank
@@ -1229,7 +1231,7 @@ if (!hasSource() && !PUBLIC) {
 // lat/lon must land before the open-meteo/NWS jobs start (resolves immediately when unconfigured)
 hydrateStation().then(() => {
   loadDeskRadar();
-  initDesk(); initIntel(); initSignals(); initBoards(); initAlmanac(); initEnv(); initPro(); initUdp(); initHome();
+  initDesk(); initIntel(); initSignals(); initBoards(); initAlmanac(); initEnv(); initPro(); initDetail(); initUdp(); initHome();
   every('server-alerts', 300, probeServerAlerts);
 });
 

--- a/site/js/detail.js
+++ b/site/js/detail.js
@@ -1,0 +1,123 @@
+// Click a value, see the detail behind it.
+//
+// One mechanism, several entry points: any element carrying `data-metric` opens a slide-over
+// with the last 48 h of that metric out of the app's own archive, the window's range and mean,
+// and one plain line on what the number means. The panel is a dialog in everything but element
+// name, the same contract as the settings drawer: it takes focus when it opens, gives it back
+// when it closes, and Escape shuts it.
+//
+// ponytail: chart points are not clickable — the detail panel is itself a chart, so a click on
+// a chart would open a chart of the chart. Add if anyone asks.
+
+import { U, num, expires } from './app.js';
+import * as api from './api.js';
+import { chart } from './charts.js';
+
+const $ = (id) => document.getElementById(id);
+const I = api.OBS;
+
+// What each clickable metric is: where it lives in an observation tuple, how it is labelled,
+// and why it moves. Values from localObs() are already in display units.
+export const METRICS = {
+  temp: { label: 'Temperature', idx: I.temp, unit: () => U.temp(), digits: 1,
+    blurb: 'Air temperature in the shade. It swings with the sun, the wind direction and what the sky is doing — a steady fall with rising humidity usually means weather on the way.' },
+  rh: { label: 'Humidity', idx: I.rh, unit: () => '%', digits: 0,
+    blurb: 'How much of the water the air could hold, it is holding. High overnight and falling through the morning is a normal day; high and staying high feeds fog, dew and storms.' },
+  press: { label: 'Pressure', idx: I.press, unit: () => ` ${U.press()}`, digits: 2,
+    blurb: 'The weight of the atmosphere overhead. The number matters less than the direction: steadily falling means unsettled weather approaching, rising means clearing.' },
+  windAvg: { label: 'Wind', idx: I.windAvg, unit: () => ` ${U.wind()}`, digits: 1,
+    blurb: 'Sustained wind, averaged over the report interval. Compare with the gust line — a big gap between them is what makes a day feel rougher than the average suggests.' },
+  windGust: { label: 'Wind gust', idx: I.windGust, unit: () => ` ${U.wind()}`, digits: 1,
+    blurb: 'The strongest burst in each interval. Gusts are what take branches and patio umbrellas; the sustained wind is what the forecast quotes.' },
+  rain: { label: 'Rain', idx: I.rain, unit: () => ` ${U.precip()}`, digits: 2, bar: true, sum: true,
+    blurb: 'Rain per interval as it fell. The bars show when it rained and how hard, which a daily total flattens away.' },
+  uv: { label: 'UV index', idx: I.uv, unit: () => '', digits: 1,
+    blurb: 'Sunburn strength, not brightness. It peaks at solar noon whatever the temperature says, and a thin overcast takes off less of it than it feels like it should.' },
+  solar: { label: 'Solar radiation', idx: I.solar, unit: () => ' W/m²', digits: 0,
+    blurb: 'Sunlight power landing on the station. The clean daily arc is a clear day; bites out of it are clouds passing over.' },
+  strikes: { label: 'Lightning', idx: I.strikes, unit: () => '', digits: 0, bar: true, sum: true,
+    blurb: 'Strikes detected per interval, out to roughly 25 miles. The station hears the radio crack of a strike — counts rise before a storm is overhead.' },
+};
+
+let returnTo = null;
+
+function build() {
+  if ($('detail')) return;
+  const el = document.createElement('div');
+  el.id = 'detail';
+  el.setAttribute('aria-hidden', 'true');
+  el.innerHTML = '<button class="iconbtn" id="detail-close" title="Close">✕</button>'
+    + '<h2 id="detail-title"></h2><div id="detail-now"></div>'
+    + '<canvas id="detail-chart" class="chart" style="height:180px"></canvas>'
+    + '<div id="detail-stats" class="kv-rows"></div><p id="detail-blurb" class="muted"></p>';
+  document.body.appendChild(el);
+  $('detail-close').onclick = close;
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && el.classList.contains('open')) close();
+  });
+}
+
+function close() {
+  const el = $('detail');
+  el.classList.remove('open');
+  el.setAttribute('aria-hidden', 'true');
+  returnTo?.focus?.();
+  returnTo = null;
+}
+
+export async function openDetail(metric) {
+  const m = METRICS[metric];
+  if (!m) return;
+  build();
+  const el = $('detail');
+  returnTo = document.activeElement;
+  $('detail-title').textContent = m.label;
+  $('detail-blurb').textContent = m.blurb;
+  $('detail-now').textContent = 'loading…';
+  $('detail-stats').innerHTML = '';
+  el.classList.add('open');
+  el.setAttribute('aria-hidden', 'false');
+  $('detail-close').focus();
+  try {
+    const obs = (await api.localObs(48)).obs || [];
+    const pts = obs.map((o) => ({ x: o[I.time] * 1000, y: o[m.idx] })).filter((p) => p.y != null);
+    if (!pts.length) { $('detail-now').textContent = 'nothing in the archive for the last 48 h'; return; }
+    const ys = pts.map((p) => p.y);
+    const fmt = (v) => `${num(v, m.digits)}${m.unit()}`;
+    $('detail-now').textContent = `${fmt(ys[ys.length - 1])} now`;
+    chart($('detail-chart'), [{ data: pts, color: '#4fb8ff', type: m.bar ? 'bar' : 'line' }],
+      { label: m.label, unit: m.unit().trim(), digits: m.digits,
+        xFormat: (x) => new Date(x).toLocaleTimeString([], { hour: 'numeric' }) });
+    const rows = m.sum
+      ? [['Total · 48 h', fmt(ys.reduce((a, b) => a + b, 0))]]
+      : [['High · 48 h', fmt(Math.max(...ys))], ['Low · 48 h', fmt(Math.min(...ys))],
+         ['Mean · 48 h', fmt(ys.reduce((a, b) => a + b, 0) / ys.length)]];
+    $('detail-stats').innerHTML = rows.map(([k, v]) => `<div><span>${k}</span><span>${v}</span></div>`).join('');
+  } catch (e) {
+    $('detail-now').textContent = `no archive to read — ${e.message}`;
+  }
+}
+
+export function initDetail() {
+  // One delegated listener, not one per value. A clickable value is a real keyboard target.
+  for (const el of document.querySelectorAll('[data-metric]')) {
+    el.setAttribute('role', 'button');
+    el.setAttribute('tabindex', '0');
+    el.title = 'Click for the last 48 hours';
+  }
+  const hit = (e) => e.target.closest?.('[data-metric]');
+  document.addEventListener('click', (e) => { const t = hit(e); if (t) openDetail(t.dataset.metric); });
+  document.addEventListener('keydown', (e) => {
+    if (e.key !== 'Enter' && e.key !== ' ') return;
+    const t = hit(e);
+    if (t) { e.preventDefault(); openDetail(t.dataset.metric); }
+  });
+}
+
+// ponytail-lite self-check: every data-metric in the page resolves, so a typo fails loudly
+// instead of opening an empty panel.
+if (location.search.includes('selftest')) {
+  for (const el of document.querySelectorAll('[data-metric]')) {
+    console.assert(METRICS[el.dataset.metric], `detail: unknown metric ${el.dataset.metric}`);
+  }
+}

--- a/site/js/layout.js
+++ b/site/js/layout.js
@@ -32,7 +32,43 @@ const $ = (id) => document.getElementById(id);
 // here on, and pointer deltas are divided back into layout pixels.
 const zoom = () => +getComputedStyle(document.documentElement).zoom || 1;
 
-const load = () => { try { return JSON.parse(localStorage.getItem(KEY)) || {}; } catch { return {}; } };
+// The designed first-run arrangement, tuned for a desktop window (~1400x900): now (hero), the
+// detail behind now (gauges), the next few days (daycards), then the map. The desk grid keeps
+// the core four visible; everything speculative starts hidden, one grip-click away. `severe`,
+// `winter` and `tropical` are absent on purpose: their cards are display:none until their
+// weather exists, and a hidden flag here would keep them hidden when it does. `alerts` stays
+// visible, so nothing safety-relevant is off-screen.
+// DEFAULT is data, not code: to redesign it, drag the dashboard into shape and copy
+// `snapshot()` out of the console.
+export const DEFAULT = {
+  hero: { order: 0 },
+  gauges: { order: 1 },
+  daycards: { order: 2 },
+  radar: { order: 3 },
+  'desk-grid': { order: 4 },
+  ticker: { order: 5 },
+  ha: { order: 6 },
+  tenday: { order: 0 },
+  alerts: { order: 1 },
+  sky: { order: 2 },
+  nearby: { order: 3 },
+  story: { hidden: true },
+  agree: { hidden: true },
+  changes: { hidden: true },
+  verify: { hidden: true },
+  solar: { hidden: true },
+  fire: { hidden: true },
+  health: { hidden: true },
+  aqi: { hidden: true },
+  lastyear: { hidden: true },
+};
+
+// A missing key seeds DEFAULT; a corrupt blob heals through dropImpossibleHeights instead of
+// silently discarding a working arrangement.
+const load = () => {
+  if (localStorage.getItem(KEY) == null) return structuredClone(DEFAULT);
+  try { return JSON.parse(localStorage.getItem(KEY)) || {}; } catch { return {}; }
+};
 
 // A height taller than the window can only have come from the bug above — a drag that grew a
 // panel past the bottom of the screen would have had to leave the window to do it. Dropping those
@@ -413,8 +449,8 @@ export function restore(next) {
 }
 
 export function resetLayout() {
-  restore({});
-  localStorage.removeItem(KEY);
+  // The designed arrangement, not raw markup order.
+  restore(DEFAULT);
 }
 
 export function initLayout() {
@@ -499,6 +535,12 @@ if (location.search.includes('selftest')) {
   console.assert(Math.abs(zoom() - 1.5) < 1e-6, 'layout: zoom() reads the root zoom');
   document.documentElement.style.zoom = was;
   probe.remove();
+
+  // every DEFAULT key is a real panel, so a rename cannot silently drop out of the default
+  const ids = new Set(panelIds());
+  for (const k of Object.keys(DEFAULT)) {
+    console.assert(ids.size === 0 || ids.has(k), `layout: DEFAULT names a real panel (${k})`);
+  }
 
   state = JSON.parse(before);
   save(); // the hide/unhide asserts wrote through to storage — put the real layout back

--- a/site/js/signals.js
+++ b/site/js/signals.js
@@ -217,7 +217,7 @@ function renderStrikes() {
   const cut = Date.now() / 1000 - 86400;
   const recent = strikes.filter((x) => x.t >= cut);
   el.innerHTML = recent.length
-    ? recent.map((x) => `<div><span>${new Date(x.t * 1000).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}</span>`
+    ? recent.map((x) => `<div data-metric="strikes" role="button" tabindex="0"><span>${new Date(x.t * 1000).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}</span>`
       + `<span>${num(miles(x.km), 1)} ${U.dist()}</span></div>`).join('')
     : '<div class="muted">No strikes in the last 24h</div>';
 }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4930,7 +4930,7 @@ dependencies = [
 
 [[package]]
 name = "weatherdesk"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "include_dir",
  "mdns-sd",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weatherdesk"
-version = "3.2.0"
+version = "3.2.1"
 description = "Self-hosted WeatherFlow Tempest dashboard"
 authors = ["David May"]
 license = "MIT"

--- a/src-tauri/deny.toml
+++ b/src-tauri/deny.toml
@@ -7,5 +7,29 @@
 
 [advisories]
 ignore = [
+  # -- rustls-webpki 0.102.8, same tree and same constraint as RUSTSEC-2026-0104 below: the fix
+  # is in 0.103.x, rumqttc 0.25.1 still pins ^0.102.8, nothing to upgrade to. See SECURITY.md.
+  { id = "RUSTSEC-2026-0049", reason = "rustls-webpki 0.102.8 CRL Distribution Point matching. This app loads no CRLs at all, so CRL handling is unreachable. Same tree as RUSTSEC-2026-0104; drop when rumqttc asks for rustls-webpki 0.103." },
+  { id = "RUSTSEC-2026-0098", reason = "rustls-webpki 0.102.8 accepts name constraints for URI names. Reachable only if the user's own MQTT broker presents a certificate from a CA that issues name-constrained certificates — a LAN broker with a self-signed or private-CA cert, the actual deployment, has none. See SECURITY.md; drop when rumqttc asks for rustls-webpki 0.103." },
+  { id = "RUSTSEC-2026-0099", reason = "rustls-webpki 0.102.8 accepts name constraints asserting a wildcard name. Same exposure and same upgrade constraint as RUSTSEC-2026-0098. See SECURITY.md." },
+  # -- unmaintained, not vulnerable: these are advisories about maintenance status, and every one
+  # comes in through Tauri v2's own dependency tree. They go away when Tauri does, not before.
+  { id = "RUSTSEC-2024-0411", reason = "gtk-rs GTK3 bindings unmaintained. Tauri v2 renders through WebKitGTK on GTK3 on Linux; the GTK4 move is Tauri v3's, not ours. Applies to the whole 0411-0420 block." },
+  { id = "RUSTSEC-2024-0412", reason = "gdk — see RUSTSEC-2024-0411." },
+  { id = "RUSTSEC-2024-0413", reason = "atk — see RUSTSEC-2024-0411." },
+  { id = "RUSTSEC-2024-0414", reason = "gdkwayland-sys — see RUSTSEC-2024-0411." },
+  { id = "RUSTSEC-2024-0415", reason = "gdkx11 — see RUSTSEC-2024-0411." },
+  { id = "RUSTSEC-2024-0416", reason = "atk-sys — see RUSTSEC-2024-0411." },
+  { id = "RUSTSEC-2024-0417", reason = "gdkx11-sys — see RUSTSEC-2024-0411." },
+  { id = "RUSTSEC-2024-0418", reason = "gdk-sys — see RUSTSEC-2024-0411." },
+  { id = "RUSTSEC-2024-0419", reason = "gdkwayland — see RUSTSEC-2024-0411." },
+  { id = "RUSTSEC-2024-0420", reason = "gtk3-macros — see RUSTSEC-2024-0411." },
+  { id = "RUSTSEC-2024-0370", reason = "proc-macro-error unmaintained; build-time proc-macro helper deep in the Tauri tree, no runtime code." },
+  { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile unmaintained; PEM parsing folded into rustls proper upstream, but rumqttc still pulls the standalone crate. Parses local PEM files only." },
+  { id = "RUSTSEC-2025-0075", reason = "unic-char-range unmaintained; part of the unic block under Tauri's tauri-utils (via unic-ucd-ident), compile-time identifier tables." },
+  { id = "RUSTSEC-2025-0080", reason = "unic-common — see RUSTSEC-2025-0075." },
+  { id = "RUSTSEC-2025-0081", reason = "unic-char-property — see RUSTSEC-2025-0075." },
+  { id = "RUSTSEC-2025-0098", reason = "unic-ucd-version — see RUSTSEC-2025-0075." },
+  { id = "RUSTSEC-2025-0100", reason = "unic-ucd-ident — see RUSTSEC-2025-0075." },
   { id = "RUSTSEC-2026-0104", reason = "rustls-webpki 0.102.8 CRL parsing panic (GHSA-82j2-j2ch-gfr8). Reached only through rumqttc's TLS transport, and only by an application that passes RevocationOptions to verify_for_usage() and hands it CRL bytes. This one never constructs RevocationOptions, builds no ClientConfig, and loads no CRL — TLS is configured in exactly two places, both a bare Transport::tls_with_default_config() in src/mqtt.rs. See SECURITY.md for the full path analysis. The fix is in 0.103.13 with no 0.102.x backport, and rumqttc 0.25.1 still requires rustls-webpki ^0.102.8, so there is nothing to upgrade to. Drop this entry the moment a rumqttc release asks for rustls-webpki 0.103." },
 ]

--- a/src-tauri/src/gui.rs
+++ b/src-tauri/src/gui.rs
@@ -38,6 +38,12 @@ async fn updater_check(app: tauri::AppHandle) -> Result<Option<String>, String> 
     if std::path::Path::new("/.flatpak-info").exists() {
         return Ok(None);
     }
+    // On Linux the updater plugin can only install an AppImage. A .deb (or anything else)
+    // install has no $APPIMAGE, so be honest instead of offering an install that cannot work.
+    #[cfg(target_os = "linux")]
+    if std::env::var("APPIMAGE").is_err() {
+        return Err("updates for this install come through your package manager (apt upgrade weather-desk), not the in-app updater".into());
+    }
     let update = app.updater().map_err(|e| e.to_string())?.check().await.map_err(|e| e.to_string())?;
     Ok(update.map(|u| u.version))
 }
@@ -46,6 +52,10 @@ async fn updater_check(app: tauri::AppHandle) -> Result<Option<String>, String> 
 #[tauri::command]
 async fn updater_install(app: tauri::AppHandle) -> Result<(), String> {
     use tauri_plugin_updater::UpdaterExt;
+    #[cfg(target_os = "linux")]
+    if std::env::var("APPIMAGE").is_err() {
+        return Err("updates for this install come through your package manager (apt upgrade weather-desk), not the in-app updater".into());
+    }
     let update = app
         .updater()
         .map_err(|e| e.to_string())?

--- a/src-tauri/src/ingest.rs
+++ b/src-tauri/src/ingest.rs
@@ -631,6 +631,14 @@ mod tests {
     const WU: &str = "/weatherstation/updateweatherstation.php?ID=KXX1&PASSWORD=x&dateutc=now\
         &tempf=77.0&humidity=55&winddir=180&windspeedmph=10.0&windgustmph=20.0&baromin=29.92&dailyrainin=0.10";
 
+    /// And as WeeWX's Wunderground uploader sends it — same protocol, WeeWX's field set and
+    /// softwaretype tag. Feeding WeatherDesk from WeeWX is docs/weewx.md, and this is the
+    /// assertion behind it.
+    const WEEWX: &str = "/weatherstation/updateweatherstation.php?ID=anything&PASSWORD=anything\
+        &dateutc=2026-08-19+14%3A30%3A00&tempf=77.0&humidity=55&dewptf=60.5&winddir=180\
+        &windspeedmph=10.0&windgustmph=20.0&baromin=29.92&rainin=0.02&dailyrainin=0.10\
+        &solarradiation=812.4&UV=7&softwaretype=weewx-5.0.2&action=updateraw";
+
     fn build(url: &str, body: &str) -> Vec<Option<f64>> {
         let f = collect(url, body);
         let mut m = Mem::default();
@@ -664,6 +672,19 @@ mod tests {
     fn absolute_pressure_wins_over_relative() {
         let t = build("/ingest", ECOWITT);
         assert!(close(t[6], 1013.21), "took the sea-level figure: {:?}", t[6]);
+    }
+
+    #[test]
+    fn weewx_wu_uploader_lands_in_the_right_slots() {
+        let t = build("/weatherstation/updateweatherstation.php", WEEWX);
+        assert!(close(t[7], 25.0), "77 F is 25 C, got {:?}", t[7]);
+        assert!(close(t[8], 55.0));
+        assert!(close(t[2], 4.4704));
+        assert!(close(t[3], 8.9408));
+        assert!(close(t[4], 180.0));
+        assert!(close(t[6], 1013.21), "29.92 inHg in mb, got {:?}", t[6]);
+        assert!(close(t[11], 812.4));
+        assert!(close(t[18], 2.54), "0.10 in of daily rain is 2.54 mm, got {:?}", t[18]);
     }
 
     #[test]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -4,6 +4,15 @@
 // `--headless` is the same process without a window — a LAN dashboard on a box with no desktop,
 // which is also all the Docker image is.
 fn main() {
+    if std::env::args().any(|a| a == "--version") {
+        println!("WeatherDesk {}", env!("CARGO_PKG_VERSION"));
+        return;
+    }
+    // Headless health check for a Pi with no browser: ask the running server, print what it
+    // says, exit non-zero if it is down or has never seen a reading.
+    if std::env::args().any(|a| a == "--check") {
+        std::process::exit(check());
+    }
     if std::env::args().any(|a| a == "--headless") {
         return weatherdesk_lib::run_headless();
     }
@@ -11,4 +20,41 @@ fn main() {
     weatherdesk_lib::run();
     #[cfg(not(feature = "gui"))]
     weatherdesk_lib::run_headless();
+}
+
+fn check() -> i32 {
+    let cfg = weatherdesk_lib::default_config_dir().join("config.json");
+    let port = weatherdesk_lib::setting(&cfg, "httpPort")
+        .and_then(|p| p.trim_matches('"').parse::<u16>().ok())
+        .unwrap_or(8088);
+    let body = match ureq::get(&format!("http://127.0.0.1:{port}/api/v1"))
+        .timeout(std::time::Duration::from_secs(5))
+        .call()
+        .ok()
+        .and_then(|r| r.into_string().ok())
+    {
+        Some(b) => b,
+        None => {
+            eprintln!("no server answering on port {port}");
+            return 1;
+        }
+    };
+    let v: serde_json::Value = serde_json::from_str(&body).unwrap_or_default();
+    let source = v["station"]["source"].as_str().unwrap_or("tempest");
+    match v["current"]["time"].as_i64() {
+        Some(t) => {
+            let age = (std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs() as i64)
+                .unwrap_or(0)
+                - t)
+                / 60;
+            println!("source: {source} — last reading {age} min ago");
+            0
+        }
+        None => {
+            eprintln!("source: {source} — no reading has landed yet");
+            1
+        }
+    }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "WeatherDesk",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "identifier": "io.github.davidmay87.weatherdesk",
   "build": {
     "frontendDist": "../site"
@@ -17,6 +17,7 @@
     "active": true,
     "targets": [
       "deb",
+      "appimage",
       "msi",
       "nsis",
       "app",


### PR DESCRIPTION
Repairs a shipped feature: `gui.rs` exposes an updater that on Linux can only ever install an AppImage, and no release produced one — every Linux "check for updates" was a path that could not complete.

- **AppImage** bundled on x86_64 (`latest.json` will point `linux-x86_64` at it via `createUpdaterArtifacts`); arm64 job stays deb-only — the AppImage bundler is x86_64-only, so the bundle list is now explicit per matrix entry.
- **Honest updater** on non-AppImage Linux installs: `$APPIMAGE` guard beside the existing Flatpak guard, pointing at the package manager.
- **#37**: a brand switch clears `token` + `stationId` along with `deviceId`, and `betterForecast` routes to open-meteo whenever a non-Tempest source is set — a stale token can no longer drag the forecast back to WeatherFlow.
- **#47**: `docs/weewx.md` — WeeWX's Wunderground uploader already speaks our ingest protocol; a WeeWX-shaped request is now asserted in the ingest tests.
- **`--version` / `--check`**: a headless Pi install verifies without a browser; `--check` exits non-zero if no reading has landed.
- **Designed default layout**: fresh installs and reset land on hero → gauges → daycards → radar + the core four grid cards, not markup order. Saved arrangements still win. `severe`/`winter`/`tropical` deliberately not hidden in `DEFAULT` — their cards are `display:none` until their weather exists.
- **Click-to-detail** (`site/js/detail.js`): any `data-metric` value — hero temp, six gauges, records rows, strike log — opens a slide-over with 48 h from the archive, range/mean, and one plain line on what the metric means. Same dialog contract as the drawer; every target is a keyboard target.

Verified: 41 cargo tests · `?selftest` clean in headless chromium · fresh-DOM default order confirmed · 98 MB AppImage built and smoke-tested locally (`NO_STRIP=true` + a gdk-pixbuf shim, both Arch-only quirks CI doesn't need).

🤖 Generated with [Claude Code](https://claude.com/claude-code)