### PR TITLE
3.4.0 — fix the Chromebook, verify in CI, then features

### DIFF
--- a/.github/ci/fixture.js
+++ b/.github/ci/fixture.js
@@ -1,0 +1,58 @@
+// Synthetic forecast + station report for CI. The Desk paints nothing without one, and a
+// screenshot of an empty page proves nothing. Fixed values, moving timestamps: the sun has to be
+// up for the day layouts, and every chart wants times near now.
+const now = Math.floor(Date.now() / 1000);
+const day = Math.floor(now / 86400) * 86400;
+
+const daily = Array.from({ length: 10 }, (_, i) => ({
+  day_start_local: day + i * 86400,
+  air_temp_high: 78 - i,
+  air_temp_low: 58 - i,
+  conditions: 'Partly Cloudy',
+  icon: i % 3 === 0 ? 'partly-cloudy-day' : i % 3 === 1 ? 'rainy' : 'clear-day',
+  precip_probability: (i * 10) % 70,
+  sunrise: day + i * 86400 + 6 * 3600 + 40 * 60,
+  sunset: day + i * 86400 + 19 * 3600 + 50 * 60,
+}));
+
+const hourly = Array.from({ length: 72 }, (_, i) => ({
+  time: now - 3600 + i * 3600,
+  air_temperature: 70 + 8 * Math.sin(i / 4),
+  feels_like: 70 + 8 * Math.sin(i / 4),
+  relative_humidity: 55 + (i % 20),
+  precip_probability: (i * 7) % 90,
+  precip: (i % 9 === 0) ? 0.02 : 0,
+  wind_avg: 6 + (i % 5),
+  wind_gust: 12 + (i % 9),
+  wind_direction: (i * 17) % 360,
+  sea_level_pressure: 1013 + Math.sin(i / 6),
+  uv: Math.max(0, 6 - Math.abs(12 - (i % 24))),
+  conditions: 'Partly Cloudy',
+  icon: 'partly-cloudy-day',
+}));
+
+const fc = {
+  latitude: 32.75, longitude: -97.33, timezone: 'America/Chicago', elevation: 180,
+  current_conditions: {
+    time: now, conditions: 'Partly Cloudy', icon: 'partly-cloudy-day',
+    air_temperature: 72.4, feels_like: 74.1, dew_point: 61.2, relative_humidity: 68,
+    sea_level_pressure: 1014.2, station_pressure: 993.1, pressure_trend: 'steady',
+    wind_avg: 7.2, wind_gust: 14.6, wind_direction: 190, uv: 4, brightness: 42000,
+    solar_radiation: 520, precip_accum_local_day: 0.12, visibility: 16093,
+    air_density: 1.18, lightning_strike_count_last_3hr: 0,
+  },
+  forecast: { daily, hourly },
+};
+
+addEventListener('load', () => {
+  dispatchEvent(new CustomEvent('wd:forecast', { detail: fc }));
+  // api.OBS order: time, temp, rh, press, ... — index by name off the module the page already
+  // loaded rather than hard-coding a shape that moves.
+  import('./js/api.js').then(({ OBS }) => {
+    const o = [];
+    o[OBS.time] = now; o[OBS.temp] = 22.4; o[OBS.rh] = 68; o[OBS.press] = 993.1;
+    o[OBS.windAvg] = 3.2; o[OBS.windGust] = 6.5; o[OBS.windDir] = 190;
+    o[OBS.uv] = 4; o[OBS.solar] = 520; o[OBS.dayRain] = 3; o[OBS.battery] = 2.71;
+    dispatchEvent(new CustomEvent('wd:ws-obs', { detail: o }));
+  });
+});

--- a/.github/ci/seed.js
+++ b/.github/ci/seed.js
@@ -1,0 +1,6 @@
+// Runs before any module: settings are read once at module eval, so this is the only place a CI
+// run can look like a configured install rather than a first-run wizard.
+localStorage.setItem('wd.settings', JSON.stringify({
+  units: 'imperial', stationName: 'CI Station', theme: 'dark', accent: '#4fb8ff',
+  stationSource: 'ecowitt', lat: 32.75, lon: -97.33, deskRadar: false, nightDim: false, kioskCycleSec: 0, eco: 'off',
+}));

--- a/.github/ci/selftest.sh
+++ b/.github/ci/selftest.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Loads the site in headless Chrome at three motion levels and three screen sizes, fails on any
+# console.assert, and leaves a screenshot of each. No bundler, no test runner: the site is plain
+# ES modules, so "does it compile" means "did boot reach the end", which is the sentinel below.
+#
+#   bash .github/ci/selftest.sh          # google-chrome
+#   CHROME=chromium bash .github/ci/selftest.sh
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+CHROME=${CHROME:-google-chrome}
+PORT=${PORT:-8089}
+OUT=$(pwd)/shots
+DIR=$(mktemp -d)
+trap 'rm -rf "$DIR"; [ -n "${SRV:-}" ] && kill "$SRV" 2>/dev/null || true' EXIT
+
+cp -r site/. "$DIR/"
+cp .github/ci/fixture.js "$DIR/ci-fixture.js"
+cp .github/ci/seed.js "$DIR/ci-seed.js"
+# Appended, not edited in place: the fixture has to run after every module has bound its listeners.
+python3 - "$DIR/index.html" <<'PY'
+import sys
+p = sys.argv[1]
+s = open(p).read()
+s = s.replace('</body>', '  <script type="module" src="ci-fixture.js"></script>\n</body>')
+# Classic script, first in the head: settings are read at module eval, so seeding them later is
+# a first-run wizard over every screenshot.
+s = s.replace('<head>', '<head>\n  <script src="ci-seed.js"></script>', 1)
+open(p, 'w').write(s)
+PY
+
+mkdir -p "$OUT"
+python3 -m http.server "$PORT" --directory "$DIR" >/dev/null 2>&1 &
+SRV=$!
+for _ in $(seq 30); do curl -sf "http://127.0.0.1:$PORT/" >/dev/null && break; sleep 0.2; done
+
+fail=0
+for motion in full lite off; do
+  for size in 1920,1080 780,360 412,915; do
+    url="http://127.0.0.1:$PORT/?selftest&motion=$motion"
+    log="$DIR/$motion-$size.log"
+    dom="$DIR/$motion-$size.html"
+    # A wedged headless Chrome would otherwise hang the whole job until the runner's timeout.
+    timeout 120 "$CHROME" --headless=new --disable-gpu --no-sandbox --hide-scrollbars \
+      --window-size="$size" --virtual-time-budget=15000 \
+      --enable-logging=stderr --screenshot="$OUT/$motion-${size/,/x}.png" \
+      --dump-dom "$url" >"$dom" 2>"$log" || true
+
+    if grep -q 'Assertion failed' "$log"; then
+      echo "FAIL $motion $size — assertion:"; grep 'Assertion failed' "$log" | sort -u; fail=1
+    fi
+    if ! grep -q 'data-selftest="ok"' "$dom"; then
+      echo "FAIL $motion $size — boot never finished (module error?):"
+      grep -iE 'error|SyntaxError' "$log" | head -5; fail=1
+    fi
+    # Animated icons are the whole point of Full and the whole cost of Lite.
+    want=$([ "$motion" = full ] && echo icons/anim/ || echo icons/static/)
+    grep -q "$want" "$dom" || { echo "FAIL $motion $size — expected $want in the DOM"; fail=1; }
+  done
+done
+
+[ "$fail" = 0 ] && echo "selftest: 9 runs clean, screenshots in $OUT"
+exit "$fail"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  rust:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: swatinem/rust-cache@v2
+        with:
+          workspaces: ./src-tauri -> target
+      - name: Install Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev build-essential curl wget file \
+            libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
+      - run: cargo test --manifest-path src-tauri/Cargo.toml
+
+  site:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: bash .github/ci/selftest.sh
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: screenshots
+          path: shots/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 src-tauri/target
+shots/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,53 @@ Raspberry Pi, an Android APK, and the `ghcr.io/d4vid87/weatherdesk` container im
 
 ## [Unreleased]
 
+## [3.4.0] - 2026-09-03
+
+### Fixed
+- **Blank window on Linux.** The AppImage always runs under XWayland, and there an Intel iGPU
+  (a Chromebook's UHD 600) painted nothing at all even with the DMABUF renderer off. Rendering is
+  now a setting — Settings → Window rendering, `Auto` / `Safe` / `GPU` — overridable per launch
+  with `WD_RENDER=safe` or `--render safe`, and `Auto` turns software compositing on for exactly
+  that combination. The app prints one line at startup saying what it picked. Because the setting
+  syncs from any browser on the LAN, a machine showing a blank window can be fixed from a phone.
+
+### Added
+- **Continuous integration.** `cargo test` and a headless-browser run of the whole site — three
+  motion levels by three screen sizes, failing on any self-check — now run on every pull request,
+  with a screenshot of each combination kept as an artifact. `bash .github/ci/selftest.sh` runs
+  the same thing locally.
+- **A one-column phone pass.** Held upright, the tabs and the settings gear move to the bottom of
+  the screen where a thumb reaches them, every control is at least 44 px tall, text inputs no
+  longer zoom the page when focused, and Save stays pinned to the bottom of the drawer.
+- **The overnight dim follows the sun.** It now ramps over the hour after sunset and the hour
+  before sunrise, a minute at a time, instead of stepping to 45% at some point in the next quarter
+  of an hour.
+- **Tap the hero icon to hear the day** — the current reading, the high and low, the 24-hour story
+  and the alert state, read aloud. Settings → Kiosk can also schedule one spoken briefing a day at
+  a fixed time.
+- **Rate-of-change and forecast alert rules.** Seven new metrics to build rules on: temperature,
+  pressure and humidity change over the last hour, and the forecast low over 18 hours, rain chance
+  over six, peak gust over a day and tomorrow's high. A forecast rule is evaluated the moment a
+  new forecast lands rather than waiting for the next station report.
+- **Click a point on a chart** on the Boards or in the almanac explorer to open the detail panel
+  on that moment, not on the last 48 hours.
+- **A still radar image on weak hardware.** Anything running Lite motion or eco mode gets one
+  radar PNG every five minutes instead of the live wasm viewer; tapping it opens the full map.
+  Motion → Full puts the live map back.
+- **US Drought Monitor** on the Fire card: the county's class and how much of it is in that class,
+  fetched by the app's own server (neither the Drought Monitor nor the county lookup it needs
+  serves CORS headers).
+- **Archive retention.** Settings → Keep history for: forever (the default), or 1, 2, 5 or 10
+  years. Deletion runs hourly, a week at a time, so it never blocks an incoming reading.
+- `/history/tuples` accepts `from` and `to` as well as `hours`.
+
+### Changed
+- **The rain and lightning counters survive a restart.** They are stored alongside every reading,
+  so rain that fell while the app was down is scored once when it comes back — unless it was down
+  more than a day, in which case the counter is started cold rather than trusted.
+- **`/history/daily` no longer rescans the whole archive per request.** Everything before today is
+  aggregated once and cached; only today's rows, an index range, are recomputed.
+
 ## [3.3.0] - 2026-09-03
 
 ### Added

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: David May <davidmay87@gmail.com>
 pkgname=weatherdesk
-pkgver=3.3.0
+pkgver=3.4.0
 pkgrel=1
 pkgdesc="Self-hosted dashboard for a WeatherFlow Tempest station"
 arch=('x86_64' 'aarch64')

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ bottom](docs/screenshot-national.png)
   station-vs-model trend strip, 48h temp/rain/wind chart, inline radar, six day cards with
   temperature arcs, eight dial gauges, 10-day list, alert center, weather story, model agreement,
   forecast changes, forecast accuracy, air quality, sun & moon detail (golden hour, day-length
-  change, moonrise/set), fire weather & dryness, and station health (battery, signal, sensor
+  change, moonrise/set), fire weather & dryness (including the county's US Drought Monitor class,
+  on installs that run the app's own server), and station health (battery, signal, sensor
   faults, time since the last report).
 - **Forecast Lab** — radar, embedded from [HookEcho](https://hookecho.io/).
 
@@ -82,6 +83,14 @@ Extreme warnings still come through, because that is what the setting is for. On
 severe alerts aloud** speaks them. On the desktop, an alert raised while the window is hidden
 becomes a real OS notification.
 
+**Tap the hero icon** and the dashboard reads the day out: what it is doing now, the high and low,
+the 24-hour story and whether anything is out. `Settings → Spoken briefing at` schedules the same
+thing once a day at a fixed time. Browsers refuse to speak before a page has been touched, so a
+briefing on a tablet nobody has touched since boot waits for the first tap.
+
+`Settings → Dim the screen overnight` fades a wall panel down over the hour after sunset and back
+up over the hour before sunrise, using the station's own sun times.
+
 `Settings → Panel catalog` moves any Desk panel to the Data or Local Signals tab; it keeps working
 where it lands. `Settings → Palette` adds OLED black, Solarized, high contrast and a flat e-ink
 mode on top of the light and dark themes.
@@ -92,11 +101,15 @@ always shows the address a tablet should open.
 ## Alert rules and push
 
 Settings → **Alert rules** builds thresholds on live readings: a metric (temperature, dew point,
-gust, wind, humidity, rain rate, UV, 3h lightning count, 3h pressure change), above or below, a
+gust, wind, humidity, rain rate, UV, 3h lightning count, 3h pressure change, the change in
+temperature / pressure / humidity over the last hour, and four straight off the forecast — the low
+over the next 18 hours, the rain chance over the next six, the peak gust over the next day and
+tomorrow's high), above or below, a
 value, and how long it has to hold. **+ AND** adds a second condition and then both have to hold —
 "gust above 25 AND humidity below 40" is a fire day; either half alone is a Tuesday. A rule fires
 once and re-arms when the reading falls back through 90% of its threshold, so a gust hovering on
-the line does not notify all afternoon.
+the line does not notify all afternoon. A forecast rule is checked the moment a new forecast
+lands rather than waiting for the next reading from the station, which is the whole point of one.
 
 Any alert can leave the machine:
 
@@ -120,6 +133,11 @@ carries meaning (counting numbers, swinging needles, sliding panels, the alert c
 the effects; *Off* is a still page. *Auto* — the default — picks Full on a desktop and Lite on
 the hardware eco mode calls slow. Asking your OS for reduced motion, or picking the e-ink
 palette, forces Off. `?motion=full|lite|off` overrides it for one page load.
+
+Anything below Full — so a wall tablet, an old Chromebook, or any box eco mode has picked up —
+gets a **still radar picture**, refreshed every five minutes, instead of the live radar viewer,
+which is megabytes of WebAssembly repainting itself. Tapping it opens the full map. Setting Motion
+to Full puts the live loop back on the Desk.
 
 Settings → **Eco mode** halves how often everything polls and drops the seconds from the clock.
 On *Auto* it turns itself on when the browser reports four cores or fewer, which covers the
@@ -152,6 +170,13 @@ again. Moving and hiding work there; resizing does not, because a phone gives ev
 width and its natural height anyway. That mode is per-device and lasts until the app is closed —
 the layout it writes is the shared one, so a panel moved on the phone moves on the wall tablet too.
 
+## Tests
+
+`cargo test --manifest-path src-tauri/Cargo.toml` covers the server, the archive and every unit
+conversion. `bash .github/ci/selftest.sh` loads the whole site in headless Chrome at three motion
+levels and three screen sizes, fails on any in-page self-check, and leaves a screenshot of each in
+`shots/` (`CHROME=chromium` if that is what you have). Both run on every pull request.
+
 ## Data sources
 
 | Feature | Endpoint |
@@ -163,6 +188,8 @@ the layout it writes is the shared one, so a panel moved on the phone moves on t
 | Multi-model agreement, 15-minute nowcast, AQI | `api.open-meteo.com` |
 | Radar | [HookEcho](https://hookecho.io/) at `hookecho.pages.dev` |
 | Place search | `photon.komoot.io` |
+| County drought class | `usdmdataservices.unl.edu` + `geo.fcc.gov` (via the app's own server) |
+| Still radar image | `img.hookecho.io` |
 | Other brands of station (see below) | your own LAN, `rt.ambientweather.net` |
 
 ## Other weather stations
@@ -418,6 +445,12 @@ history runs out. A station that has been up for years gets years of records on 
 and the almanac says how much it has and whether it is still fetching. The walk is resumable — kill
 the app halfway and it picks up from where it stopped.
 
+`Settings → Keep history for` sets how far back the archive goes: forever, which is the default,
+or 1, 2, 5 or 10 years. Anything older is deleted an hour after you save, a week at a time so an
+incoming reading never has to wait for it. There is no undo and most stations have no cloud to
+restore from, so it asks once before shortening the window. The file itself does not shrink — the
+freed space is reused — and `sqlite3 weatherdesk.db VACUUM` with the app stopped will reclaim it.
+
 `Settings → History CSV` hands the whole archive over as a spreadsheet, and `Backup archive`
 downloads a consistent snapshot of the database itself. To restore one: quit the app, copy the file
 over `<app data>/weatherdesk.db` (delete the `-wal` and `-shm` files beside it if they exist), and
@@ -562,6 +595,19 @@ viewport size. Start there — it separates "my token is wrong" from "NWS is dow
 
 On Windows, if the tablet can't load the LAN URL, it's the firewall prompt that was dismissed on
 first launch — allow WeatherDesk on private networks.
+
+**The window opens blank (Linux).** WebKitGTK's GPU paths do not survive every combination of
+driver and compositor — an Intel iGPU under the AppImage is the known-bad one. Start it once with
+the workarounds on:
+
+```sh
+WD_RENDER=safe ./WeatherDesk_*.AppImage      # or: ./WeatherDesk_*.AppImage --render safe
+```
+
+If that draws, make it permanent in `Settings → Window rendering → Safe`, which you can set from
+any browser on the LAN (`http://<that machine>:8088`) — a blank window is still a working server.
+The app prints one line at startup saying which mode it picked and what it set. The AUR build,
+which links the system WebKitGTK, generally does not need any of this.
 
 ## Security
 

--- a/site/index.html
+++ b/site/index.html
@@ -83,8 +83,8 @@
   }
   #shortcuts[hidden] { display: none; }
   body.dimmed::after {
-    content: ''; position: fixed; inset: 0; background: #000; opacity: .45;
-    pointer-events: none; z-index: 999;
+    content: ''; position: fixed; inset: 0; background: #000; opacity: var(--dim, .45);
+    pointer-events: none; z-index: 999; transition: opacity 60s linear;
   }
   /* Keyboard focus has to be visible on every theme and palette — the default ring disappears
      entirely on the dark panels. :focus-visible, so a mouse click doesn't leave one behind. */
@@ -327,7 +327,10 @@
   #hero-sun { font-size: 17px; font-weight: 500; }
   /* Beside the temperature, not floating over the middle of the panel: with a live sky behind
      it, an absolutely positioned glyph sat wherever the sun happened to be. */
-  #hero-icon { position: relative; width: 96px; height: 96px; opacity: .95; pointer-events: none; flex: none; }
+  /* Tappable: it reads the day out loud (intel.js briefing). The children stay inert so a tap
+     always lands on the icon itself. */
+  #hero-icon { position: relative; width: 96px; height: 96px; opacity: .95; flex: none; cursor: pointer; }
+  #hero-icon > * { pointer-events: none; }
   #hero-icon svg, #hero-icon img { width: 96px; height: 96px; }
   /* A radial glow behind the glyph rather than a 26px drop-shadow filter on it: the filter
      re-rasterised the whole icon on every repaint. */
@@ -419,6 +422,11 @@
     position: relative; height: 100%; background: var(--panel); display: flex; align-items: center; justify-content: center; }
   #desk-radar-frame { width: 100%; height: 100%; border: 0; display: none; }
   #desk-radar.loaded > #desk-radar-frame { display: block; }
+  /* The still: a weak box cannot afford megabytes of wasm painting a loop, but it can afford one
+     PNG every five minutes. Same panel, same size, no iframe at all. */
+  #desk-radar-still { width: 100%; height: 100%; object-fit: cover; cursor: pointer; }
+  #desk-radar-caption { position: absolute; inset: auto 0 0 0; padding: 6px 10px; font-size: 12px;
+    background: var(--panel2); pointer-events: none; }
   #desk-radar.unreachable::after { content: 'Radar unreachable'; position: absolute; inset: auto 0 0 0;
     padding: 6px 10px; font-size: 13px; color: var(--muted); background: var(--panel2); }
   /* Loaded in HookEcho's `?embed` mode: chromeless, and holding one frame a minute until it is
@@ -553,7 +561,12 @@
     .dc-head { gap: 6px; }
     .tab { padding: 8px 12px; white-space: nowrap; }
     /* thumbs, not mouse pointers */
-    .iconbtn, button { min-height: 40px; }
+    .iconbtn, button, .tab { min-height: 44px; }
+    /* 16px is the size below which mobile browsers zoom the page on focus, which then leaves the
+       drawer half off-screen. */
+    input, select, textarea { min-height: 44px; font-size: 16px; }
+    /* Save sits under a long scroll of settings; on a phone it has to stay reachable. */
+    #drawer-actions { position: sticky; bottom: 0; background: var(--panel); padding: 8px 0; }
     .phone-only { display: inline-flex; }
     #drawer { width: 100%; }
     /* A phone is where the dashboard is read, not where it is rearranged: left on, the grips and
@@ -595,6 +608,18 @@
     .sig-row { grid-template-columns: 1.5fr .8fr 1fr .9fr 20px; font-size: 12px; }
     .sig-row > span:nth-child(3), .sig-row > span:nth-child(5) { display: none; }
     .sig-row .fail { grid-column: 2 / -2 !important; }
+  }
+  /* One hand, one column: on a phone held upright the tabs and the gear belong under the thumb,
+     not at the top edge. `body` is already a flex column of header then main, so reversing it is
+     the whole move — no fixed positioning, and the drawer (absolute inside main) still opens over
+     the page with its gear visible. */
+  @media (max-width: 720px) and (orientation: portrait) {
+    body { flex-direction: column-reverse; }
+    header {
+      border-top: 1px solid var(--line);
+      border-bottom: 0;
+      padding-bottom: calc(6px + env(safe-area-inset-bottom));
+    }
   }
   /* A phone in landscape is compact by height, not by width: the hero's two columns fit side by
      side again, and stacking them there costs the rows below the fold. */
@@ -738,7 +763,7 @@
       </div>
       <div id="hero-feels" class="hero-dim"></div>
       <div class="hero-now">
-        <div id="hero-icon"></div>
+        <div id="hero-icon" role="button" tabindex="0" title="Tap to hear today"></div>
         <div id="hero-temp" data-metric="temp">--°</div>
         <div>
           <div id="hero-cond"></div>
@@ -758,6 +783,8 @@
 
     <div id="desk-radar" data-panel="radar">
       <iframe id="desk-radar-frame" title="Radar loop"></iframe>
+      <img id="desk-radar-still" alt="Radar" hidden>
+      <div id="desk-radar-caption" class="muted" hidden>Still image · 5 min · tap for the live map</div>
     </div>
 
         <div id="trends" data-panel="trends">
@@ -1035,6 +1062,7 @@
     <label>Cycle tabs every (seconds, 0 = off)</label><input id="set-kiosk" type="number" min="0" step="5">
     <label><input id="set-night-dim" type="checkbox"> Dim the screen overnight</label>
     <label><input id="set-speak" type="checkbox"> Read severe and emergency alerts aloud</label>
+    <label>Spoken briefing at (blank = off)</label><input id="set-brief-time" type="time">
     <label><input id="set-web-notif" type="checkbox"> Browser notifications (https only)</label>
 
     <label style="margin-top:14px">Eco mode (slower polling)</label>
@@ -1050,6 +1078,14 @@
       <option value="lite">Lite — movement only, no effects</option>
       <option value="off">Off — nothing moves</option>
     </select>
+    <label style="margin-top:14px">Window rendering (desktop app, next launch)</label>
+    <select id="set-render">
+      <option value="auto">Auto</option>
+      <option value="safe">Safe — software compositing</option>
+      <option value="gpu">GPU — no workarounds</option>
+    </select>
+    <p class="muted" style="font-size:12px">If the desktop window opens blank, set this to Safe
+      from any browser at http://&lt;this computer&gt;:8088 and restart the app.</p>
     <h2 style="font-size:13px;margin-top:18px">This computer</h2>
     <label>LAN dashboard port (blank = 8088; restart to apply)</label>
     <input id="set-http-port" type="number" min="1" max="65535" placeholder="8088">
@@ -1065,6 +1101,17 @@
       minute. Consoles hold one upload address, so pointing yours at WeatherDesk takes it off
       these networks — this puts it back.</p>
 
+    <label style="margin-top:14px">Keep history for</label>
+    <select id="set-retention">
+      <option value="0">Forever</option>
+      <option value="1">1 year</option>
+      <option value="2">2 years</option>
+      <option value="5">5 years</option>
+      <option value="10">10 years</option>
+    </select>
+    <p class="muted" style="font-size:12px">Older readings are deleted for good, an hour after
+      you save. Back the archive up first — most stations have no cloud to restore them from.</p>
+
     <div class="row">
       <button id="btn-export">Export settings</button>
       <button id="btn-import">Import settings</button>
@@ -1074,7 +1121,7 @@
       <span id="app-version" class="muted" style="font-size:12px;align-self:center"></span>
     </div>
     <input id="import-file" type="file" accept="application/json,.json" hidden>
-    <div class="row">
+    <div class="row" id="drawer-actions">
       <button class="primary" id="btn-save">Save</button>
       <button id="btn-diag">Diagnostics</button>
       <button id="btn-close">Close</button>

--- a/site/js/almanac.js
+++ b/site/js/almanac.js
@@ -6,6 +6,7 @@
 // so rather than pretending the record is older than it is.
 import { settings, U, num, every, expires, msToWind } from './app.js';
 import { chart } from './charts.js';
+import { openDetail } from './detail.js';
 import { normals, normalFor, getJSON } from './api.js';
 
 const $ = (id) => document.getElementById(id);
@@ -144,6 +145,12 @@ function drawMonthly() {
 
 // --- explorer: any date range, any column ---
 
+// Which per-reading metric each daily column is a summary of. `battMin` is missing on purpose:
+// detail.js has no battery entry, and a chart of the chart is what the panel is not for.
+const EXPLORE_DETAIL = {
+  tempMin: 'temp', tempMax: 'temp', gustMax: 'windGust', rain: 'rain', strikes: 'strikes',
+};
+
 function drawExplore() {
   const from = $('ex-from').value || days[0]?.day;
   const to = $('ex-to').value || days[days.length - 1]?.day;
@@ -155,7 +162,13 @@ function drawExplore() {
     data: rows.map((d) => ({ x: new Date(`${d.day}T12:00:00`).getTime(), y: d[key] })),
     color: '#4fb8ff',
     type: key === 'rain' || key === 'strikes' ? 'bar' : 'line',
-  }], { digits, unit, label: $('ex-metric').selectedOptions[0].textContent, yMin: key === 'rain' ? 0 : undefined });
+  }], {
+    digits, unit, label: $('ex-metric').selectedOptions[0].textContent,
+    yMin: key === 'rain' ? 0 : undefined,
+    // A daily row is a summary of a day; the detail panel shows the readings behind it. Battery
+    // has no detail entry, so that column simply is not clickable.
+    onPick: EXPLORE_DETAIL[key] ? (p) => openDetail(EXPLORE_DETAIL[key], p.x) : undefined,
+  });
   if (!rows.length) { $('ex-summary').textContent = 'No observations in that range.'; return; }
   const vals = rows.map((d) => d[key]);
   const total = vals.reduce((a, b) => a + b, 0);

--- a/site/js/api.js
+++ b/site/js/api.js
@@ -189,8 +189,11 @@ export function siToDisplay(obs) {
 // The same window of history for a station that has no cloud behind it: our own archive, which
 // is where every ingested report lands whatever brand sent it. Shaped like `deviceObs` so
 // `pro.js` reads one or the other without knowing which.
-export async function localObs(hours = 3) {
-  const j = await getJSON(`${window.__WD_SRV || ''}/history/tuples?${qs({ hours })}`);
+export async function localObs(hours = 3, at = null) {
+  // `at` is a moment someone clicked on a chart: a day either side of it, rather than the last
+  // `hours` up to now, which for a point three weeks back is the wrong archive entirely.
+  const params = at ? { from: Math.round(at / 1000) - 86400, to: Math.round(at / 1000) + 86400 } : { hours };
+  const j = await getJSON(`${window.__WD_SRV || ''}/history/tuples?${qs(params)}`);
   siToDisplay(j.obs || []);
   return j;
 }
@@ -534,6 +537,14 @@ export function tropical() {
   const srv = window.__WD_SRV ?? (window.location.protocol.startsWith('http') ? '' : null);
   if (srv == null) return Promise.reject(new Error('no server to proxy NHC'));
   return getJSON(`${srv}/proxy/nhc`);
+}
+
+// The US Drought Monitor, behind the same kind of proxy and for the same reason — neither it nor
+// the FCC county lookup it needs sends CORS headers. Nothing on a static host, as with NHC.
+export function droughtMonitor() {
+  const srv = window.__WD_SRV ?? (window.location.protocol.startsWith('http') ? '' : null);
+  if (srv == null) return Promise.reject(new Error('no server to proxy the Drought Monitor'));
+  return getJSON(`${srv}/proxy/drought`);
 }
 
 // --- Climate normals (ERA5 reanalysis via open-meteo, keyless) ---

--- a/site/js/app.js
+++ b/site/js/app.js
@@ -56,6 +56,12 @@ const DEFAULTS = {
   // 'auto' | 'full' | 'lite' | 'off' — see motion.js. Auto means Full on a desktop and Lite on
   // the same hardware eco mode calls slow.
   motion: 'auto',
+  // 'HH:MM' local, blank = off. A spoken summary at a fixed time — see intel.js briefing().
+  briefTime: '',
+  // 'auto' | 'safe' | 'gpu' — WebKitGTK renderer workarounds, read by the Rust side at launch.
+  render: 'auto',
+  // Years of readings to keep, 0 = forever. Enforced by the Rust side, hourly.
+  retentionYears: 0,
   // Quiet hours, 'HH:MM' each, both empty = off. Suppresses the chime and every push channel;
   // a Severe or Extreme alert still comes through, because that is what the setting is for.
   quietStart: '', quietEnd: '',
@@ -305,16 +311,22 @@ const replay = () => {
 window.addEventListener('pointerdown', replay);
 window.addEventListener('keydown', replay);
 
-function speak(entry) {
-  if (!shouldSpeak(entry) || !('speechSynthesis' in window)) return;
-  const words = `${entry.severity === 'Extreme' ? 'Emergency. ' : ''}${entry.title}. ${entry.headline || entry.body || ''}`;
+// Say something out loud, with the hold-and-replay above. Also the tap-the-hero briefing and the
+// morning one, which is why the alert wrapper is a caller rather than the whole of it.
+export function say(words, delayMs = 0) {
+  if (!words || !('speechSynthesis' in window)) return;
   try {
     const utter = new SpeechSynthesisUtterance(words);
     utter.lang = navigator.language || 'en-US';
     utter.onerror = (e) => { if (e.error === 'not-allowed') held = { utter: new SpeechSynthesisUtterance(words), at: Date.now() }; };
-    // After the chime, not over it.
-    setTimeout(() => window.speechSynthesis.speak(utter), 300);
+    setTimeout(() => window.speechSynthesis.speak(utter), delayMs);
   } catch { /* no voices installed; the banner is still there */ }
+}
+
+function speak(entry) {
+  if (!shouldSpeak(entry)) return;
+  // After the chime, not over it.
+  say(`${entry.severity === 'Extreme' ? 'Emergency. ' : ''}${entry.title}. ${entry.headline || entry.body || ''}`, 300);
 }
 
 // An in-page banner is no use behind another window. Desktop only, and only when this window
@@ -445,6 +457,33 @@ export function isNight(now = new Date()) {
   return h >= 21 || h < 6;
 }
 
+// How dark the overlay should be right now, 0..1. A step at sunset is a light going off in the
+// room; over an hour nobody notices it happen, which is the point of a screen on a wall.
+export function dimLevel(now = new Date()) {
+  const t = now.getTime() / 1000;
+  if (sunTimes) {
+    const ramp = (from, to) => Math.min(1, Math.max(0, (t - from) / (to - from)));
+    // Sunset today ramps down; sunrise ramps back up. The sunrise pair is yesterday's day, so
+    // compare against the same day's numbers shifted by whichever side of them we are on.
+    if (t < sunTimes.sunrise + 3600) return 1 - ramp(sunTimes.sunrise, sunTimes.sunrise + 3600);
+    if (t >= sunTimes.sunset) return ramp(sunTimes.sunset, sunTimes.sunset + 3600);
+    return 0;
+  }
+  // No forecast yet: the clock, with 30-minute ramps around the old 21:00/06:00 window.
+  const mins = now.getHours() * 60 + now.getMinutes();
+  if (mins >= 21 * 60) return Math.min(1, (mins - 21 * 60) / 30);
+  if (mins < 6 * 60) return 1;
+  if (mins < 6 * 60 + 30) return 1 - (mins - 6 * 60) / 30;
+  return 0;
+}
+
+// The overlay itself: one custom property so the CSS owns how dark "full" is.
+export function applyDim() {
+  const level = _settings.nightDim ? dimLevel() : 0;
+  document.body.style.setProperty('--dim', (level * 0.45).toFixed(3));
+  document.body.classList.toggle('dimmed', level > 0);
+}
+
 // Seconds this job should actually run at.
 export function paceFor(name, base) {
   if (storm) return name === 'desk-obs' || name === 'desk-alerts' ? Math.max(30, base / 2) : base;
@@ -521,7 +560,7 @@ export function applyTheme() {
   document.body.classList.toggle('big-numbers', !!s.bigNumbers);
   if (s.accent) document.documentElement.style.setProperty('--accent', s.accent);
   else document.documentElement.style.removeProperty('--accent');
-  document.body.classList.toggle('dimmed', !!s.nightDim && isNight());
+  applyDim();
 }
 
 // --- kiosk ---
@@ -553,6 +592,8 @@ export function initKiosk() {
   clearJob('kiosk');
   if (secs) every('kiosk', secs, kioskStep);
   every('appearance', 900, () => { applyTheme(); burnInStep(); });
+  // Its own minute job: the appearance one runs quarter-hourly, which is a visible staircase.
+  every('dim', 60, applyDim);
 }
 
 // A job turned off in settings has to actually stop — every() only ever replaces.
@@ -665,6 +706,16 @@ if (location.search.includes('selftest')) {
   _settings.eco = 'off';
   console.assert(paceFor('desk-forecast', 300) === (night ? 900 : 300), 'pace: eco off');
   _settings = save;
+
+  // The dim ramp, on the clock fallback (no forecast has landed in a selftest run).
+  {
+    const at = (h, m = 0) => { const d = new Date(); d.setHours(h, m, 0, 0); return d; };
+    console.assert(dimLevel(at(14)) === 0, 'dim: nothing at midday');
+    console.assert(Math.abs(dimLevel(at(21, 15)) - 0.5) < 1e-9, 'dim: half way up the ramp');
+    console.assert(dimLevel(at(0)) === 1, 'dim: full at midnight');
+    console.assert(Math.abs(dimLevel(at(6, 15)) - 0.5) < 1e-9, 'dim: half way back down');
+    console.assert(dimLevel(at(7)) === 0, 'dim: clear by morning');
+  }
 
   // quiet hours: the window that wraps midnight is the one worth checking
   const q = { quietStart: '22:00', quietEnd: '07:00' };

--- a/site/js/boards.js
+++ b/site/js/boards.js
@@ -3,6 +3,7 @@
 import * as api from './api.js';
 import { settings, coords, configured, U, num, every, expires } from './app.js';
 import { chart } from './charts.js';
+import { openDetail } from './detail.js';
 import { accuracy } from './track.js';
 import { forecast as deskForecast } from './desk.js';
 
@@ -45,7 +46,9 @@ const pts = (idx, from = 0) =>
   history.filter((o) => o[I.time] >= from).map((o) => ({ x: o[I.time] * 1000, y: o[idx] }));
 
 function drawTemp() {
-  chart($('c-temp'), [{ data: pts(I.temp), color: '#4fb8ff' }], { digits: 0 });
+  // Clicking a point opens the same slide-over the gauges open, windowed on that moment.
+  chart($('c-temp'), [{ data: pts(I.temp), color: '#4fb8ff' }],
+    { digits: 0, onPick: (p) => openDetail('temp', p.x) });
   $('board-temp').textContent = `7-day air temperature (${U.temp()})`;
 }
 
@@ -61,7 +64,9 @@ function dailyRain() {
 
 function drawRain() {
   const d = dailyRain();
-  chart($('c-rain'), [{ data: d, type: 'bar', color: '#4fdc8b' }], { yMin: 0, digits: 2 });
+  // The bars are whole days; noon is the middle of the window the detail panel will read.
+  chart($('c-rain'), [{ data: d, type: 'bar', color: '#4fdc8b' }],
+    { yMin: 0, digits: 2, onPick: (p) => openDetail('rain', p.x + 12 * 3600 * 1000) });
   const total = d.reduce((a, b) => a + b.y, 0);
   $('board-rain').textContent = `7-day rain — ${num(total, 2)} ${U.precip()} total`;
 }
@@ -69,9 +74,9 @@ function drawRain() {
 function drawWind() {
   const from = Math.floor(Date.now() / 1000) - DAY;
   chart($('c-wind'), [
-    { data: pts(I.windGust, from), color: '#ffb84f' },
-    { data: pts(I.windAvg, from), color: '#4fb8ff' },
-  ], { yMin: 0, digits: 0 });
+    { data: pts(I.windGust, from), color: '#ffb84f', name: 'gust' },
+    { data: pts(I.windAvg, from), color: '#4fb8ff', name: 'avg' },
+  ], { yMin: 0, digits: 0, onPick: (p, name) => openDetail(name === 'avg' ? 'windAvg' : 'windGust', p.x) });
   $('board-wind').textContent = `24h wind (${U.wind()}) — gust amber, average blue`;
 }
 
@@ -122,7 +127,8 @@ function drawRose() {
 
 function drawPressure() {
   const from = Math.floor(Date.now() / 1000) - 2 * DAY;
-  chart($('c-press'), [{ data: pts(I.press, from), color: '#e6edf5' }], { digits: 2 });
+  chart($('c-press'), [{ data: pts(I.press, from), color: '#e6edf5' }],
+    { digits: 2, onPick: (p) => openDetail('press', p.x) });
   const p = pts(I.press, from);
   const delta = p.length > 1 ? p[p.length - 1].y - p[0].y : 0;
   $('board-press').textContent = `48h pressure (${U.press()}) — net ${delta >= 0 ? '+' : ''}${num(delta, 2)}`;

--- a/site/js/boot.js
+++ b/site/js/boot.js
@@ -1,6 +1,7 @@
 // Wire the shell: settings drawer, diagnostics, nav, section modules.
-import { settings, saveSettings, configured, hasSource, hasLocation, initNav, applyTabs, fullscreen, holdScreen, refreshAll, notify, load, store, applyEco, ecoOn, initKiosk, expires, num, U, msToWind, windToMs, setServerAlerts, alertsAreServerSide, every } from './app.js';
+import { settings, saveSettings, configured, hasSource, hasLocation, initNav, applyTabs, fullscreen, holdScreen, refreshAll, notify, load, store, applyEco, ecoOn, initKiosk, expires, num, U, msToWind, windToMs, setServerAlerts, alertsAreServerSide, every, clearJob } from './app.js';
 import * as api from './api.js';
+import { motionLevel } from './motion.js';
 import { initDesk, refreshDesk, refreshObs, refreshAlerts, refreshAqi } from './desk.js';
 import { initIntel, refreshModels, refreshNowcast } from './intel.js';
 import { initSignals, refreshSignals } from './signals.js';
@@ -148,6 +149,8 @@ function fillDrawer() {
   $('set-desk-radar').checked = !!s.deskRadar;
   $('set-eco').value = s.eco || 'auto';
   $('set-motion').value = s.motion || 'auto';
+  $('set-render').value = s.render || 'auto';
+  $('set-retention').value = String(s.retentionYears || 0);
   $('set-storm-auto').checked = !!s.stormAuto;
   $('set-theme').value = s.theme || 'dark';
   $('set-accent').value = s.accent || '#4fb8ff';
@@ -157,6 +160,7 @@ function fillDrawer() {
   $('set-kiosk').value = s.kioskCycleSec || 0;
   $('set-night-dim').checked = !!s.nightDim;
   $('set-speak').checked = !!s.speakAlerts;
+  $('set-brief-time').value = s.briefTime || '';
   $('set-web-notif').checked = !!s.webNotif;
   $('set-palette').value = s.palette || '';
   $('set-quiet-start').value = s.quietStart || '';
@@ -408,6 +412,15 @@ $('btn-full').onclick = fullscreen;
 $('btn-refresh').onclick = refreshAll;
 
 $('btn-save').onclick = async () => {
+  // Retention deletes readings for good and there is no undo, so a shorter window is confirmed
+  // once, here, rather than discovered as a hole in the archive.
+  const keep = +$('set-retention').value || 0;
+  const kept = +settings().retentionYears || 0;
+  if (keep && (!kept || keep < kept)
+      && !confirm(`Delete every reading older than ${keep} year${keep > 1 ? 's' : ''}? This cannot be undone.`)) {
+    $('set-retention').value = String(kept);
+    return;
+  }
   // A new radar site means the saved camera belongs to the old one — drop it so the fresh
   // site-only link recenters.
   if ($('set-radar-site').value !== (settings().radarSite || '')) { radarView = null; store('wd.radar', null); }
@@ -425,6 +438,8 @@ $('btn-save').onclick = async () => {
     deskRadar: $('set-desk-radar').checked,
     eco: $('set-eco').value,
     motion: $('set-motion').value,
+    render: $('set-render').value,
+    retentionYears: +$('set-retention').value || 0,
     stormAuto: $('set-storm-auto').checked,
     theme: $('set-theme').value,
     // The picker cannot express "no accent", so the default colour means the default.
@@ -435,6 +450,7 @@ $('btn-save').onclick = async () => {
     kioskCycleSec: Math.max(0, Math.min(3600, +$('set-kiosk').value || 0)),
     nightDim: $('set-night-dim').checked,
     speakAlerts: $('set-speak').checked,
+    briefTime: $('set-brief-time').value,
     webNotif: $('set-web-notif').checked,
     palette: $('set-palette').value,
     quietStart: $('set-quiet-start').value,
@@ -742,8 +758,8 @@ function changelog() {
   if (!seen) return; // a fresh install has nothing to be new since
   notify({
     title: `WeatherDesk ${APP_VERSION}`,
-    body: 'New: broadcast-style motion with a live sky and animated icons, a Motion setting '
-      + '(Auto/Full/Lite/Off), severe alerts read aloud, and a faster Desk.',
+    body: 'New: tap the hero to hear the day, forecast and rate-of-change alert rules, clickable '
+      + 'charts, drought on the Fire card, archive retention — and a fix for the blank window on Linux.',
   });
 }
 
@@ -1149,6 +1165,40 @@ window.addEventListener('wd:section', (e) => {
 // it with the page ate the same process the Settings drawer lives in — the window painted and then
 // accepted no input at all, so the token could never be typed in. Wait for setup to be done, for
 // the panel to actually be on screen, and for the main thread to go idle.
+// A live radar is megabytes of wasm repainting itself; on the boxes that already run Lite (a
+// wall tablet, a Celeron Chromebook) that is the single most expensive thing on the page. They
+// get a picture instead — same map, five minutes stale, one PNG. Motion=Full puts the live map
+// back on any box, which is why this needs no setting of its own.
+function stillRadar() {
+  return ecoOn() || motionLevel() !== 'full';
+}
+
+// HookEcho's snapshot renderer. `t` is a five-minute bucket: Cloudflare rewrites the browser TTL
+// to four hours, so without a changing URL the panel would show one frame all afternoon.
+function stillUrl() {
+  const v = radarView ?? load('wd.radar', null);
+  const q = new URLSearchParams({
+    site: v?.site || radarSite(), size: '768', zoom: String(v?.zoom ?? 6.5),
+    t: String(Math.floor(Date.now() / 300000)),
+  });
+  if (v?.basemap) q.set('basemap', v.basemap);
+  return `https://img.hookecho.io/snapshot.png?${q}`;
+}
+
+function showStill(panel) {
+  const img = $('desk-radar-still'), f = $('desk-radar-frame');
+  if (f.src) { f.src = 'about:blank'; f.removeAttribute('src'); }
+  img.hidden = false;
+  $('desk-radar-caption').hidden = false;
+  panel.classList.add('loaded');
+  const refresh = () => { img.src = stillUrl(); };
+  img.onerror = () => panel.classList.add('unreachable');
+  img.onload = () => panel.classList.remove('unreachable');
+  img.onclick = () => document.querySelector('.tab[data-section="lab"]')?.click();
+  refresh();
+  every('radar-still', 300, refresh);
+}
+
 function loadDeskRadar() {
   const panel = $('desk-radar'), f = $('desk-radar-frame');
   if (!panel) return;
@@ -1158,9 +1208,20 @@ function loadDeskRadar() {
   panel.hidden = !(settings().deskRadar || (stormOverride && settings().stormAuto));
   if (panel.hidden) {
     if (f.src) { f.src = 'about:blank'; f.removeAttribute('src'); }
+    $('desk-radar-still').hidden = true;
+    $('desk-radar-caption').hidden = true;
+    clearJob('radar-still');
     loadDeskRadar.armed = false;
     return;
   }
+  // Motion changed while the panel was up: swap whichever one is showing for the other.
+  if (stillRadar()) {
+    if (!$('desk-radar-still').hidden) return;
+    return showStill(panel);
+  }
+  $('desk-radar-still').hidden = true;
+  $('desk-radar-caption').hidden = true;
+  clearJob('radar-still');
   if (f.src || loadDeskRadar.armed) return;
   // First run: the drawer is open and typing the token matters more than the map. Closing the
   // drawer (by saving, or by hand — a hub-only install has no token to type) calls back here.
@@ -1327,6 +1388,11 @@ if (location.search.includes('selftest')) {
   console.assert(sig.aborted === false, 'expires: not aborted yet');
   console.assert(typeof sig.addEventListener === 'function', 'expires: returns a real signal');
 
+  // The radar still: which boxes get it, and a URL that actually changes.
+  console.assert(stillRadar() === (motionLevel() !== 'full' || ecoOn()), 'radar: still follows motion and eco');
+  console.assert(/[?&]site=/.test(stillUrl()) && /[?&]t=\d/.test(stillUrl()),
+    'radar: the still URL carries a site and a cache-buster');
+
   // The config echo, the one bug here that costs a whole CPU core rather than a wrong number.
   const held = rev;
   rev = 7;
@@ -1335,3 +1401,7 @@ if (location.search.includes('selftest')) {
   console.assert(shouldPull(undefined), 'config: a server that sends no revision still pulls');
   rev = held;
 }
+
+// Reached only if every module parsed and boot ran to the end — CI greps for it, which is the
+// closest thing a bundler-free site has to a compile check.
+if (location.search.includes('selftest')) document.documentElement.dataset.selftest = 'ok';

--- a/site/js/charts.js
+++ b/site/js/charts.js
@@ -98,10 +98,13 @@ export function chart(canvas, series, opts = {}) {
   );
 
   if (canvas._wdHover != null) crosshair(c, canvas._wdHover);
+  // A time the caller wants marked whatever the pointer is doing — the detail panel opens on the
+  // point that was clicked and has to show which one that was.
+  else if (opts.markX != null) crosshair(c, px(opts.markX));
 
-  // The readout under the pointer: nearest real sample on each line, not an interpolation —
-  // a chart that invents a value between two readings is a chart that lies.
-  function crosshair(c, hx) {
+  // The nearest real sample on each line to a pixel x, or [] when the pointer is nowhere near
+  // one. Shared by the crosshair and the click handler so both agree on what was picked.
+  function nearest(hx) {
     const marks = [];
     for (const s of series) {
       if (s.type === 'band') continue;
@@ -113,6 +116,14 @@ export function chart(canvas, series, opts = {}) {
       }
       if (best && best.d < (w - padL - padR) / 4) marks.push({ p: best.p, color: s.color, name: s.name });
     }
+    return marks;
+  }
+  canvas._wdNearest = nearest;
+
+  // The readout under the pointer: nearest real sample on each line, not an interpolation —
+  // a chart that invents a value between two readings is a chart that lies.
+  function crosshair(c, hx) {
+    const marks = nearest(hx);
     if (!marks.length) return;
     const gx = px(marks[0].p.x);
     c.strokeStyle = MUTED; c.lineWidth = 1;
@@ -154,6 +165,15 @@ function bindHover(canvas, series, opts) {
     canvas._wdHover = null;
     canvas._wdDraw();
   };
+  // A click is a hover that stopped: `move` has already run, so the pick is whatever the readout
+  // is showing. Nothing to do on a chart nobody wired an `onPick` to.
+  canvas.addEventListener('click', (e) => {
+    if (!opts.onPick) return;
+    const hx = e.clientX - canvas.getBoundingClientRect().left;
+    const m = canvas._wdNearest?.(hx)?.[0];
+    if (m) opts.onPick(m.p, m.name);
+  });
+  canvas.style.cursor = opts.onPick ? 'pointer' : '';
   canvas.addEventListener('pointermove', move);
   canvas.addEventListener('pointerdown', move);
   canvas.addEventListener('pointerleave', clear);
@@ -181,6 +201,20 @@ if (typeof window !== 'undefined' && location.search.includes('selftest')) {
   cv._wdHover = 36;
   chart(cv, [{ data: [{ x: 0, y: 1 }, { x: 1, y: 5 }], color: '#f00' }], { label: 'test' });
   console.assert(cv.toDataURL() !== before, 'chart: hover draws a crosshair');
+  // Click to pick: the handler reads the same nearest-sample map the readout draws with.
+  {
+    const cv2 = document.createElement('canvas');
+    cv2.width = 200; cv2.height = 100;
+    let picked = null;
+    chart(cv2, [{ data: [{ x: 0, y: 1 }, { x: 100, y: 5 }], color: '#f00', name: 'a' }],
+      { onPick: (p, name) => { picked = { p, name }; } });
+    cv2._wdNearest = (hx) => (hx < 50 ? [{ p: { x: 0, y: 1 }, name: 'a' }] : []);
+    cv2.dispatchEvent(new MouseEvent('click', { clientX: 4 }));
+    console.assert(picked?.p.y === 1 && picked.name === 'a', 'chart: a click hands back the sample under it');
+    picked = null;
+    cv2.dispatchEvent(new MouseEvent('click', { clientX: 400 }));
+    console.assert(picked === null, 'chart: a click nowhere near a sample picks nothing');
+  }
   cv._wdHover = null;
   chart(cv, [{ type: 'band', data: [{ x: 0, lo: 1, hi: 9 }, { x: 1, lo: 2, hi: 8 }], color: '#0f0' }]);
   console.assert(/1 to 9/.test(cv.getAttribute('aria-label')), 'chart: a band sets the scale from lo and hi');

--- a/site/js/detail.js
+++ b/site/js/detail.js
@@ -6,8 +6,8 @@
 // name, the same contract as the settings drawer: it takes focus when it opens, gives it back
 // when it closes, and Escape shuts it.
 //
-// ponytail: chart points are not clickable — the detail panel is itself a chart, so a click on
-// a chart would open a chart of the chart. Add if anyone asks.
+// A click on a point in any of the dashboard's own charts lands here too, with the time that was
+// clicked: same panel, windowed on that moment instead of on now.
 
 import { U, num, expires } from './app.js';
 import * as api from './api.js';
@@ -66,14 +66,16 @@ function close() {
 // metric's chart under the second one's title.
 let gen = 0;
 
-export async function openDetail(metric) {
+export async function openDetail(metric, at = null) {
   const m = METRICS[metric];
   if (!m) return;
   const mine = ++gen;
   build();
   const el = $('detail');
   returnTo = document.activeElement;
-  $('detail-title').textContent = m.label;
+  $('detail-title').textContent = at
+    ? `${m.label} · ${new Date(at).toLocaleString([], { weekday: 'short', month: 'short', day: 'numeric' })}`
+    : m.label;
   $('detail-blurb').textContent = m.blurb;
   $('detail-now').textContent = 'loading…';
   $('detail-stats').innerHTML = '';
@@ -81,16 +83,19 @@ export async function openDetail(metric) {
   el.setAttribute('aria-hidden', 'false');
   $('detail-close').focus();
   try {
-    const obs = (await api.localObs(48)).obs || [];
+    const obs = (await api.localObs(48, at)).obs || [];
     if (mine !== gen) return;
     const pts = obs.map((o) => ({ x: o[I.time] * 1000, y: o[m.idx] })).filter((p) => p.y != null);
-    if (!pts.length) { $('detail-now').textContent = 'nothing in the archive for the last 48 h'; return; }
+    if (!pts.length) {
+      $('detail-now').textContent = at ? 'nothing in the archive around that time' : 'nothing in the archive for the last 48 h';
+      return;
+    }
     const ys = pts.map((p) => p.y);
     const fmt = (v) => `${num(v, m.digits)}${m.unit()}`;
-    $('detail-now').textContent = `${fmt(ys[ys.length - 1])} now`;
+    $('detail-now').textContent = at ? `${fmt(pts[pts.length - 1].y)} at the end of the window` : `${fmt(ys[ys.length - 1])} now`;
     chart($('detail-chart'), [{ data: pts, color: '#4fb8ff', type: m.bar ? 'bar' : 'line' }],
-      { label: m.label, unit: m.unit().trim(), digits: m.digits,
-        xFormat: (x) => new Date(x).toLocaleTimeString([], { hour: 'numeric' }) });
+      { label: m.label, unit: m.unit().trim(), digits: m.digits, markX: at,
+        xFormat: (x) => new Date(x).toLocaleTimeString([], at ? { weekday: 'short', hour: 'numeric' } : { hour: 'numeric' }) });
     const rows = m.sum
       ? [['Total · 48 h', fmt(ys.reduce((a, b) => a + b, 0))]]
       : [['High · 48 h', fmt(Math.max(...ys))], ['Low · 48 h', fmt(Math.min(...ys))],

--- a/site/js/env.js
+++ b/site/js/env.js
@@ -5,6 +5,7 @@
 // keep on screen all day.
 import { settings, coords, U, num, notify, every, stamp, expires } from './app.js';
 import { forecast as deskForecast } from './desk.js';
+import * as api from './api.js';
 import { OBS, getJSON } from './api.js';
 import { toDisplay } from './almanac.js';
 
@@ -171,10 +172,10 @@ async function renderLastYear() {
 // Red flag comes out of the NWS alert feed the Desk already polls — a second request for the
 // same JSON would be a second chance to be rate-limited.
 //
-// ponytail: no US Drought Monitor. Its county API sends no Access-Control-Allow-Origin (checked
-// 2026-08-17) and the one CORS-enabled file it publishes is a 27 MB national GeoJSON, which is
-// not something a 2013 tablet is going to parse. Dryness here is measured from this station's
-// own rain log instead, which is the number that actually applies to this garden.
+// The US Drought Monitor's county API sends no Access-Control-Allow-Origin, so it comes through
+// the app's own server (api::drought) and only appears on an install that has one. Dryness is
+// still measured from this station's own rain log alongside it — that is the number that applies
+// to this garden, where the county class is the one everyone else is quoting.
 let dryness = null;
 export function drynessFrom(days) {
   if (!days.length) return null;
@@ -184,6 +185,27 @@ export function drynessFrom(days) {
   for (let i = days.length - 1; i >= 0 && !(days[i].rain > 0); i--) since++;
   return { total, since, days: last30.length };
 }
+
+// The worst class with any of the county in it, which is how the Monitor itself is quoted. The
+// percentages are cumulative — d1 includes everything in d2 — so d0 alone means "abnormally dry".
+const DROUGHT_WORDS = [
+  ['d4', 'D4 exceptional'], ['d3', 'D3 extreme'], ['d2', 'D2 severe'],
+  ['d1', 'D1 moderate'], ['d0', 'D0 abnormally dry'],
+];
+export function droughtWord(d) {
+  const hit = DROUGHT_WORDS.find(([k]) => (d[k] || 0) > 0);
+  if (!hit) return 'none · county is clear';
+  const [key, word] = hit;
+  // The service dates a map either "9/1/2026" or as a full ISO stamp, depending on the endpoint's
+  // mood. Both parse; anything that doesn't is printed as it came.
+  const at = new Date(d.date);
+  const when = Number.isNaN(at.getTime())
+    ? d.date || ''
+    : at.toLocaleDateString([], { month: 'short', day: 'numeric' });
+  return `${word} · ${num(d[key], 0)}% of county · ${when}`;
+}
+
+let drought = null;
 
 function renderFire() {
   const alerts = [...document.querySelectorAll('#alerts .alert-head')]
@@ -196,6 +218,7 @@ function renderFire() {
     rows.push([`Rain · last ${dryness.days} days`, `${num(dryness.total, 2)} ${U.precip()}`]);
     rows.push(['Days since rain', num(dryness.since)]);
   }
+  if (drought) rows.push(['Drought (USDM)', droughtWord(drought)]);
   $('fire').innerHTML = rows.map(([k, v]) => `<div><span>${k}</span><span>${v}</span></div>`).join('');
 }
 
@@ -266,6 +289,10 @@ async function loadSeason() {
   garden.gddC = gdd(daysSI.filter((d) => d.day >= yearStart));
   // …while the Fire card prints rain next to U.precip(), so it needs the display units.
   dryness = drynessFrom(daysSI.map(toDisplay));
+  // No server (static host, Android) simply leaves the row off, the same way the tropical card
+  // does — see api.droughtMonitor.
+  drought = await api.droughtMonitor().catch(() => null);
+  if (drought?.error) drought = null;
   renderGarden();
   renderFire();
 }
@@ -390,6 +417,11 @@ if (location.search.includes('selftest')) {
   console.assert(gdd([{ tempMin: null, tempMax: 30 }]) === 0, 'env: partial day skipped');
   const dry = drynessFrom([{ rain: 5 }, { rain: 0 }, { rain: 0 }]);
   console.assert(dry.since === 2 && dry.total === 5, 'env: dryness counts back to the last rain');
+  // Drought classes are cumulative, so the worst one with any county in it is the headline.
+  console.assert(/D2 severe · 19% of county · Sep 2/.test(
+    droughtWord({ d0: 19, d1: 19, d2: 18.6, d3: 0, d4: 0, date: '2025-09-02T00:00:00' })),
+    'env: drought reports the worst class present');
+  console.assert(/^none/.test(droughtWord({ d0: 0, d1: 0, d2: 0, d3: 0, d4: 0 })), 'env: a clear county says so');
   console.assert(faults(0) .length === 0, 'env: clean status has no faults');
   console.assert(faults(0x40).includes('wind sensor failed'), 'env: wind fault decoded');
 }

--- a/site/js/intel.js
+++ b/site/js/intel.js
@@ -1,9 +1,9 @@
 // Phase 2 — forecast intelligence: model agreement, timing anchor, live edge,
 // nowcast, weather story, forecast changes, verification.
 import * as api from './api.js';
-import { settings, U, num, timeStr, every, notify } from './app.js';
+import { settings, U, num, timeStr, every, notify, say } from './app.js';
 import { snapshot, changes, recordForecast, scoreForecast, accuracy } from './track.js';
-import { forecast as deskForecast } from './desk.js';
+import { forecast as deskForecast, severeAlerts } from './desk.js';
 
 const $ = (id) => document.getElementById(id);
 const MODEL_LIST = api.MODELS.split(',');
@@ -164,7 +164,60 @@ export function renderStory() {
     notify({ id: `winter-${wintry.time}`, category: 'winter', title: 'Snow / ice in forecast', body: `${wintry.conditions} around ${timeStr(wintry.time)}` });
   }
   if (maxGust >= settings().windGustAlert) out.push('Wind advisory-level gusts in the period.');
+  storyLines = out;
   $('story').innerHTML = out.map((s) => `<div>${s}</div>`).join('');
+}
+
+// --- spoken briefing ---
+
+// The sentences the story panel is showing, so the briefing says the same thing the screen does
+// rather than deriving a second opinion off the same forecast.
+let storyLines = [];
+
+// What a person across the room would want if they asked "what's it doing". Read off the hero
+// rather than the forecast: the hero is already the station overlaid on the model, which is the
+// number the dashboard is standing behind.
+export function briefing() {
+  const h = new Date().getHours();
+  const greet = h < 12 ? 'Good morning.' : h < 18 ? 'Good afternoon.' : 'Good evening.';
+  const t = (id) => ($(id)?.textContent || '').replace(/·/g, '.').trim();
+  const alerts = severeAlerts();
+  const parts = [
+    greet,
+    t('hero-temp') ? `It is ${t('hero-temp').replace('°', ' degrees')}.` : '',
+    t('hero-cond') ? `${t('hero-cond')}.` : '',
+    t('hero-feels'),
+    t('hero-hilo') ? `${t('hero-hilo')}.` : '',
+    ...storyLines,
+    alerts.length ? `${alerts.length} active alert${alerts.length > 1 ? 's' : ''}: ${alerts.map((a) => a.title).join(', ')}.` : 'No active alerts.',
+  ];
+  return parts.filter(Boolean).join(' ');
+}
+
+// Module level for the same reason as the listeners below: initIntel() re-runs on every save.
+document.addEventListener('click', (e) => {
+  if (e.target.closest('#hero-icon')) say(briefing());
+});
+// It is a button, so it answers the keyboard like one.
+document.addEventListener('keydown', (e) => {
+  if ((e.key === 'Enter' || e.key === ' ') && e.target.closest?.('#hero-icon')) {
+    e.preventDefault();
+    say(briefing());
+  }
+});
+
+// One briefing per day at the time in settings. A wall tablet nobody has touched since boot has
+// no gesture yet, so the utterance lands in the replay hold and speaks on the first tap.
+let briefedDay = '';
+function briefTick() {
+  const want = settings().briefTime;
+  if (!want) return;
+  const now = new Date();
+  const hhmm = `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`;
+  const day = now.toDateString();
+  if (hhmm !== want || briefedDay === day) return;
+  briefedDay = day;
+  say(briefing());
 }
 
 // --- changes + verification panels ---
@@ -198,6 +251,10 @@ export function renderTrack() {
 }
 
 if (location.search.includes('selftest')) {
+  // The briefing has to say something even before a forecast has landed, and it must always end
+  // with the alert sentence — silence about alerts reads as "no alerts" to someone listening.
+  console.assert(/^Good (morning|afternoon|evening)\./.test(briefing()), 'intel: briefing opens with a greeting');
+  console.assert(/alert/.test(briefing()), 'intel: briefing ends on the alert state');
   console.assert(trustWord(2) === 'Good' && trustWord(4) === 'Fair' && trustWord(9) === 'Watch closely',
     'intel: trust badge thresholds');
 }
@@ -208,6 +265,7 @@ window.addEventListener('wd:forecast', () => { renderStory(); renderTrack(); ren
 window.addEventListener('wd:obs', (e) => scoreForecast(e.detail));
 
 export function initIntel() {
+  every('intel-brief', 60, briefTick);
   every('intel-models', 900, refreshModels);
   every('intel-nowcast', 600, refreshNowcast);
 }

--- a/site/js/rules.js
+++ b/site/js/rules.js
@@ -23,6 +23,16 @@ export const METRICS = {
   uv: ['UV index', () => '', 1],
   strikes3h: ['Lightning strikes · 3h', () => '', 0],
   press3h: ['Pressure change · 3h', U.press, 2],
+  // Signed differences over the last hour: "falling fast" is a rule you write as `temp1h < -8`.
+  temp1h: ['Temp change · 1h', U.temp, 1],
+  press1h: ['Pressure change · 1h', U.press, 2],
+  rh1h: ['Humidity change · 1h', () => '%', 0],
+  // From the forecast, not the sensor — a warning that arrives when it is already freezing is
+  // not a warning. Refreshed on every wd:forecast, null until the first one lands.
+  low18h: ['Forecast low · 18h', U.temp, 0],
+  rain6h: ['Forecast rain chance · 6h', () => '%', 0],
+  gust24h: ['Forecast gust · 24h', U.wind, 0],
+  hiTomorrow: ['Forecast high · tomorrow', U.temp, 0],
 };
 
 export const OPS = { '>': 'above', '<': 'below' };
@@ -62,14 +72,49 @@ function fromTuple(t) {
 // here and neither should be able to grow it without limit.
 const ring = [];
 function derive(m) {
-  ring.push({ t: m._t, press: m._press, strikes: m._strikes });
+  ring.push({ t: m._t, press: m._press, strikes: m._strikes, temp: m.temp, rh: m.rh });
   const cutoff = m._t - 3 * 3600;
   while (ring.length && ring[0].t < cutoff) ring.shift();
   const first = ring.find((r) => r.press != null);
   m.press3h = first && m._press != null ? m._press - first.press : null;
   // Tempest reports strikes per interval, so 3h worth is a sum, not a difference.
   m.strikes3h = ring.reduce((a, r) => a + (r.strikes || 0), 0);
-  return m;
+  // An hour ago is the nearest sample to it, and null unless the ring actually reaches back that
+  // far — a dashboard opened ten minutes ago has no hour to compare against.
+  const hourAgo = nearest(m._t - 3600);
+  const delta = (key, now) => (hourAgo && hourAgo[key] != null && now != null ? now - hourAgo[key] : null);
+  m.temp1h = delta('temp', m.temp);
+  m.press1h = delta('press', m._press);
+  m.rh1h = delta('rh', m.rh);
+  return Object.assign(m, fcM);
+}
+
+// Nearest sample to a time, or null when the oldest one is still less than half an hour from it.
+function nearest(t) {
+  let best = null;
+  for (const r of ring) {
+    const d = Math.abs(r.t - t);
+    if (!best || d < best.d) best = { d, r };
+  }
+  return best && best.d <= 1800 ? best.r : null;
+}
+
+// Forecast-derived metrics, merged into every evaluation. Display units already: the built-in
+// frost rule below compares air_temp_low against 34 for the same reason.
+let fcM = {};
+export function forecastMetrics(fc) {
+  const hourly = fc?.forecast?.hourly || [];
+  const daily = fc?.forecast?.daily || [];
+  const now = Date.now() / 1000;
+  const within = (h) => hourly.filter((x) => x.time >= now && x.time <= now + h * 3600);
+  const max = (arr, key) => (arr.length ? Math.max(...arr.map((x) => x[key] || 0)) : null);
+  const next18 = within(18).map((x) => x.air_temperature).filter((v) => v != null);
+  return {
+    low18h: next18.length ? Math.min(...next18) : null,
+    rain6h: max(within(6), 'precip_probability'),
+    gust24h: max(within(24), 'wind_gust'),
+    hiTomorrow: daily[1]?.air_temp_high ?? null,
+  };
 }
 
 // --- evaluation ---
@@ -116,8 +161,17 @@ export function evaluate(m, rules = settings().rules || [], nowSec = Math.floor(
   return fired;
 }
 
+// The last derived reading, so a new forecast can re-evaluate without pushing a duplicate sample
+// into the ring.
+let lastM = null;
+
 function run(m) {
-  for (const { rule, value, index } of evaluate(derive(m))) {
+  lastM = derive(m);
+  fire(lastM);
+}
+
+function fire(m) {
+  for (const { rule, value, index } of evaluate(m)) {
     // home.js turns this into a per-rule binary sensor; the banner alone had no way to say
     // which rule it came from.
     window.dispatchEvent(new CustomEvent('wd:rule', { detail: { index, rule, value } }));
@@ -138,6 +192,10 @@ window.addEventListener('wd:ws-obs', (e) => run(fromTuple(e.detail)));
 // Not a rule the user has to think to write. The forecast low, not the reading: a warning that
 // arrives when it is already freezing is not a warning.
 window.addEventListener('wd:forecast', (e) => {
+  fcM = forecastMetrics(e.detail);
+  // A forecast rule that waited for the next station report would be up to ten minutes late on
+  // a REST source, and the whole point of these is lead time.
+  if (lastM) fire(Object.assign(lastM, fcM));
   const days = e.detail?.forecast?.daily?.slice(0, 2) || [];
   const limit = settings().units === 'metric' ? 1 : 34;
   for (const d of days) {
@@ -241,4 +299,39 @@ if (location.search.includes('selftest')) {
   console.assert(evaluate({ gust: 40 }, [{ metric: 'gust', op: '>', value: 30 }], 0).length === 1,
     'rules: a rule saved before v3 still fires');
   state.clear();
+
+  // Rate of change: an hour of samples in the ring, then the signed delta out of derive().
+  {
+    ring.length = 0;
+    const now = Math.floor(Date.now() / 1000);
+    ring.push({ t: now - 3600, press: 1010, strikes: 0, temp: 70, rh: 60 });
+    const m = derive({ temp: 65, rh: 75, _press: 1006, _strikes: 0, _t: now });
+    console.assert(m.temp1h === -5, 'rules: temp fell five in the hour');
+    console.assert(Math.abs(m.press1h + 4) < 1e-9, 'rules: pressure change is signed');
+    console.assert(m.rh1h === 15, 'rules: humidity change');
+    ring.length = 0;
+    console.assert(derive({ temp: 65, _t: now }).temp1h === null, 'rules: no hour of history, no delta');
+    ring.length = 0;
+  }
+
+  // Forecast metrics, off the same shape the Desk broadcasts.
+  {
+    const now = Date.now() / 1000;
+    const fc = { forecast: {
+      daily: [{ air_temp_high: 80 }, { air_temp_high: 91 }],
+      hourly: [
+        { time: now + 3600, air_temperature: 40, precip_probability: 20, wind_gust: 12 },
+        { time: now + 5 * 3600, air_temperature: 31, precip_probability: 80, wind_gust: 30 },
+        { time: now + 20 * 3600, air_temperature: 55, precip_probability: 10, wind_gust: 44 },
+      ],
+    } };
+    const m = forecastMetrics(fc);
+    console.assert(m.low18h === 31, 'rules: forecast low over the next 18h');
+    console.assert(m.rain6h === 80, 'rules: rain chance peak over six hours');
+    console.assert(m.gust24h === 44, 'rules: gust peak over the day');
+    console.assert(m.hiTomorrow === 91, 'rules: tomorrow high');
+    console.assert(evaluate(m, [{ metric: 'low18h', op: '<', value: 34 }], 0).length === 1,
+      'rules: a forecast rule fires on the forecast alone');
+    state.clear();
+  }
 }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4946,7 +4946,7 @@ dependencies = [
 
 [[package]]
 name = "weatherdesk"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
  "include_dir",
  "mdns-sd",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weatherdesk"
-version = "3.3.0"
+version = "3.4.0"
 description = "Self-hosted WeatherFlow Tempest dashboard"
 authors = ["David May"]
 license = "MIT"

--- a/src-tauri/src/api.rs
+++ b/src-tauri/src/api.rs
@@ -242,9 +242,146 @@ fn states_cache() -> &'static Mutex<Option<(u64, String)>> {
 /// on the panel while somebody is still standing next to it.
 const STATES_TTL: u64 = 15;
 
+// --- US Drought Monitor ---
+//
+// Two hops, neither of which a browser can make (no CORS on either): the FCC block API turns the
+// station's coordinates into a county FIPS code, then the Drought Monitor hands back that
+// county's weekly severity split. The page shows one line of it on the fire card.
+//
+// The whole result is cached rather than the two halves: a county's drought class changes once a
+// week, on a Thursday.
+pub fn drought(cfg: &std::path::Path) -> String {
+    let now = crate::server::epoch();
+    if let Ok(c) = drought_cache().lock() {
+        if let Some((expires, body)) = c.as_ref() {
+            if now < *expires {
+                return body.clone();
+            }
+        }
+    }
+    let get = |k: &str| {
+        crate::setting(cfg, k)
+            .and_then(|v| v.trim_matches('"').parse::<f64>().ok())
+    };
+    let (Some(lat), Some(lon)) = (get("lat"), get("lon")) else {
+        return r#"{"error":"no location set"}"#.to_string();
+    };
+    let (body, ok) = match fetch_drought(lat, lon) {
+        Ok(b) => (b, true),
+        Err(e) => (serde_json::json!({ "error": e }).to_string(), false),
+    };
+    if let Ok(mut c) = drought_cache().lock() {
+        // A dead upstream costs one worker one round trip every ten minutes, not one per screen
+        // per refresh.
+        *c = Some((now + if ok { DROUGHT_TTL } else { 600 }, body.clone()));
+    }
+    body
+}
+
+fn fetch_drought(lat: f64, lon: f64) -> Result<String, String> {
+    // Coordinates are the house. Never format the error — the URL is in it.
+    let fips_body = ureq::get(&format!(
+        "https://geo.fcc.gov/api/census/block/find?latitude={lat}&longitude={lon}&format=json"
+    ))
+    .timeout(Duration::from_secs(8))
+    .call()
+    .map_err(|e| match e {
+        ureq::Error::Status(code, _) => format!("county lookup HTTP {code}"),
+        _ => "county lookup unreachable".to_string(),
+    })?
+    .into_string()
+    .map_err(|_| "county lookup unreadable".to_string())?;
+    let v: serde_json::Value = serde_json::from_str(&fips_body).map_err(|_| "county lookup unexpected".to_string())?;
+    let fips = v["County"]["FIPS"].as_str().unwrap_or_default().to_string();
+    if fips.len() != 5 {
+        return Err("no US county here".into());
+    }
+    // Six weeks back is enough to always contain a published map, whatever day it is asked on.
+    let ymd = |t: i64| {
+        let (y, m, d, ..) = crate::server::utc_ymdhms(t);
+        format!("{m}/{d}/{y}")
+    };
+    let now = crate::server::epoch() as i64;
+    // `Accept: application/json` is load-bearing: without it this endpoint answers CSV.
+    let body = ureq::get(&format!(
+        "https://usdmdataservices.unl.edu/api/CountyStatistics/GetDroughtSeverityStatisticsByAreaPercent\
+?aoi={fips}&startdate={}&enddate={}&statisticsType=1",
+        ymd(now - 42 * 86400),
+        ymd(now)
+    ))
+    .set("Accept", "application/json")
+    .timeout(Duration::from_secs(8))
+    .call()
+    .map_err(|e| match e {
+        ureq::Error::Status(code, _) => format!("drought monitor HTTP {code}"),
+        _ => "drought monitor unreachable".to_string(),
+    })?
+    .into_string()
+    .map_err(|_| "drought monitor unreadable".to_string())?;
+    newest_week(&body).ok_or_else(|| "no drought map published yet".to_string())
+}
+
+/// The most recent weekly row, by its map date rather than its position in the array — the order
+/// the service returns is not part of anything anybody documented.
+fn newest_week(body: &str) -> Option<String> {
+    let rows: Vec<serde_json::Value> = serde_json::from_str(body).ok()?;
+    let key = |r: &serde_json::Value| {
+        // "9/2/2025" — pad it into something that sorts.
+        let d = r["mapDate"].as_str().unwrap_or_default().to_string();
+        let p: Vec<&str> = d.split('/').collect();
+        if p.len() == 3 {
+            format!("{:0>4}{:0>2}{:0>2}", p[2], p[0], p[1])
+        } else {
+            d
+        }
+    };
+    let best = rows.iter().max_by_key(|r| key(r))?;
+    let pct = |k: &str| {
+        best[k]
+            .as_f64()
+            .or_else(|| best[k].as_str().and_then(|s| s.parse().ok()))
+            .unwrap_or(0.0)
+    };
+    Some(
+        serde_json::json!({
+            "date": best["mapDate"].as_str().unwrap_or_default(),
+            "county": best["county"].as_str().unwrap_or_default(),
+            "state": best["state"].as_str().unwrap_or_default(),
+            "none": pct("none"), "d0": pct("d0"), "d1": pct("d1"),
+            "d2": pct("d2"), "d3": pct("d3"), "d4": pct("d4"),
+        })
+        .to_string(),
+    )
+}
+
+fn drought_cache() -> &'static Mutex<Option<(u64, String)>> {
+    static C: OnceLock<Mutex<Option<(u64, String)>>> = OnceLock::new();
+    C.get_or_init(|| Mutex::new(None))
+}
+
+/// The map is published once a week; six hours is "the same day, at most one extra fetch".
+const DROUGHT_TTL: u64 = 6 * 3600;
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The published week is picked by its date, not by where it happens to sit in the array, and
+    /// the percentages survive whether the service quotes them or not.
+    #[test]
+    fn drought_picks_the_newest_week_by_date() {
+        let body = r#"[
+          {"mapDate":"8/19/2025","county":"Tarrant County","state":"TX","none":100,"d0":0,"d1":0,"d2":0,"d3":0,"d4":0},
+          {"mapDate":"9/2/2025","county":"Tarrant County","state":"TX","none":"81","d0":"19","d1":"19","d2":"19","d3":0,"d4":0},
+          {"mapDate":"8/26/2025","county":"Tarrant County","state":"TX","none":90,"d0":10,"d1":0,"d2":0,"d3":0,"d4":0}
+        ]"#;
+        let v: serde_json::Value = serde_json::from_str(&newest_week(body).unwrap()).unwrap();
+        assert_eq!(v["date"], "9/2/2025");
+        assert_eq!(v["d2"], 19.0);
+        assert_eq!(v["none"], 81.0);
+        assert!(newest_week("[]").is_none(), "no rows is no answer, not a zero week");
+        assert!(newest_week("not json").is_none());
+    }
 
     /// Named fields, and the derived pair alongside them — the whole point of the endpoint.
     #[test]

--- a/src-tauri/src/ingest.rs
+++ b/src-tauri/src/ingest.rs
@@ -200,8 +200,6 @@ struct Mem {
 /// alternative, a negative rainfall, would corrupt every SUM downstream. The first report after a
 /// start scores zero: we have no idea how much of that total we already recorded.
 ///
-/// ponytail: the counters live in memory, so a restart forfeits one interval. Persist them in the
-/// `meta` table if that ever shows up in someone's rain total.
 fn delta(prev: &mut Option<f64>, cur: f64) -> f64 {
     let was = prev.replace(cur);
     match was {
@@ -209,6 +207,31 @@ fn delta(prev: &mut Option<f64>, cur: f64) -> f64 {
         Some(p) if cur < p => cur,
         Some(p) => cur - p,
     }
+}
+
+impl Mem {
+    /// Just the two running totals and when they were saved. `last_wall`/`last_raw` are throttle
+    /// state, not accounting: a restart should write the next report it hears, not skip it.
+    fn json(&self, at: u64) -> String {
+        serde_json::json!({ "rain": self.rain, "strikes": self.strikes, "at": at }).to_string()
+    }
+
+    /// A seed older than a day is thrown away. The console's own total has almost certainly
+    /// rolled over since, and scoring a whole day's rain against one interval is a worse lie than
+    /// forfeiting the outage.
+    fn from_json(s: &str, now: u64) -> Mem {
+        let v: serde_json::Value = serde_json::from_str(s).unwrap_or_default();
+        let stale = now.saturating_sub(v["at"].as_u64().unwrap_or(0)) > 86400;
+        Mem {
+            rain: if stale { None } else { v["rain"].as_f64() },
+            strikes: if stale { None } else { v["strikes"].as_f64() },
+            ..Default::default()
+        }
+    }
+}
+
+fn counter_key(origin: &str) -> String {
+    format!("counters:{origin}")
 }
 
 /// Counters and throttle state, per source. One shared set used to serve every brand at once,
@@ -318,7 +341,16 @@ fn take(state: &Arc<State>, f: &Fields, raw_ts: f64, src: i64, origin: &'static 
     }
 
     let mut all = mem().lock().unwrap();
-    let m = all.entry(origin).or_default();
+    // First report of this run: pick the counters back up off disk, so an app that was restarted
+    // (or updated) does not forfeit the rain that fell while it was down. A read connection —
+    // holding the writer's mutex across a query is what starves the UDP listener.
+    let m = all.entry(origin).or_insert_with(|| {
+        state
+            .db()
+            .and_then(|c| store::meta_get(&c, &counter_key(origin)))
+            .map(|s| Mem::from_json(&s, at))
+            .unwrap_or_default()
+    });
     if !keep(at, m, raw_ts) {
         drop(all);
         // Healthy: the poll is faster than the archive write gate. "throttled" read as a fault.
@@ -329,10 +361,16 @@ fn take(state: &Arc<State>, f: &Fields, raw_ts: f64, src: i64, origin: &'static 
     m.last_ts = Some(ts);
     m.last_wall = Some(at);
     m.last_raw = Some(raw_ts);
+    let saved = m.json(at);
     drop(all);
     note(origin, true, "stored", true);
 
-    state.with_db(|conn| store::insert(conn, &t, src));
+    // One lock, two writes: the row and the counters it was scored against move together, so a
+    // crash between them cannot double-count an interval of rain.
+    state.with_db(|conn| {
+        store::insert(conn, &t, src);
+        store::meta_set(conn, &counter_key(origin), &saved);
+    });
     if let (Some(d), Some(c)) = (t[14], t[15]) {
         if c > 0.0 {
             publish(
@@ -585,6 +623,19 @@ pub fn start_pollers(state: Arc<State>) {
                 poll_wll(&state, &wll);
             }
 
+            // Retention, hourly, from the one loop that already holds the state. Off by default:
+            // an archive is the reason most people run this, and a non-Tempest install has no
+            // cloud to backfill from once a year is gone.
+            if tick % 360 == 1 {
+                let years = s("retentionYears").trim_matches('"').parse::<i64>().unwrap_or(0);
+                if years > 0 {
+                    let cutoff = epoch() as i64 - years * 365 * 86400;
+                    // A week per lock: the UDP listener writes on its own connection and gives up
+                    // after ten seconds, so a long DELETE is a dropped reading.
+                    while state.with_db(|c| store::prune(c, cutoff)).unwrap_or(0) > 0 {}
+                }
+            }
+
             // A minute apart: the API allows one request a second, and the station behind it
             // uploads far more slowly than that.
             let (api, app) = (s("awnApiKey"), s("awnAppKey"));
@@ -614,6 +665,38 @@ pub fn start_pollers(state: Arc<State>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Rain that fell while the app was down still gets scored once, and a console that rolled
+    /// its daily total over in the meantime never scores a negative interval.
+    #[test]
+    fn counters_survive_a_restart_and_a_rollover_while_down() {
+        let now = 1_700_000_000u64;
+        let mut m = Mem { rain: Some(0.4), ..Default::default() };
+        let saved = m.json(now);
+
+        // Restart: the seed is picked up and the next report scores only the difference.
+        let mut back = Mem::from_json(&saved, now + 600);
+        assert!((delta(&mut back.rain, 0.7) - 0.3).abs() < 1e-9);
+
+        // Rolled over while we were down — the new total is the accumulation since, never negative.
+        let mut rolled = Mem::from_json(&saved, now + 600);
+        assert_eq!(delta(&mut rolled.rain, 0.1), 0.1_f64);
+
+        // Three days later the console's total means nothing to us any more: start cold, which
+        // scores the first report as zero rather than inventing a day of rain.
+        let mut stale = Mem::from_json(&saved, now + 3 * 86400);
+        assert!(stale.rain.is_none());
+        assert_eq!(delta(&mut stale.rain, 5.0), 0.0_f64);
+
+        // A truncated or hand-edited meta row is a cold start, not a panic.
+        assert!(Mem::from_json("{oops", now).rain.is_none());
+        assert!(Mem::from_json("", now).strikes.is_none());
+
+        // Throttle state is deliberately not carried across: the first report after a restart is
+        // worth a row whatever the clock says.
+        m.last_wall = Some(now);
+        assert!(Mem::from_json(&m.json(now), now).last_wall.is_none());
+    }
 
     /// A real Ecowitt "customized upload" body, GW2000 firmware, Wittboy attached.
     const ECOWITT: &str = "PASSKEY=A1B2C3&stationtype=GW2000A_V3.1.5&dateutc=2026-08-19+14:30:00\

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -116,3 +116,67 @@ pub fn run_headless() {
 pub fn run() {
     gui::run();
 }
+
+/// Which WebKitGTK renderer knobs to set before the window is created.
+///
+/// The DMABUF renderer draws a blank window on some Wayland stacks; on the AppImage — which
+/// always runs under XWayland, because linuxdeploy's GTK hook exports `GDK_BACKEND=x11` — an
+/// Intel iGPU needs software compositing on top of that. Both flags cost the GPU path, so
+/// `auto` only reaches for the second one on the combination that is known to draw nothing.
+/// Pure so it can be tested; `main.rs` decides the mode and does the setting.
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+pub fn render_env(mode: &str, appimage: bool, gpu_vendor: Option<&str>) -> Vec<(&'static str, &'static str)> {
+    match mode {
+        "gpu" => vec![],
+        "safe" => vec![
+            ("WEBKIT_DISABLE_DMABUF_RENDERER", "1"),
+            ("WEBKIT_DISABLE_COMPOSITING_MODE", "1"),
+        ],
+        _ => {
+            let mut v = vec![("WEBKIT_DISABLE_DMABUF_RENDERER", "1")];
+            // 0x8086 is Intel. The desktop's NVIDIA card draws fine with compositing on.
+            if appimage && gpu_vendor == Some("0x8086") {
+                v.push(("WEBKIT_DISABLE_COMPOSITING_MODE", "1"));
+            }
+            v
+        }
+    }
+}
+
+/// PCI vendor id of the first DRM card, e.g. `0x8086` (Intel), `0x10de` (NVIDIA).
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+pub fn gpu_vendor() -> Option<String> {
+    let mut cards: Vec<_> = std::fs::read_dir("/sys/class/drm")
+        .ok()?
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.file_name().and_then(|n| n.to_str()).map(|n| n.starts_with("card") && !n.contains('-')).unwrap_or(false))
+        .collect();
+    cards.sort();
+    cards
+        .iter()
+        .find_map(|p| std::fs::read_to_string(p.join("device/vendor")).ok())
+        .map(|s| s.trim().to_string())
+}
+
+#[cfg(all(test, not(any(target_os = "android", target_os = "ios"))))]
+mod render_tests {
+    use super::render_env;
+
+    #[test]
+    fn render_env_only_softens_the_combination_that_draws_nothing() {
+        fn names(v: Vec<(&'static str, &'static str)>) -> Vec<&'static str> {
+            v.iter().map(|(k, _)| *k).collect()
+        }
+        assert!(render_env("gpu", true, Some("0x8086")).is_empty());
+        assert_eq!(
+            names(render_env("safe", false, None)),
+            ["WEBKIT_DISABLE_DMABUF_RENDERER", "WEBKIT_DISABLE_COMPOSITING_MODE"]
+        );
+        assert_eq!(
+            names(render_env("auto", true, Some("0x8086"))),
+            ["WEBKIT_DISABLE_DMABUF_RENDERER", "WEBKIT_DISABLE_COMPOSITING_MODE"]
+        );
+        assert_eq!(names(render_env("auto", true, Some("0x10de"))), ["WEBKIT_DISABLE_DMABUF_RENDERER"]);
+        assert_eq!(names(render_env("auto", false, Some("0x8086"))), ["WEBKIT_DISABLE_DMABUF_RENDERER"]);
+    }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -16,12 +16,33 @@ fn main() {
     if std::env::args().any(|a| a == "--headless") {
         return weatherdesk_lib::run_headless();
     }
-    // WebKitGTK's DMABUF renderer draws a blank window on some Wayland stacks (seen on
-    // Hyprland + Intel UHD 600, same class as the NVIDIA/Wayland Error 71 in dev). Disable
-    // it unless the user set the variable themselves; costs the GPU compositing path.
+    // WebKitGTK renderer knobs. Which ones depend on the box: the AppImage runs under XWayland
+    // and an Intel iGPU there draws a blank window unless compositing is software too. Mode comes
+    // from `WD_RENDER`, `--render <mode>`, then the saved setting, so a blank window can be fixed
+    // from any browser on the LAN. Only set what the user has not set themselves.
     #[cfg(target_os = "linux")]
-    if std::env::var_os("WEBKIT_DISABLE_DMABUF_RENDERER").is_none() {
-        std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+    {
+        let args: Vec<String> = std::env::args().collect();
+        let flag = args.iter().position(|a| a == "--render").and_then(|i| args.get(i + 1)).cloned();
+        let cfg = weatherdesk_lib::default_config_dir().join("config.json");
+        let mode = std::env::var("WD_RENDER")
+            .ok()
+            .or(flag)
+            .or_else(|| weatherdesk_lib::setting(&cfg, "render").map(|s| s.trim_matches('"').to_string()))
+            .unwrap_or_else(|| "auto".into());
+        let appimage = std::env::var_os("APPIMAGE").is_some();
+        let vendor = weatherdesk_lib::gpu_vendor();
+        let mut set = vec![];
+        for (k, v) in weatherdesk_lib::render_env(&mode, appimage, vendor.as_deref()) {
+            if std::env::var_os(k).is_none() {
+                std::env::set_var(k, v);
+                set.push(k);
+            }
+        }
+        eprintln!(
+            "weatherdesk: render={mode} appimage={appimage} gpu={} set={set:?}",
+            vendor.as_deref().unwrap_or("unknown")
+        );
     }
     #[cfg(feature = "gui")]
     weatherdesk_lib::run();

--- a/src-tauri/src/server.rs
+++ b/src-tauri/src/server.rs
@@ -38,7 +38,8 @@ pub struct State {
     pub packets: Mutex<HashMap<String, String>>,
     pub cfg_path: PathBuf,
     pub data_dir: PathBuf,
-    /// (tz, oldest ts, newest ts, body) — see `/history/daily`.
+    /// (tz, oldest ts, local midnight, everything before today) — see `/history/daily`. Today's
+    /// row is appended per request; the head only changes when the day turns or history is pruned.
     daily: Mutex<Option<(i64, i64, i64, String)>>,
     /// The ingest path's connection, opened once and kept. Every reading used to open a fresh
     /// SQLite handle (file open, WAL header read, pragmas, schema check) a few times a second.
@@ -274,6 +275,24 @@ pub fn query(url: &str, key: &str) -> Option<String> {
         .map(String::from)
 }
 
+/// The archive window a `/history/tuples` request is asking for.
+///
+/// `hours` is the old contract and still the default; `from`+`to` is what a click on a chart
+/// point sends. A week is the cap either way — the page draws pixels, not a data dump — and an
+/// explicit range keeps its `to` end, because that is the moment the viewer clicked. Without a
+/// `to` there is no upper bound at all: a hub whose clock runs a few seconds fast would otherwise
+/// lose the newest row it just wrote.
+pub fn window(url: &str, now: u64) -> (i64, i64) {
+    let n = |k| query(url, k).and_then(|v| v.parse::<i64>().ok());
+    match (n("from"), n("to")) {
+        (Some(from), Some(to)) => (to.saturating_sub(168 * 3600).max(from), to),
+        _ => {
+            let hours = n("hours").unwrap_or(3).clamp(1, 168);
+            (now as i64 - hours * 3600, i64::MAX)
+        }
+    }
+}
+
 fn asset(path: &str) -> Option<(Vec<u8>, &'static str)> {
     let rel = path.trim_start_matches('/');
     let rel = if rel.is_empty() { "index.html" } else { rel };
@@ -473,33 +492,43 @@ fn handle(state: &Arc<State>, mut req: Request) {
                 None => Response::empty(502).with_header(header("Access-Control-Allow-Origin", "*")).boxed(),
             }
         }
+        // The US Drought Monitor, via the FCC's county lookup. Neither serves CORS headers, and
+        // the coordinates in both URLs are the house — see api::drought.
+        "/proxy/drought" => json(crate::api::drought(&state.cfg_path)),
         "/history/daily" => {
-            let tz = query(&url, "tz").and_then(|v| v.parse::<i64>().ok()).unwrap_or(0);
+            // Clamped: a hostile `tz` must not overflow the day arithmetic and panic a worker,
+            // and a panicked worker is never replaced. ±14 h is the widest real offset.
+            let tz = query(&url, "tz").and_then(|v| v.parse::<i64>().ok()).unwrap_or(0).clamp(-840, 840);
             let Some(conn) = state.db() else { return drop(req.respond(Response::empty(503))) };
-            let (min, max) = store::stamp(&conn);
+            let (min, _max) = store::stamp(&conn);
+            let ds = store::day_start(now() as i64, tz);
             // The lock is not held across the query: a slow aggregate would otherwise block
             // every other screen asking the same question.
             let hit = {
                 let cache = state.daily.lock().unwrap();
                 match cache.as_ref() {
-                    Some((t, c, m, body)) if (*t, *c, *m) == (tz, min, max) => Some(body.clone()),
+                    Some((t, c, d, head)) if (*t, *c, *d) == (tz, min, ds) => Some(head.clone()),
                     _ => None,
                 }
             };
-            let body = hit.unwrap_or_else(|| {
-                let fresh = store::daily_json(&conn, tz);
-                *state.daily.lock().unwrap() = Some((tz, min, max, fresh.clone()));
+            // The head is every day but today: a full-table aggregate, and one that cannot change
+            // until midnight or a prune. Today's row is a primary-key range scan, cheap enough to
+            // redo per request — which is what keeps the archive's growth off this endpoint.
+            let head = hit.unwrap_or_else(|| {
+                let fresh = store::daily_head_json(&conn, tz, ds);
+                *state.daily.lock().unwrap() = Some((tz, min, ds, fresh.clone()));
                 fresh
             });
+            let body = store::daily_join(&head, store::daily_today_row(&conn, tz, ds).as_deref());
             json(body)
         }
         // The raw archive, SI, in `store::FIELDS` order. `/history/daily` answers the almanac's
         // question; this one answers the Data tab's, which for a non-Tempest station is the only
         // way to draw a trend — there is no cloud to ask.
         "/history/tuples" => {
-            let hours = query(&url, "hours").and_then(|v| v.parse::<i64>().ok()).unwrap_or(3).clamp(1, 168);
+            let (from, to) = window(&url, now());
             let Some(conn) = state.db() else { return drop(req.respond(Response::empty(503))) };
-            json(store::tuples_json(&conn, hours))
+            json(store::tuples_json(&conn, from, to))
         }
         "/history/coverage" => {
             let Some(conn) = state.db() else { return drop(req.respond(Response::empty(503))) };
@@ -720,6 +749,21 @@ pub fn start_backfill(state: Arc<State>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The window a history request asks for: the old `hours` contract, and the explicit range a
+    /// click on a chart point sends — capped, but from the end the viewer clicked.
+    #[test]
+    fn tuples_window_defaults_to_hours_and_caps_an_explicit_range() {
+        let now = 1_700_000_000u64;
+        assert_eq!(window("/history/tuples", now), (now as i64 - 3 * 3600, i64::MAX));
+        assert_eq!(window("/history/tuples?hours=48", now), (now as i64 - 48 * 3600, i64::MAX));
+        // Out of range and nonsense both fall back inside the clamp rather than scanning the archive.
+        assert_eq!(window("/history/tuples?hours=100000", now), (now as i64 - 168 * 3600, i64::MAX));
+        assert_eq!(window("/history/tuples?hours=x", now), (now as i64 - 3 * 3600, i64::MAX));
+        assert_eq!(window("/history/tuples?from=100&to=200", now), (100, 200));
+        let (from, to) = window("/history/tuples?from=0&to=1000000000", now);
+        assert_eq!((from, to), (1_000_000_000 - 168 * 3600, 1_000_000_000));
+    }
 
     /// The header contract, end to end: a real request over a real socket, because the etag and
     /// the cache policy are only worth anything if they reach the wire.

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -138,16 +138,66 @@ pub fn migrate_jsonl(conn: &mut Connection, log_dir: &Path) {
 /// offset because the process has no notion of a timezone and "yesterday" has to mean the same
 /// day the user saw.
 pub fn daily_json(conn: &Connection, tz_off_min: i64) -> String {
-    let mut stmt = match conn.prepare(
+    let ds = day_start(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0),
+        tz_off_min,
+    );
+    daily_join(&daily_head_json(conn, tz_off_min, ds), daily_today_row(conn, tz_off_min, ds).as_deref())
+}
+
+/// Midnight local, as an epoch second. `div_euclid` rather than `/`: a negative offset west of
+/// Greenwich would otherwise round towards zero and land the boundary a day out.
+pub fn day_start(now: i64, tz_off_min: i64) -> i64 {
+    let off = tz_off_min * 60;
+    (now + off).div_euclid(86400) * 86400 - off
+}
+
+/// Everything before today. This is the expensive half — a full-table GROUP BY of every reading
+/// the archive holds — and it is also the half that cannot change any more, so the server caches
+/// it across requests and only today's row is recomputed.
+pub fn daily_head_json(conn: &Connection, tz_off_min: i64, day_start: i64) -> String {
+    rows_json(
+        conn,
         "SELECT strftime('%Y-%m-%d', ts + ?1, 'unixepoch'),
                 MIN(temp), MAX(temp), MAX(wind_gust), SUM(rain), SUM(strikes), MIN(battery)
-         FROM obs GROUP BY 1 ORDER BY 1",
-    ) {
-        Ok(s) => s,
-        Err(_) => return "[]".into(),
-    };
+         FROM obs WHERE ts < ?2 GROUP BY 1 ORDER BY 1",
+        tz_off_min,
+        day_start,
+    )
+    .map(|v| format!("[{}]", v.join(",")))
+    .unwrap_or_else(|| "[]".into())
+}
+
+/// Today, over the primary key range — an index lookup rather than a scan. `None` on a day with
+/// no readings yet, which is what the `GROUP BY` returns for an empty range.
+pub fn daily_today_row(conn: &Connection, tz_off_min: i64, day_start: i64) -> Option<String> {
+    rows_json(
+        conn,
+        "SELECT strftime('%Y-%m-%d', ts + ?1, 'unixepoch'),
+                MIN(temp), MAX(temp), MAX(wind_gust), SUM(rain), SUM(strikes), MIN(battery)
+         FROM obs WHERE ts >= ?2 GROUP BY 1 ORDER BY 1",
+        tz_off_min,
+        day_start,
+    )?
+    .pop()
+}
+
+/// Glue the cached head and today's row back into one array, without parsing either.
+pub fn daily_join(head: &str, today: Option<&str>) -> String {
+    match today {
+        None => head.to_string(),
+        Some(row) if head == "[]" => format!("[{row}]"),
+        Some(row) => format!("{},{row}]", head.trim_end_matches(']')),
+    }
+}
+
+fn rows_json(conn: &Connection, sql: &str, tz_off_min: i64, day_start: i64) -> Option<Vec<String>> {
+    let mut stmt = conn.prepare(sql).ok()?;
     let n = |v: Option<f64>| v.map(|x| x.to_string()).unwrap_or_else(|| "null".into());
-    let rows = stmt.query_map([tz_off_min * 60], |r| {
+    let rows = stmt.query_map([tz_off_min * 60, day_start], |r| {
         Ok(format!(
             "{{\"day\":\"{}\",\"tempMin\":{},\"tempMax\":{},\"gustMax\":{},\"rain\":{},\"strikes\":{},\"battMin\":{}}}",
             r.get::<_, String>(0)?,
@@ -159,26 +209,40 @@ pub fn daily_json(conn: &Connection, tz_off_min: i64) -> String {
             n(r.get(6)?)
         ))
     });
-    let body: Vec<String> = match rows {
-        Ok(it) => it.flatten().collect(),
-        Err(_) => return "[]".into(),
-    };
-    format!("[{}]", body.join(","))
+    rows.ok().map(|it| it.flatten().collect())
+}
+
+/// Delete the oldest week of readings that is older than `cutoff`, and say how many went.
+///
+/// A week at a time on purpose: two connections write to this file (the ingest path and the UDP
+/// listener, which gives up after its ten-second busy timeout and silently drops the reading), so
+/// nothing here may hold the write lock for longer than milliseconds. The caller loops until it
+/// returns 0.
+///
+/// ponytail: no VACUUM — it holds the whole file and balloons the WAL. Freed pages are reused, so
+/// the file plateaus rather than shrinks; `sqlite3 weatherdesk.db VACUUM` with the app stopped is
+/// the escape hatch if the size ever actually matters.
+pub fn prune(conn: &Connection, cutoff: i64) -> usize {
+    conn.execute(
+        "DELETE FROM obs WHERE ts < MIN(?1, (SELECT MIN(ts) FROM obs) + 7*86400)",
+        [cutoff],
+    )
+    .unwrap_or(0)
 }
 
 /// Cheap cache key for the aggregate above: the table is append-only in practice, so a row
 /// count and the newest timestamp change whenever the answer would.
 /// Recent rows, whole tuples, newest last — the shape `api.js` already reads for a Tempest's
 /// cloud history, so the page's trend code needs no second parser.
-pub fn tuples_json(conn: &Connection, hours: i64) -> String {
+pub fn tuples_json(conn: &Connection, from: i64, to: i64) -> String {
     let cols = FIELDS.join(", ");
     let mut stmt = match conn.prepare(&format!(
-        "SELECT ts, {cols} FROM obs WHERE ts >= strftime('%s','now') - ?1 ORDER BY ts"
+        "SELECT ts, {cols} FROM obs WHERE ts >= ?1 AND ts <= ?2 ORDER BY ts"
     )) {
         Ok(s) => s,
         Err(_) => return "{\"obs\":[]}".into(),
     };
-    let rows = stmt.query_map([hours * 3600], |r| {
+    let rows = stmt.query_map([from, to], |r| {
         let mut out = vec![r.get::<_, i64>(0)?.to_string()];
         for i in 1..=FIELDS.len() {
             out.push(r.get::<_, Option<f64>>(i)?.map(|v| v.to_string()).unwrap_or_else(|| "null".into()));
@@ -446,5 +510,72 @@ mod tests {
         insert(&c, &obs(1_700_020_800, 10.0, 1.0), SRC_UDP);
         assert!(daily_json(&c, 0).contains("2023-11-15"));
         assert!(daily_json(&c, -300).contains("2023-11-14"));
+    }
+
+    /// Retention deletes in week-sized bites so the write lock is never held long, and it stops
+    /// exactly at the cutoff rather than one bite past it.
+    #[test]
+    fn prune_walks_a_week_at_a_time_and_stops_at_the_cutoff() {
+        let c = open(std::path::Path::new(":memory:")).unwrap();
+        let day = 86_400i64;
+        for d in [0i64, 5, 10, 20, 30] {
+            insert(&c, &obs(d * day, 20.0, 0.0), SRC_UDP);
+        }
+        let cutoff = 25 * day;
+        let mut rounds = 0;
+        while prune(&c, cutoff) > 0 {
+            rounds += 1;
+            assert!(rounds < 10, "prune is not making progress");
+        }
+        // Days 0/5 go together (one week from the oldest), then 10, then 20 — three rounds.
+        assert_eq!(rounds, 3);
+        assert_eq!(stamp(&c), (30 * day, 30 * day), "only the rows past the cutoff are left");
+        assert_eq!(prune(&c, cutoff), 0, "a settled archive is a no-op");
+
+        let empty = open(std::path::Path::new(":memory:")).unwrap();
+        assert_eq!(prune(&empty, cutoff), 0, "an empty archive is not an error");
+    }
+
+    /// The expensive half of /history/daily is everything before today, and it must not change
+    /// when today's readings land — that is the whole basis for caching it.
+    #[test]
+    fn today_s_row_is_appended_without_recomputing_the_head() {
+        // 2023-11-15 00:00 UTC.
+        let midnight = 1_700_006_400i64;
+        assert_eq!(day_start(midnight + 3600, 0), midnight);
+        assert_eq!(day_start(midnight - 1, 0), midnight - 86400);
+        // Five hours west: local midnight is 05:00 UTC, so 02:00 UTC is still yesterday.
+        assert_eq!(day_start(midnight + 2 * 3600, -300), midnight - 86400 + 5 * 3600);
+
+        let c = open(std::path::Path::new(":memory:")).unwrap();
+        insert(&c, &obs(midnight - 3600, 10.0, 1.0), SRC_UDP);
+        let head = daily_head_json(&c, 0, midnight);
+        assert!(head.contains("2023-11-14"));
+        assert!(daily_today_row(&c, 0, midnight).is_none(), "an empty day has no row");
+
+        insert(&c, &obs(midnight + 3600, 20.0, 2.0), SRC_UDP);
+        assert_eq!(daily_head_json(&c, 0, midnight), head, "today's reading never touches the head");
+        let today = daily_today_row(&c, 0, midnight).unwrap();
+        assert!(today.contains("2023-11-15") && today.contains("\"tempMax\":20"));
+
+        let joined = daily_join(&head, Some(&today));
+        let rows: Vec<serde_json::Value> = serde_json::from_str(&joined).unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(daily_join("[]", None), "[]");
+        assert_eq!(daily_join("[]", Some("{\"day\":\"x\"}")), "[{\"day\":\"x\"}]");
+    }
+
+    /// Both ends of the window are honoured — the detail panel asks for a day either side of the
+    /// point that was clicked, which is the first caller that ever needed an upper bound.
+    #[test]
+    fn tuples_honour_both_ends_of_the_window() {
+        let c = open(std::path::Path::new(":memory:")).unwrap();
+        for t in [1_000i64, 2_000, 3_000] {
+            insert(&c, &obs(t, 20.0, 0.0), SRC_UDP);
+        }
+        let body = tuples_json(&c, 1_500, 2_500);
+        assert!(body.contains("[2000,"), "the row inside the window is there");
+        assert!(!body.contains("[1000,") && !body.contains("[3000,"), "the rows outside it are not");
+        assert_eq!(tuples_json(&c, 9_000, 9_999), "{\"obs\":[]}");
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "WeatherDesk",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "identifier": "io.github.davidmay87.weatherdesk",
   "build": {
     "frontendDist": "../site"


### PR DESCRIPTION
The batch the interview picked: fix the bug on real hardware first, put a check in CI so the next release is not shipped blind, then the features.

## Fixed

**Blank window on Linux.** The 3.2.3 fix (`WEBKIT_DISABLE_DMABUF_RENDERER=1`) was inferred, not tested, and it was not enough: the AppImage always runs under XWayland (linuxdeploy's GTK hook exports `GDK_BACKEND=x11`) and an Intel iGPU there needs software compositing too. Since that flag slows down the setups that work, it is not unconditional:

- `render_env(mode, appimage, gpu_vendor)` in `lib.rs`, pure and table-tested. `gpu` sets nothing, `safe` sets both, `auto` sets DMABUF off plus compositing off only for AppImage + `0x8086`.
- Mode from `WD_RENDER` → `--render <mode>` → the `render` setting → `auto`, applied only where the user has not set the variable.
- One stderr line at startup: `weatherdesk: render=auto appimage=true gpu=0x8086 set=[...]` — the next report will not be blind.
- The setting syncs through `config.json`, so a machine showing a blank window is fixable from a phone at `http://<it>:8088`.

Still to confirm against the Chromebook diagnostic; the `auto` rule is the one line that would change if it shows something else.

## Added

- **CI** (`.github/workflows/ci.yml`): `cargo test`, plus `.github/ci/selftest.sh` loading the whole site in headless Chrome at full/lite/off × 1920×1080 / 780×360 / 412×915. Fails on any `console.assert`, on a missing `data-selftest="ok"` sentinel (the closest a bundler-free site gets to a compile check), or on the wrong icon set for the motion level. Nine screenshots kept as an artifact — the 3.3.0 tween bug was only ever visible in one.
- **Phone one-column pass**: in portrait `body` reverses to `column-reverse`, so the tabs and the gear land under the thumb with no fixed positioning; 44 px targets, 16 px inputs (no zoom-on-focus), sticky Save.
- **Dim ramps with the sun**: `dimLevel()` is a linear ramp over the hour after sunset / before sunrise, evaluated every minute instead of every fifteen, driving `--dim` through a 60 s transition.
- **Voice**: `say()` extracted from the alert path; the hero icon is a button that reads the day out (reading, high/low, the story, the alert state), and `Settings → Spoken briefing at` schedules one a day.
- **Rules**: seven new metrics. `temp1h` / `press1h` / `rh1h` off a widened ring, and `low18h` / `rain6h` / `gust24h` / `hiTomorrow` off the forecast, re-evaluated the moment a forecast lands. Compound AND rules already existed — nothing needed there.
- **Chart click**: `nearest()` factored out of `crosshair()` and shared with a `click` handler; `openDetail(metric, at)` windows the archive a day either side of the point using the new `from`/`to`.
- **Still radar**: below Full motion the Desk shows one `img.hookecho.io/snapshot.png` every five minutes instead of the wasm viewer. Cache-busted per five-minute bucket (Cloudflare rewrites the browser TTL to four hours). No new setting: Motion → Full puts the loop back.
- **Drought Monitor** on the Fire card, FCC county lookup then USDM, both through the Rust side. Verified live against Tarrant County. `Accept: application/json` is load-bearing — without it the service answers CSV.
- **Retention**: forever / 1 / 2 / 5 / 10 years, confirmed once before shortening, pruned hourly. No VACUUM by design.

## Changed

- **Ingest counters persist** in `meta` alongside every insert, so rain that fell during a restart is scored once. A seed older than a day starts cold instead of charging a day of rain to one interval.
- **`/history/daily` is incremental**: everything before local midnight is aggregated once and cached; only today's row (a primary-key range) is recomputed per request. `tz` is clamped — a panicked worker is never replaced.

## Checked

- `cargo test`: 45 → 52. New: `render_env`, counters across a restart and a rollover, daily head/today/join, prune walking a week at a time, both tuples windows, drought week picking.
- `bash .github/ci/selftest.sh` clean, screenshots reviewed.
- The new routes curled against a headless build on a spare port: `/proxy/drought` returned the live county row, `/history/tuples?from&to` honours both ends, `/history/daily` unchanged in shape.

Not verified: the AppImage on the Chromebook (pending the user's diagnostic), and whether the Android WebView actually speaks the briefing.