### PR TITLE
fix: single instance — relaunch focuses the window instead of crashing the old instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Raspberry Pi, an Android APK, and the `ghcr.io/d4vid87/weatherdesk` container im
 
 ## [Unreleased]
 
+### Fixed
+- **Relaunching while WeatherDesk was already running crashed the old instance.** Each new
+  launch tore down the previous instance's UI process, and its WebKit web process — busy in
+  JavaScript — missed WebKit's shutdown deadline and was killed with SIGTRAP, leaving a core
+  dump behind. WeatherDesk is now single-instance: a second launch focuses the window that is
+  already open and exits.
+
 ## [3.2.1] - 2026-08-30
 
 ### Added

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4091,6 +4091,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3214becf9ef5783c0ae99a3bb25adf5353a7a16ebf53e74b909e29205735c6c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.20",
+ "tokio",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
+]
+
+[[package]]
 name = "tauri-plugin-updater"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4940,6 +4956,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-notification",
+ "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "tiny_http",
  "ureq",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 # libraries installed at all.
 [features]
 default = ["gui"]
-gui = ["dep:tauri", "dep:tauri-build", "dep:tauri-plugin-notification", "dep:tauri-plugin-updater"]
+gui = ["dep:tauri", "dep:tauri-build", "dep:tauri-plugin-notification", "dep:tauri-plugin-updater", "dep:tauri-plugin-single-instance"]
 
 [build-dependencies]
 tauri-build = { version = "2", features = [], optional = true }
@@ -32,6 +32,10 @@ serde_json = "1"
 # Serving the dashboard to the rest of the LAN is a desktop job — Android neither serves nor
 # receives the hub's broadcasts.
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
+# One instance only. A relaunch while one is running used to tear the old instance down, and
+# its WebKit web process would outlive the shutdown watchdog and SIGTRAP. Focus the existing
+# window instead.
+tauri-plugin-single-instance = { version = "2", optional = true }
 tiny_http = "0.12"
 # The observation archive. Bundled: a wall tablet's distro is not where you go looking for a
 # matching libsqlite3.

--- a/src-tauri/src/gui.rs
+++ b/src-tauri/src/gui.rs
@@ -68,15 +68,27 @@ async fn updater_install(app: tauri::AppHandle) -> Result<(), String> {
 }
 
 pub fn run() {
-    #[allow(unused_mut)]
-    let mut builder = tauri::Builder::default().plugin(tauri_plugin_notification::init());
+    let mut builder = tauri::Builder::default();
 
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     {
         builder = builder
+            // Registered first, per the plugin's docs, so a second launch exits here before any
+            // other plugin has run. Without this, relaunching while an instance was running tore
+            // down the old UI process, and its WebKit web process — busy in JS — missed the
+            // shutdown watchdog's deadline and died SIGTRAP. The second launch now just focuses
+            // the window that already exists.
+            .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+                if let Some(w) = app.get_webview_window("main") {
+                    let _ = w.show();
+                    let _ = w.set_focus();
+                }
+            }))
             .plugin(tauri_plugin_updater::Builder::new().build())
             .invoke_handler(tauri::generate_handler![updater_check, updater_install]);
     }
+
+    builder = builder.plugin(tauri_plugin_notification::init());
 
     builder
         .setup(|app| {


### PR DESCRIPTION
Launching WeatherDesk while it was already running tore down the previous instance's UI process; its WebKit web process — busy in JavaScript — missed the shutdown watchdog's ~10 s deadline and died SIGTRAP, leaving a core dump per relaunch (three identical dumps in one evening on the reporting machine).

**Fix:** `tauri-plugin-single-instance`, registered before every other plugin. A second launch shows and focuses the existing main window and exits 0 immediately — nothing is ever torn down.

**Verified** on Linux (Wayland, NVIDIA): with an instance running, a second launch exits 0 in under a second, the first instance keeps running and still shuts down cleanly afterward. `cargo test` green, `--no-default-features` (headless/Docker) still builds without the plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)