### PR TITLE
fix: chart pick, briefing pacing, daily cache during backfill, forecast max

### DIFF
--- a/site/js/app.js
+++ b/site/js/app.js
@@ -418,7 +418,8 @@ const jobs = new Map();
 // a battery percent.
 // 'pace' itself is exempt for an obvious reason: stretched to 45 minutes it would be the thing
 // that never notices the night window closing.
-const PACE_EXEMPT = ['clock', 'udp', 'desk-alerts', 'pace', 'stale-sweep', 'kiosk', 'appearance'];
+// `dim` and `intel-brief` are clocks: tripled at night they would miss their minute.
+const PACE_EXEMPT = ['clock', 'udp', 'desk-alerts', 'pace', 'stale-sweep', 'kiosk', 'appearance', 'dim', 'intel-brief'];
 
 // Set by desk.js when NWS has a Severe/Extreme alert out. Beats eco and night both.
 let storm = false;

--- a/site/js/charts.js
+++ b/site/js/charts.js
@@ -151,6 +151,10 @@ export function chart(canvas, series, opts = {}) {
 // mouse events so a tablet gets the same readout from a fingertip.
 function bindHover(canvas, series, opts) {
   canvas._wdDraw = () => chart(canvas, series, opts);
+  // The listeners below are bound once, but the explorer redraws the same canvas with a different
+  // `onPick` per metric — so the click reads the latest opts, not the ones it was bound with.
+  canvas._wdOpts = opts;
+  canvas.style.cursor = opts.onPick ? 'pointer' : '';
   if (canvas._wdBound || opts.hover === false) return;
   canvas._wdBound = true;
   // One redraw per frame however fast the pointer reports.
@@ -168,12 +172,12 @@ function bindHover(canvas, series, opts) {
   // A click is a hover that stopped: `move` has already run, so the pick is whatever the readout
   // is showing. Nothing to do on a chart nobody wired an `onPick` to.
   canvas.addEventListener('click', (e) => {
-    if (!opts.onPick) return;
+    const onPick = canvas._wdOpts?.onPick;
+    if (!onPick) return;
     const hx = e.clientX - canvas.getBoundingClientRect().left;
     const m = canvas._wdNearest?.(hx)?.[0];
-    if (m) opts.onPick(m.p, m.name);
+    if (m) onPick(m.p, m.name);
   });
-  canvas.style.cursor = opts.onPick ? 'pointer' : '';
   canvas.addEventListener('pointermove', move);
   canvas.addEventListener('pointerdown', move);
   canvas.addEventListener('pointerleave', clear);
@@ -214,6 +218,11 @@ if (typeof window !== 'undefined' && location.search.includes('selftest')) {
     picked = null;
     cv2.dispatchEvent(new MouseEvent('click', { clientX: 400 }));
     console.assert(picked === null, 'chart: a click nowhere near a sample picks nothing');
+    // Redrawn without a pick: the old handler must not keep firing the old callback.
+    chart(cv2, [{ data: [{ x: 0, y: 1 }], color: '#f00', name: 'a' }], {});
+    cv2._wdNearest = () => [{ p: { x: 0, y: 1 }, name: 'a' }];
+    cv2.dispatchEvent(new MouseEvent('click', { clientX: 4 }));
+    console.assert(picked === null && cv2.style.cursor === '', 'chart: a redraw replaces the pick handler');
   }
   cv._wdHover = null;
   chart(cv, [{ type: 'band', data: [{ x: 0, lo: 1, hi: 9 }, { x: 1, lo: 2, hi: 8 }], color: '#0f0' }]);

--- a/site/js/intel.js
+++ b/site/js/intel.js
@@ -213,9 +213,12 @@ function briefTick() {
   const want = settings().briefTime;
   if (!want) return;
   const now = new Date();
-  const hhmm = `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`;
+  const [h, m] = want.split(':').map(Number);
+  // A window, not an exact minute: the job is a setInterval, and a tab that was hidden or throttled
+  // can skip the one tick that matched. Five minutes late is still the morning briefing.
+  const late = now.getHours() * 60 + now.getMinutes() - (h * 60 + m);
   const day = now.toDateString();
-  if (hhmm !== want || briefedDay === day) return;
+  if (late < 0 || late >= 5 || briefedDay === day) return;
   briefedDay = day;
   say(briefing());
 }

--- a/site/js/rules.js
+++ b/site/js/rules.js
@@ -107,7 +107,8 @@ export function forecastMetrics(fc) {
   const daily = fc?.forecast?.daily || [];
   const now = Date.now() / 1000;
   const within = (h) => hourly.filter((x) => x.time >= now && x.time <= now + h * 3600);
-  const max = (arr, key) => (arr.length ? Math.max(...arr.map((x) => x[key] || 0)) : null);
+  // Missing values are missing, not zero: a forecast with no gust field must not read as calm.
+  const max = (arr, key) => { const v = arr.map((x) => x[key]).filter((x) => x != null); return v.length ? Math.max(...v) : null; };
   const next18 = within(18).map((x) => x.air_temperature).filter((v) => v != null);
   return {
     low18h: next18.length ? Math.min(...next18) : null,

--- a/src-tauri/src/server.rs
+++ b/src-tauri/src/server.rs
@@ -504,10 +504,13 @@ fn handle(state: &Arc<State>, mut req: Request) {
             let ds = store::day_start(now() as i64, tz);
             // The lock is not held across the query: a slow aggregate would otherwise block
             // every other screen asking the same question.
+            // Backfill writes past days while it runs, which nothing in the key can see: no cache
+            // until it is done.
+            let filling = *state.backfill.lock().unwrap() == "running";
             let hit = {
                 let cache = state.daily.lock().unwrap();
                 match cache.as_ref() {
-                    Some((t, c, d, head)) if (*t, *c, *d) == (tz, min, ds) => Some(head.clone()),
+                    Some((t, c, d, head)) if !filling && (*t, *c, *d) == (tz, min, ds) => Some(head.clone()),
                     _ => None,
                 }
             };
@@ -516,7 +519,9 @@ fn handle(state: &Arc<State>, mut req: Request) {
             // redo per request — which is what keeps the archive's growth off this endpoint.
             let head = hit.unwrap_or_else(|| {
                 let fresh = store::daily_head_json(&conn, tz, ds);
-                *state.daily.lock().unwrap() = Some((tz, min, ds, fresh.clone()));
+                if !filling {
+                    *state.daily.lock().unwrap() = Some((tz, min, ds, fresh.clone()));
+                }
                 fresh
             });
             let body = store::daily_join(&head, store::daily_today_row(&conn, tz, ds).as_deref());
@@ -741,6 +746,8 @@ pub fn start_backfill(state: Arc<State>) {
         *state.backfill.lock().unwrap() = "running";
         store::backfill(&conn, &token, &device);
         *state.backfill.lock().unwrap() = "done";
+        // The cloud just wrote days that are all before today: the cached head is wrong now.
+        *state.daily.lock().unwrap() = None;
     });
 }
 


### PR DESCRIPTION
Review pass over 3.4.0. Four bugs, all with a check behind them; `cargo test` 52/52 and the headless selftest matrix 9/9 locally.

- **Chart click used a stale callback.** `bindHover` binds once per canvas and captured the first `opts`; the almanac explorer redraws the same canvas with a different `onPick` per metric, so after switching columns a click opened the wrong detail. Click now reads the opts of the latest draw. Selftest case added.
- **Scheduled briefing missed its minute.** `paceFor` triples non-exempt jobs at night and doubles them under eco, so the 60 s tick ran every 2–3 minutes and matched `HH:MM` by luck; `dim` became a staircase for the same reason. Both are pace-exempt; the briefing fires inside a five-minute window after the set time, once a day.
- **`/history/daily` cache stale during cloud backfill.** The head cache keys on `(tz, min_ts, day_start)`. Backfill walks forward from a cursor, so after its first chunk it writes past days without moving `min`, and the almanac stayed wrong until midnight. The cache is bypassed while backfill is `running` and cleared when it finishes.
- **Forecast max read a missing field as zero.** `x[key] || 0` made an hour without `wind_gust` score `gust24h = 0`. Nulls are filtered; empty means `null`, as `low18h` already did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)