### PR TITLE
fix: blank window on some Linux GPU/compositor combos (3.2.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Raspberry Pi, an Android APK, and the `ghcr.io/d4vid87/weatherdesk` container im
 
 ## [Unreleased]
 
+## [3.2.3] - 2026-08-31
+
+### Fixed
+- **Blank window on some Linux GPU/compositor combinations** (seen on Hyprland with Intel UHD
+  600 graphics): WeatherDesk started and ran, but never drew anything. WebKitGTK's DMABUF
+  renderer is now disabled by default on Linux. Export
+  `WEBKIT_DISABLE_DMABUF_RENDERER=0` to force the old behaviour back on.
+
 ## [3.2.2] - 2026-08-30
 
 ### Fixed

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: David May <davidmay87@gmail.com>
 pkgname=weatherdesk
-pkgver=3.2.2
+pkgver=3.2.3
 pkgrel=1
 pkgdesc="Self-hosted dashboard for a WeatherFlow Tempest station"
 arch=('x86_64' 'aarch64')

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4946,7 +4946,7 @@ dependencies = [
 
 [[package]]
 name = "weatherdesk"
-version = "3.2.2"
+version = "3.2.3"
 dependencies = [
  "include_dir",
  "mdns-sd",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weatherdesk"
-version = "3.2.2"
+version = "3.2.3"
 description = "Self-hosted WeatherFlow Tempest dashboard"
 authors = ["David May"]
 license = "MIT"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -16,6 +16,13 @@ fn main() {
     if std::env::args().any(|a| a == "--headless") {
         return weatherdesk_lib::run_headless();
     }
+    // WebKitGTK's DMABUF renderer draws a blank window on some Wayland stacks (seen on
+    // Hyprland + Intel UHD 600, same class as the NVIDIA/Wayland Error 71 in dev). Disable
+    // it unless the user set the variable themselves; costs the GPU compositing path.
+    #[cfg(target_os = "linux")]
+    if std::env::var_os("WEBKIT_DISABLE_DMABUF_RENDERER").is_none() {
+        std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+    }
     #[cfg(feature = "gui")]
     weatherdesk_lib::run();
     #[cfg(not(feature = "gui"))]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "WeatherDesk",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "identifier": "io.github.davidmay87.weatherdesk",
   "build": {
     "frontendDist": "../site"


### PR DESCRIPTION
WeatherDesk started and ran on the Chromebook (Omarchy/Hyprland, Intel UHD 600) but never drew a window — the WebKit web process was busy executing JavaScript while nothing appeared on screen. That is WebKitGTK's DMABUF renderer failing on an awkward GPU/compositor combination, the same bug class as the NVIDIA/Wayland `Error 71 (Protocol error)` we already work around in development builds.

`WEBKIT_DISABLE_DMABUF_RENDERER=1` is now set before any GTK/WebKit initialisation, only when the user has not set the variable themselves — so `WEBKIT_DISABLE_DMABUF_RENDERER=0` still forces the GPU compositing path back on. `--headless` returns before reaching it.

Also bumps to 3.2.3 (PKGBUILD, tauri.conf.json, Cargo.toml + lock) and adds the changelog entry.

`cargo test`: 40 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)