### PR TITLE
WeatherDesk 4.0 — Timeline, recovery, and health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@ Raspberry Pi, an Android APK, and the `ghcr.io/d4vid87/weatherdesk` container im
 
 ## [Unreleased]
 
+## [4.0.0] - 2026-09-04
+
+### Added
+- **Weather Timeline.** A compact Desk strip and a full Timeline tab combine the past 24 hours
+  with the next 48: rain windows and the 15-minute nowcast, thunder, snow and ice, freezes,
+  heat index, strong wind, unhealthy air, rapid station changes, official alerts and sun times.
+  Adjacent hours become one event, quiet one-hour forecast noise is suppressed, and a click opens
+  the underlying observation detail. Thresholds and categories are configurable in Settings.
+- **Plain-language confidence.** Forecast events say High, Medium, Low or Unavailable and why,
+  using the existing GFS, ECMWF, ICON, GEM and HRRR guidance. Exact contributing values and data
+  age stay behind an expander.
+- **Health Center.** Browser, server, ingest, forecast, alert, radar and archive checks are shown
+  together with safe actions: retry, clear stale caches, use still radar, checkpoint SQLite,
+  save the Safe renderer or open the LAN dashboard. A copyable support report excludes secrets
+  and location.
+- **Complete `.wdbak` backup and restore.** One portable SQLite file carries history, settings,
+  layouts, rules and metadata. Restore is staged, inspected and confirmed; corrupt, incomplete or
+  newer formats are rejected before live data changes. Applying it keeps a pre-restore recovery
+  bundle and rolls back failures.
+- **Browser fallback.** `--browser` runs the server and opens the dashboard without a webview.
+  On Linux, a native window that never becomes ready automatically opens that same dashboard in
+  the system browser after 20 seconds, so the Chromebook EGL failure no longer strands the app.
+- First-run setup now shows explicit station, first-reading and forecast verification progress.
+
+### Changed
+- `/health` exposes redacted server and archive status; `/health/action` accepts only fixed safe
+  actions. `/backup.wdbak`, `/restore/inspect` and `/restore/apply` form the recovery interface.
+- Open-Meteo forecast hours now retain relative humidity so heat events use heat index rather
+  than air temperature alone.
+
 ## [3.4.0] - 2026-09-03
 
 ### Fixed

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: David May <davidmay87@gmail.com>
 pkgname=weatherdesk
-pkgver=3.4.0
+pkgver=4.0.0
 pkgrel=1
 pkgdesc="Self-hosted dashboard for a WeatherFlow Tempest station"
 arch=('x86_64' 'aarch64')

--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ bottom](docs/screenshot-national.png)
   change, moonrise/set), fire weather & dryness (including the county's US Drought Monitor class,
   on installs that run the app's own server), and station health (battery, signal, sensor
   faults, time since the last report).
+- **Timeline** — one continuous view from 24 hours ago through the next 48 hours. It merges rain,
+  storms, winter weather, freeze and heat-index crossings, wind, air quality, rapid station
+  changes, sun times and official alerts into readable windows. Forecast events carry a
+  plain-language confidence label; expand one for the contributing model values and source age.
+  The three nearest events also appear on the Desk. Timeline events do not notify by themselves.
 - **Forecast Lab** — radar, embedded from [HookEcho](https://hookecho.io/).
 
 The Desk radar loads itself, in HookEcho's embedded mode: no chrome, and one frame a minute until
@@ -451,10 +456,11 @@ incoming reading never has to wait for it. There is no undo and most stations ha
 restore from, so it asks once before shortening the window. The file itself does not shrink — the
 freed space is reused — and `sqlite3 weatherdesk.db VACUUM` with the app stopped will reclaim it.
 
-`Settings → History CSV` hands the whole archive over as a spreadsheet, and `Backup archive`
-downloads a consistent snapshot of the database itself. To restore one: quit the app, copy the file
-over `<app data>/weatherdesk.db` (delete the `-wal` and `-shm` files beside it if they exist), and
-start it again.
+`Settings → History CSV` hands the whole archive over as a spreadsheet. `Complete backup` downloads
+one `.wdbak` SQLite file containing the archive, settings, layouts, rules and metadata. `Restore
+backup` inspects it first, shows its station, row count and date range, then applies it only after
+confirmation. WeatherDesk keeps the previous state as `pre-restore.wdbak`; invalid or newer
+formats do not touch the running data.
 
 **CWOP.** Put a callsign in `Settings → CWOP station ID` and the app reports your readings to the
 Citizen Weather Observer Program every ten minutes, where NOAA's MADIS feeds them to the models
@@ -583,6 +589,10 @@ open — for a phone that is asleep, use the ntfy channel.
 Settings → **Diagnostics** pings every source and prints ✓/✗ plus latency for each, along with the
 viewport size. Start there — it separates "my token is wrong" from "NWS is down".
 
+The **Health Center** adds server uptime, archive integrity and safe repair buttons. **Copy support
+report** produces a redacted report with version, platform, viewport, renderer and source status;
+it never contains credentials, webhook addresses or station coordinates.
+
 | What you see | What it means |
 |---|---|
 | *token rejected: create or check a personal use token…* | The token is wrong, expired, or was never created. tempestwx.com → Settings → Data Authorizations. |
@@ -608,6 +618,9 @@ If that draws, make it permanent in `Settings → Window rendering → Safe`, wh
 any browser on the LAN (`http://<that machine>:8088`) — a blank window is still a working server.
 The app prints one line at startup saying which mode it picked and what it set. The AUR build,
 which links the system WebKitGTK, generally does not need any of this.
+
+If the webview never becomes ready, WeatherDesk 4 opens its still-running LAN dashboard in the
+default browser after 20 seconds. `weatherdesk --browser` chooses that reliable mode immediately.
 
 ## Security
 

--- a/site/index.html
+++ b/site/index.html
@@ -25,6 +25,7 @@
 <link rel="modulepreload" href="js/icons.js">
 <link rel="modulepreload" href="js/motion.js">
 <link rel="modulepreload" href="js/sky.js">
+<link rel="modulepreload" href="js/timeline.js">
 <style>
   @font-face { font-family: 'Barlow SC'; font-style: normal; font-weight: 500; font-display: swap;
     src: url(fonts/barlow-semi-condensed-500.woff2) format('woff2'); }
@@ -670,6 +671,29 @@
     border: 1px solid var(--line); border-radius: 8px; font: inherit; }
   .notif-x { position: absolute; top: 4px; right: 6px; background: none; border: 0; color: var(--muted);
     font-size: 16px; cursor: pointer; }
+  .timeline-strip { display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:8px; }
+  .tl-event { display:grid; gap:3px; padding:10px; border:1px solid var(--line); border-left:4px solid var(--accent);
+    border-radius:8px; background:var(--panel2); cursor:pointer; min-width:0; }
+  .tl-event.sev-watch { border-left-color:var(--warn); }
+  .tl-event.sev-warning { border-left-color:var(--bad); }
+  .tl-event > span { color:var(--muted); font-size:12px; }
+  .tl-when { color:var(--muted); font-size:11px; text-transform:uppercase; letter-spacing:.05em; }
+  #timeline-list { display:grid; gap:8px; max-width:900px; margin:0 auto; }
+  #timeline-range { position:sticky; top:0; z-index:2; background:var(--bg); padding:10px 0; text-align:center; }
+  #timeline-axis { display:grid; grid-template-columns:1fr 2fr; height:8px; max-width:900px; margin:0 auto 12px;
+    border-radius:8px; overflow:visible; position:relative; background:var(--line); }
+  #timeline-axis .observed { background:var(--muted); border-radius:8px 0 0 8px; }
+  #timeline-axis .forecast { background:var(--accent); border-radius:0 8px 8px 0; opacity:.7; }
+  #timeline-axis::after { content:'NOW'; position:absolute; left:33.333%; top:-7px; transform:translateX(-50%);
+    color:var(--text); background:var(--bg); padding:0 4px; font-size:10px; }
+  #timeline-filters { display:flex; flex-wrap:wrap; gap:5px; max-width:900px; margin:0 auto 12px; }
+  #timeline-filters button { color:var(--muted); background:var(--panel2); border:1px solid var(--line);
+    border-radius:7px; padding:6px 9px; cursor:pointer; }
+  #timeline-filters button.active { border-color:var(--accent); color:var(--text); }
+  #timeline-title { max-width:900px; margin:0 auto; }
+  html[data-motion="full"] .tl-event { transition:transform .18s ease,border-color .18s ease; }
+  html[data-motion="full"] .tl-event:hover, .tl-event:focus-visible { transform:translateY(-2px); border-color:var(--accent); }
+  @media(max-width:720px) { .timeline-strip { grid-template-columns:1fr; } }
 </style>
 </head>
 <body>
@@ -678,6 +702,7 @@
   <h1>WEATHERDESK</h1>
   <nav>
     <button class="tab" data-section="desk">Desk</button>
+    <button class="tab" data-section="timeline">Timeline</button>
     <button class="tab" data-section="lab">Forecast Lab</button>
     <button class="tab" data-section="signals">Local Signals</button>
     <button class="tab" data-section="data">Data</button>
@@ -697,6 +722,11 @@
   <div class="wizard-box">
     <img src="icon-512.png" alt="" loading="lazy" style="display:block;width:180px;max-width:60%;margin:0 auto 10px">
     <h2 style="margin-top:0;text-align:center">Welcome to WeatherDesk</h2>
+    <div id="wizard-progress" class="kv-rows" aria-label="Setup progress">
+      <div><span>1 · Choose a station</span><span id="wiz-step-source">current</span></div>
+      <div><span>2 · Receive a reading</span><span id="wiz-step-reading">waiting</span></div>
+      <div><span>3 · Verify forecast</span><span id="wiz-step-forecast">waiting</span></div>
+    </div>
     <p class="muted" style="font-size:13px">Pick the brand of station in the garden. Every brand
       except Tempest needs no token and no account — the readings come from your own sensors, the
       forecast from open-meteo.</p>
@@ -774,6 +804,10 @@
     </div>
 
     <div id="ticker" data-panel="ticker"><div id="ticker-track"></div><span id="src-health"></span><button id="ticker-pause">❚❚</button></div>
+
+    <div class="card" id="timeline-peek" data-panel="timeline-peek">
+      <h2>What happens next</h2><div id="timeline-strip" class="timeline-strip"></div>
+    </div>
 
     <div id="ha-panel" data-panel="ha" style="display:none">
       <h2 id="ha-stamp">Home Assistant<span id="mqtt-state" class="muted" style="float:right;font-size:12px"></span></h2>
@@ -879,6 +913,19 @@
 
   <!-- ponytail: Forecast Lab is the existing weathermap app in an iframe (radar loop, satellite,
        lightning, SPC, alerts already work there). Inline it into map.js only if the two need shared state. -->
+  <section class="page" id="timeline" aria-labelledby="timeline-title">
+    <h2 id="timeline-title">Weather timeline</h2>
+    <div id="timeline-range" class="muted"></div>
+    <div id="timeline-axis" aria-hidden="true"><span class="observed"></span><span class="forecast"></span></div>
+    <div id="timeline-filters" aria-label="Filter timeline">
+      <button data-tl-filter="all" class="active">All</button><button data-tl-filter="precip">Rain</button>
+      <button data-tl-filter="storm">Storm</button><button data-tl-filter="winter">Snow / ice</button>
+      <button data-tl-filter="freeze">Freeze</button><button data-tl-filter="heat">Heat</button>
+      <button data-tl-filter="wind">Wind</button><button data-tl-filter="aqi">Air</button>
+      <button data-tl-filter="change">Changes</button><button data-tl-filter="sun">Sun</button><button data-tl-filter="alert">Alerts</button>
+    </div>
+    <div id="timeline-list" aria-live="polite"></div>
+  </section>
   <section class="page" id="lab" style="padding:0"><iframe id="lab-frame" title="Forecast Lab"></iframe></section>
   <section class="page" id="signals">
     <div class="grid" id="signals-grid">
@@ -1116,11 +1163,26 @@
       <button id="btn-export">Export settings</button>
       <button id="btn-import">Import settings</button>
       <button id="btn-csv">History CSV</button>
-      <button id="btn-backup">Backup archive</button>
+      <button id="btn-backup">Complete backup</button>
+      <button id="btn-restore">Restore backup</button>
       <button id="btn-update">Check for updates</button>
       <span id="app-version" class="muted" style="font-size:12px;align-self:center"></span>
     </div>
     <input id="import-file" type="file" accept="application/json,.json" hidden>
+    <input id="restore-file" type="file" accept=".wdbak,application/octet-stream" hidden>
+    <section id="health-center">
+      <h2 style="font-size:13px;margin-top:18px">Health Center</h2>
+      <div id="health-summary" class="kv-rows"></div>
+      <div class="row">
+        <button data-health-action="retry">Retry now</button>
+        <button data-health-action="still">Use still radar</button>
+        <button data-health-action="clear">Clear stale cache</button>
+        <button data-health-action="checkpoint">Checkpoint archive</button>
+        <button data-health-action="safe">Use Safe renderer</button>
+        <button data-health-action="open">Open LAN dashboard</button>
+        <button id="btn-support">Copy support report</button>
+      </div>
+    </section>
     <div class="row" id="drawer-actions">
       <button class="primary" id="btn-save">Save</button>
       <button id="btn-diag">Diagnostics</button>
@@ -1158,9 +1220,24 @@
 
     <h2 style="font-size:13px;margin-top:18px">Tabs</h2>
     <div id="tab-toggles">
+      <label><input type="checkbox" data-tab="timeline"> Timeline</label>
       <label><input type="checkbox" data-tab="lab"> Forecast Lab</label>
       <label><input type="checkbox" data-tab="signals"> Local Signals</label>
       <label><input type="checkbox" data-tab="data"> Data</label>
+    </div>
+    <h2 style="font-size:13px;margin-top:18px">Timeline</h2>
+    <p class="muted" style="font-size:12px">Events stay here. Official warnings and explicit alert rules are the only things that notify.</p>
+    <label>Precipitation chance (%)</label><input id="set-tl-precip" type="number" min="0" max="100">
+    <label>Freeze threshold</label><input id="set-tl-freeze" type="number">
+    <label>Heat threshold</label><input id="set-tl-heat" type="number">
+    <label>Wind gust threshold</label><input id="set-tl-gust" type="number" min="0">
+    <label>Air quality threshold (AQI)</label><input id="set-tl-aqi" type="number" min="0">
+    <div class="checkgrid">
+      <label><input type="checkbox" data-tl-cat="precip"> Rain</label><label><input type="checkbox" data-tl-cat="storm"> Thunder</label>
+      <label><input type="checkbox" data-tl-cat="winter"> Snow / ice</label><label><input type="checkbox" data-tl-cat="freeze"> Freeze</label>
+      <label><input type="checkbox" data-tl-cat="heat"> Heat</label><label><input type="checkbox" data-tl-cat="wind"> Wind</label>
+      <label><input type="checkbox" data-tl-cat="aqi"> Air quality</label><label><input type="checkbox" data-tl-cat="sun"> Sun</label>
+      <label><input type="checkbox" data-tl-cat="change"> Rapid changes</label><label><input type="checkbox" data-tl-cat="alert"> Official alerts</label>
     </div>
     <h2 style="font-size:13px;margin-top:18px">Places</h2>
     <div class="row" style="margin-top:6px">

--- a/site/js/api.js
+++ b/site/js/api.js
@@ -297,6 +297,7 @@ export function shapeOm(j, ownTuple = null) {
   const hourly = times.map((t, i) => ({
     time: t,
     air_temperature: H.temperature_2m?.[i],
+    relative_humidity: H.relative_humidity_2m?.[i],
     precip_probability: H.precipitation_probability?.[i],
     wind_avg: H.wind_speed_10m?.[i],
     wind_gust: H.wind_gusts_10m?.[i],
@@ -367,7 +368,7 @@ export async function omForecast(lat = coords().lat, lon = coords().lon) {
     latitude: lat, longitude: lon,
     current: 'temperature_2m,relative_humidity_2m,dew_point_2m,apparent_temperature,is_day,'
       + 'weather_code,pressure_msl,surface_pressure,wind_speed_10m,wind_direction_10m,wind_gusts_10m',
-    hourly: 'temperature_2m,precipitation_probability,weather_code,wind_speed_10m,wind_gusts_10m,'
+    hourly: 'temperature_2m,relative_humidity_2m,precipitation_probability,weather_code,wind_speed_10m,wind_gusts_10m,'
       + 'wind_direction_10m,uv_index,shortwave_radiation,wet_bulb_temperature_2m,visibility',
     daily: 'weather_code,temperature_2m_max,temperature_2m_min,sunrise,sunset,'
       + 'precipitation_probability_max,precipitation_sum',

--- a/site/js/app.js
+++ b/site/js/app.js
@@ -62,6 +62,8 @@ const DEFAULTS = {
   render: 'auto',
   // Years of readings to keep, 0 = forever. Enforced by the Rust side, hourly.
   retentionYears: 0,
+  timeline: { precip: 30, freezeC: 0, heatC: 35, gustMs: 13.4112, aqi: 101,
+    categories: ['precip', 'storm', 'winter', 'freeze', 'heat', 'wind', 'aqi', 'change', 'sun', 'alert'] },
   // Quiet hours, 'HH:MM' each, both empty = off. Suppresses the chime and every push channel;
   // a Severe or Extreme alert still comes through, because that is what the setting is for.
   quietStart: '', quietEnd: '',

--- a/site/js/boot.js
+++ b/site/js/boot.js
@@ -16,6 +16,7 @@ import { initUdp } from './udp.js';
 import { initHome } from './home.js';
 import { initOutlook } from './outlook.js';
 import { initDetail } from './detail.js';
+import { initTimeline, timelineSettings } from './timeline.js';
 import { applyMotion } from './motion.js';
 
 const $ = (id) => document.getElementById(id);
@@ -151,6 +152,13 @@ function fillDrawer() {
   $('set-motion').value = s.motion || 'auto';
   $('set-render').value = s.render || 'auto';
   $('set-retention').value = String(s.retentionYears || 0);
+  const tl = timelineSettings(s);
+  $('set-tl-precip').value = tl.precip;
+  $('set-tl-freeze').value = s.units === 'metric' ? tl.freezeC : Math.round(tl.freezeC * 9 / 5 + 32);
+  $('set-tl-heat').value = s.units === 'metric' ? tl.heatC : Math.round(tl.heatC * 9 / 5 + 32);
+  $('set-tl-gust').value = Math.round(msToWind(tl.gustMs));
+  $('set-tl-aqi').value = tl.aqi;
+  document.querySelectorAll('[data-tl-cat]').forEach((c) => { c.checked = tl.categories.includes(c.dataset.tlCat); });
   $('set-storm-auto').checked = !!s.stormAuto;
   $('set-theme').value = s.theme || 'dark';
   $('set-accent').value = s.accent || '#4fb8ff';
@@ -440,6 +448,14 @@ $('btn-save').onclick = async () => {
     motion: $('set-motion').value,
     render: $('set-render').value,
     retentionYears: +$('set-retention').value || 0,
+    timeline: {
+      precip: Math.max(0, Math.min(100, +$('set-tl-precip').value || 30)),
+      freezeC: settings().units === 'metric' ? +$('set-tl-freeze').value : (+$('set-tl-freeze').value - 32) / 1.8,
+      heatC: settings().units === 'metric' ? +$('set-tl-heat').value : (+$('set-tl-heat').value - 32) / 1.8,
+      gustMs: windToMs(+$('set-tl-gust').value || 30),
+      aqi: Math.max(0, +$('set-tl-aqi').value || 101),
+      categories: [...document.querySelectorAll('[data-tl-cat]:checked')].map((c) => c.dataset.tlCat),
+    },
     stormAuto: $('set-storm-auto').checked,
     theme: $('set-theme').value,
     // The picker cannot express "no accent", so the default colour means the default.
@@ -507,7 +523,7 @@ $('btn-save').onclick = async () => {
   }
   loadDeskRadar();
   initDesk(); // idempotent: every() replaces existing jobs
-  initIntel(); initSignals(); initBoards(); initAlmanac(); initEnv(); initPro(); initLayout(); initDetail(); initUdp(); initHome(); initOutlook();
+  initIntel(); initSignals(); initBoards(); initAlmanac(); initEnv(); initPro(); initLayout(); initDetail(); initTimeline(); initUdp(); initHome(); initOutlook();
 };
 
 // station meta fills name/lat/lon and the Tempest device id when blank
@@ -557,19 +573,31 @@ async function firstReading(fetcher) {
   const out = $('wiz-first');
   out.className = 'muted';
   out.textContent = 'waiting for the first reading…';
+  $('wiz-step-source').textContent = 'done ✓'; $('wiz-step-source').className = 'ok';
+  $('wiz-step-reading').textContent = 'checking…';
   for (let i = 0; i < 15; i++) {
     try {
       const t = await fetcher();
       if (t != null) {
         out.className = 'ok';
         out.textContent = `${num(t, 1)}${U.temp()} received ✓`;
-        setTimeout(() => { $('wizard').hidden = true; }, 1500);
+        $('wiz-step-reading').textContent = 'done ✓'; $('wiz-step-reading').className = 'ok';
+        $('wiz-step-forecast').textContent = 'checking…';
+        try {
+          await api.betterForecast();
+          $('wiz-step-forecast').textContent = 'done ✓'; $('wiz-step-forecast').className = 'ok';
+          setTimeout(() => { $('wizard').hidden = true; }, 1500);
+        } catch {
+          $('wiz-step-forecast').textContent = 'needs attention'; $('wiz-step-forecast').className = 'fail';
+          out.textContent += ' · forecast/location could not be verified yet';
+        }
         return;
       }
     } catch { /* the console may still be mid-upload; the loop is the retry */ }
     await new Promise((r) => setTimeout(r, 2000));
   }
   out.className = 'fail';
+  $('wiz-step-reading').textContent = 'needs attention'; $('wiz-step-reading').className = 'fail';
   out.textContent = 'no reading yet — the dashboard is open behind this; check the console is uploading to the address above';
 }
 
@@ -758,8 +786,8 @@ function changelog() {
   if (!seen) return; // a fresh install has nothing to be new since
   notify({
     title: `WeatherDesk ${APP_VERSION}`,
-    body: 'New: tap the hero to hear the day, forecast and rate-of-change alert rules, clickable '
-      + 'charts, drought on the Fire card, archive retention — and a fix for the blank window on Linux.',
+    body: 'New: a past-and-future Weather Timeline with confidence, guided Health Center, complete '
+      + 'portable backup and restore, and an automatic browser fallback when Linux cannot draw the native window.',
   });
 }
 
@@ -976,14 +1004,37 @@ $('import-file').onchange = async (e) => {
 // button would be a second code path for something done once in a lifetime.
 $('btn-backup').onclick = async () => {
   try {
-    const r = await fetch(`${SRV}/backup.db`, { signal: expires(120000) });
+    const r = await fetch(`${SRV}/backup.wdbak`, { signal: expires(120000) });
     if (!r.ok) throw new Error(`${r.status}`);
-    download('weatherdesk.db', await r.blob());
+    download('weatherdesk.wdbak', await r.blob());
   } catch {
     notify({
       title: 'No archive to back up',
       body: 'The observation archive lives on the machine running the desktop app.',
     });
+  }
+};
+
+$('btn-restore').onclick = () => $('restore-file').click();
+$('restore-file').onchange = async (e) => {
+  const file = e.target.files?.[0]; e.target.value = '';
+  if (!file) return;
+  try {
+    const inspected = await (await fetch(`${SRV}/restore/inspect`, {
+      method: 'POST', body: file, signal: expires(120000),
+    })).json();
+    if (!inspected.ok) throw new Error(inspected.error || 'Backup rejected');
+    const s = inspected.summary;
+    const span = s.first ? `${new Date(s.first * 1000).toLocaleDateString()}–${new Date(s.last * 1000).toLocaleDateString()}` : 'empty archive';
+    if (!confirm(`Restore ${s.station} · ${s.rows} readings · ${span}? Current settings and history will be replaced. A recovery backup will be kept.`)) return;
+    const applied = await (await fetch(`${SRV}/restore/apply?id=${encodeURIComponent(inspected.id)}`, {
+      method: 'POST', signal: expires(120000),
+    })).json();
+    if (!applied.ok) throw new Error(applied.error || 'Restore failed');
+    notify({ title: 'Backup restored', body: 'Reloading settings and history.' });
+    setTimeout(() => location.reload(), 800);
+  } catch (err) {
+    notify({ title: 'Restore failed', body: err.message });
   }
 };
 
@@ -1021,6 +1072,7 @@ $('btn-csv').onclick = async () => {
 
 $('btn-diag').onclick = async () => {
   $('diag').innerHTML = '<div class="muted">running…</div>';
+  $('health-summary').innerHTML = '<div class="muted">running…</div>';
   // Viewport first, because it is the one number that explains a dashboard drawn at the wrong
   // size: WebKitGTK on Wayland sometimes hands the page a viewport that doesn't match the window
   // it lives in, and there is otherwise no way to tell that from the inside.
@@ -1030,6 +1082,60 @@ $('btn-diag').onclick = async () => {
     + rows.map((r) =>
     `<div><span>${r.name}</span><span class="${r.ok ? 'ok' : 'fail'}">${r.ok ? '✓ ' : '✗ '}${r.detail}</span></div>`
   ).join('');
+  let server = null;
+  try { server = await api.getJSON(`${SRV}/health`); } catch { /* browser-only build */ }
+  const archive = server?.archive;
+  const cards = [
+    ['Server', !!server, server ? `v${server.version} · up ${Math.floor(server.uptime / 60)} min` : 'not available in this build'],
+    ['Archive', !!archive?.ok, archive ? `${archive.rows || 0} rows · ${archive.check}` : 'not available'],
+    ['Forecast', rows.some((r) => r.ok && /forecast/i.test(r.name)), 'cloud forecast source'],
+    ['Alerts', rows.some((r) => r.ok && /alerts/i.test(r.name)), 'official warning feed'],
+    ['Radar', rows.some((r) => r.ok && /RainViewer/i.test(r.name)), 'map source'],
+    ['MQTT', !server?.integrations?.mqtt?.configured || server.integrations.mqtt.ok === true,
+      server?.integrations?.mqtt?.configured ? (server.integrations.mqtt.ok ? 'publishing' : 'needs attention') : 'not configured'],
+    ['Home Assistant', true,
+      server?.integrations?.homeAssistant?.configured ? 'configured · use Test both to verify credentials' : 'not configured'],
+    ['Push channels', !server?.integrations?.push?.configured || server.integrations.push.ok === true,
+      server?.integrations?.push?.configured ? (server.integrations.push.ok ? 'watching' : 'needs a test') : 'not configured'],
+    ['Browser', !!window.fetch && !!window.Promise, `${navigator.platform || 'unknown'} · ${view}`],
+  ];
+  const quota = await navigator.storage?.estimate?.().catch(() => null);
+  if (quota) cards.push(['Browser storage', true, `${Math.round((quota.usage || 0) / 1048576)} MB used of ${Math.round((quota.quota || 0) / 1048576)} MB`]);
+  $('health-summary').innerHTML = cards.map(([name, ok, detail]) =>
+    `<div><span>${name}</span><span class="${ok ? 'ok' : 'fail'}">${ok ? '✓' : '✗'} ${detail}</span></div>`).join('');
+  $('health-summary')._report = { version: APP_VERSION, viewport: view, platform: navigator.platform,
+    motion: document.documentElement.dataset.motion, render: settings().render, server,
+    sources: rows.map((r) => ({ name: r.name, ok: r.ok })) };
+};
+
+$('health-center').onclick = async (e) => {
+  const action = e.target.dataset.healthAction;
+  if (!action) return;
+  try {
+    if (action === 'retry') { refreshAll(); initSignals(); initUdp(); }
+    if (action === 'still') { saveSettings({ motion: 'lite' }); $('set-motion').value = 'lite'; loadDeskRadar(); }
+    if (action === 'clear') {
+      localStorage.removeItem('wd.cache.fc'); localStorage.removeItem('wd.cache.obs'); localStorage.removeItem('wd.normals');
+      refreshAll();
+    }
+    if (action === 'safe') { saveSettings({ render: 'safe' }); $('set-render').value = 'safe'; await pushConfig(); }
+    if (action === 'open') window.open(`${SRV || location.origin}/`, '_blank', 'noopener');
+    if (action === 'checkpoint') {
+      const r = await fetch(`${SRV}/health/action`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{"action":"checkpoint"}' });
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+    }
+    notify({ title: 'Health Center', body: action === 'safe' ? 'Safe renderer saved for the next launch.' : 'Action complete.' });
+    $('btn-diag').click();
+  } catch {
+    notify({ title: 'Health Center', body: 'That repair could not be completed.' });
+  }
+};
+
+$('btn-support').onclick = async () => {
+  if (!$('health-summary')._report) await $('btn-diag').onclick();
+  const text = JSON.stringify($('health-summary')._report || {}, null, 2);
+  await navigator.clipboard?.writeText(text);
+  notify({ title: 'Support report copied', body: 'Secrets and location are excluded.' });
 };
 
 window.addEventListener('wd:refresh', () => {
@@ -1315,7 +1421,7 @@ pulled.then(() => {
   showWizard();
   hydrateStation().then(() => {
     loadDeskRadar();
-    initDesk(); initIntel(); initSignals(); initBoards(); initAlmanac(); initEnv(); initPro(); initDetail(); initUdp(); initHome();
+    initDesk(); initIntel(); initSignals(); initBoards(); initAlmanac(); initEnv(); initPro(); initDetail(); initTimeline(); initUdp(); initHome();
     every('server-alerts', 300, probeServerAlerts);
   });
 });

--- a/site/js/intel.js
+++ b/site/js/intel.js
@@ -14,6 +14,8 @@ let models = null;
 export async function refreshModels() {
   if (settings().lat == null) return;
   models = await api.multiModel();
+  models._fetchedAt = Date.now() / 1000;
+  window.dispatchEvent(new CustomEvent('wd:models', { detail: models }));
   renderAgreement();
   renderTiming();
   renderEdge();

--- a/site/js/timeline.js
+++ b/site/js/timeline.js
@@ -1,0 +1,238 @@
+// One answer to “what happens when?” Past events come from the station archive; future events
+// come from the same forecast, alerts and model guidance the rest of the Desk already uses.
+import * as api from './api.js';
+import { settings, U, num, every, msToWind } from './app.js';
+import { forecast as deskForecast } from './desk.js';
+import { openDetail } from './detail.js';
+
+const $ = (id) => document.getElementById(id);
+const HOUR = 3600;
+const DEFAULT_CATS = ['precip', 'storm', 'winter', 'freeze', 'heat', 'wind', 'aqi', 'change', 'sun', 'alert'];
+let history = [], alerts = [], aqi = null, models = null, events = [];
+let filter = 'all';
+
+export const timelineSettings = (s = settings()) => ({
+  precip: 30,
+  freezeC: 0,
+  heatC: 35,
+  gustMs: 13.4112, // 30 mph
+  aqi: 101,
+  categories: DEFAULT_CATS,
+  ...(s.timeline || {}),
+});
+
+const metric = (v, imperial) => imperial ? v * 9 / 5 + 32 : v;
+const wind = (v) => v == null ? null : msToWind(v);
+const stamp = (t) => new Date(t * 1000).toLocaleString([], { weekday: 'short', hour: 'numeric', minute: '2-digit' });
+const eventId = (kind, start) => `${kind}-${Math.floor(start / HOUR)}`;
+const esc = (s) => String(s ?? '').replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+
+export function heatIndex(temp, rh, imperial = settings().units !== 'metric') {
+  if (temp == null) return null;
+  const f = imperial ? temp : temp * 9 / 5 + 32;
+  if (f < 80 || rh == null || rh < 40) return temp;
+  const hi = -42.379 + 2.04901523 * f + 10.14333127 * rh - 0.22475541 * f * rh
+    - 0.00683783 * f * f - 0.05481717 * rh * rh + 0.00122874 * f * f * rh
+    + 0.00085282 * f * rh * rh - 0.00000199 * f * f * rh * rh;
+  return imperial ? hi : (hi - 32) / 1.8;
+}
+
+function candidate(kind, start, title, summary, metrics = {}, severity = 'info', source = 'forecast') {
+  return { id: eventId(kind, start), kind, start, end: start + HOUR, severity, title, summary,
+    confidence: 'Unavailable', confidenceReason: 'Only one usable forecast source', observed: source === 'station', metrics, source };
+}
+
+// Merge consecutive hours of the same condition. A one-hour threshold wobble should not make
+// three cards for what is plainly one weather window.
+export function mergeEvents(input, gap = 90 * 60) {
+  const out = [];
+  for (const e of [...input].sort((a, b) => a.start - b.start || a.kind.localeCompare(b.kind))) {
+    const prev = [...out].reverse().find((x) => x.kind === e.kind && e.start <= x.end + gap);
+    if (prev) {
+      prev.end = Math.max(prev.end, e.end);
+      prev.severity = ['info', 'watch', 'warning'].indexOf(e.severity) > ['info', 'watch', 'warning'].indexOf(prev.severity)
+        ? e.severity : prev.severity;
+      Object.assign(prev.metrics, e.metrics);
+    } else out.push({ ...e, metrics: { ...e.metrics } });
+  }
+  return out.filter((e) => e.end - e.start >= 2 * HOUR || e.observed || e.severity === 'warning'
+    || e.kind === 'sun' || e.source === 'Open-Meteo nowcast').sort((a, b) => a.start - b.start);
+}
+
+export function modelConfidence(modelData, event) {
+  const M = api.MODELS.split(',');
+  const h = modelData?.hourly;
+  if (!h?.time) return ['Unavailable', 'Only one usable forecast source', ''];
+  const i = h.time.findIndex((t) => Math.abs(new Date(t).getTime() / 1000 - event.start) <= 1800);
+  if (i < 0) return ['Unavailable', 'No model guidance for this hour', ''];
+  const field = event.kind === 'precip' || event.kind === 'storm' || event.kind === 'winter'
+    ? 'precipitation' : event.kind === 'wind' ? 'wind_speed_10m' : 'temperature_2m';
+  const pairs = M.map((m) => [m.replace('_seamless', '').toUpperCase(), h[`${field}_${m}`]?.[i]]).filter(([, v]) => Number.isFinite(v));
+  const vals = pairs.map(([, v]) => v);
+  if (vals.length < 2) return ['Unavailable', 'Only one usable model', pairs.map(([n, v]) => `${n} ${num(v, 1)}`).join(' · ')];
+  const spread = Math.max(...vals) - Math.min(...vals);
+  const age = Date.now() / 1000 - (modelData._fetchedAt || Date.now() / 1000);
+  const detail = `${pairs.map(([n, v]) => `${n} ${num(v, 1)}`).join(' · ')} · fetched ${Math.max(0, Math.round(age / 60))} min ago`;
+  const precip = ['precip', 'storm', 'winter'].includes(event.kind);
+  const imperial = settings().units !== 'metric';
+  const low = event.kind === 'wind' ? msToWind(8) : precip ? (imperial ? 0.25 : 6) : (imperial ? 7 : 4);
+  const medium = event.kind === 'wind' ? msToWind(3.5) : precip ? (imperial ? 0.08 : 2) : (imperial ? 3 : 1.7);
+  if (precip && vals.some((v) => v <= 0) && vals.some((v) => v > 0)) return ['Low', 'Models disagree whether precipitation occurs', detail];
+  if (age > 12 * HOUR || spread > low) return ['Low', age > 12 * HOUR ? 'Model guidance is aging' : 'Models disagree widely', detail];
+  if (spread > medium) return ['Medium', 'Models differ on intensity or timing', detail];
+  return ['High', `Models agree closely (${num(spread, 1)} spread)`, detail];
+}
+
+export function buildTimeline({ forecast, observations = [], nws = [], air = null, nowcast = null, modelData = null, now = Date.now() / 1000, prefs = timelineSettings() }) {
+  const enabled = new Set(prefs.categories || DEFAULT_CATS);
+  const imperial = settings().units !== 'metric';
+  const raw = [];
+  for (const o of observations) {
+    const t = o[api.OBS.time], temp = o[api.OBS.temp], gust = o[api.OBS.windGust];
+    if (!t || t < now - 24 * HOUR || t > now) continue;
+    if (enabled.has('freeze') && temp != null && temp <= metric(prefs.freezeC, imperial)) raw.push(candidate('freeze', t, 'Freezing conditions', `${num(temp)}${U.temp()} observed`, { temp }, 'watch', 'station'));
+    const hi = heatIndex(temp, o[api.OBS.rh], imperial);
+    if (enabled.has('heat') && hi != null && hi >= metric(prefs.heatC, imperial)) raw.push(candidate('heat', t, 'Dangerous heat', `Heat index ${num(hi)}${U.temp()} observed`, { temp, heatIndex: hi }, 'warning', 'station'));
+    if (enabled.has('wind') && gust != null && gust >= wind(prefs.gustMs)) raw.push(candidate('wind', t, 'Strong wind', `Gust ${num(gust)} ${U.wind()} observed`, { gust }, 'watch', 'station'));
+    if (enabled.has('precip') && (o[api.OBS.rain] || 0) > 0) raw.push(candidate('precip', t, 'Rain observed', `${num(o[api.OBS.rain], 2)} ${U.precip()}`, { rain: o[api.OBS.rain] }, 'info', 'station'));
+    if (enabled.has('change')) {
+      const old = observations.find((x) => x[api.OBS.time] >= t - 3900 && x[api.OBS.time] <= t - 3300);
+      const td = old?.[api.OBS.temp] == null || temp == null ? 0 : temp - old[api.OBS.temp];
+      const pd = old?.[api.OBS.press] == null || o[api.OBS.press] == null ? 0 : o[api.OBS.press] - old[api.OBS.press];
+      if (Math.abs(td) >= (imperial ? 5 : 3)) raw.push(candidate('change', t, 'Temperature changing quickly', `${td > 0 ? 'Up' : 'Down'} ${num(Math.abs(td), 1)}${U.temp()} in an hour`, { tempChange: td }, 'watch', 'station'));
+      if (Math.abs(pd) >= (imperial ? 0.06 : 2)) raw.push(candidate('change', t, 'Pressure changing quickly', `${pd > 0 ? 'Up' : 'Down'} ${num(Math.abs(pd), 2)} ${U.press()} in an hour`, { pressureChange: pd }, 'watch', 'station'));
+    }
+  }
+  const hourly = forecast?.forecast?.hourly || [];
+  for (const h of hourly) {
+    if (!h.time || h.time < now || h.time > now + 48 * HOUR) continue;
+    const text = h.conditions || '';
+    if (enabled.has('precip') && (h.precip_probability || 0) >= prefs.precip) raw.push(candidate('precip', h.time, 'Precipitation window', `${num(h.precip_probability)}% chance`, { pop: h.precip_probability }));
+    if (enabled.has('storm') && /thunder/i.test(text)) raw.push(candidate('storm', h.time, 'Thunderstorms possible', text, {}, 'warning'));
+    if (enabled.has('winter') && /snow|sleet|ice|freezing/i.test(text)) raw.push(candidate('winter', h.time, 'Wintry weather possible', text, {}, 'warning'));
+    if (enabled.has('freeze') && h.air_temperature != null && h.air_temperature <= metric(prefs.freezeC, imperial)) raw.push(candidate('freeze', h.time, 'Freeze possible', `${num(h.air_temperature)}${U.temp()} forecast`, { temp: h.air_temperature }, 'watch'));
+    const hi = heatIndex(h.air_temperature, h.relative_humidity, imperial);
+    if (enabled.has('heat') && hi != null && hi >= metric(prefs.heatC, imperial)) raw.push(candidate('heat', h.time, 'Dangerous heat possible', `Heat index near ${num(hi)}${U.temp()}`, { temp: h.air_temperature, heatIndex: hi }, 'warning'));
+    if (enabled.has('wind') && h.wind_gust != null && h.wind_gust >= wind(prefs.gustMs)) raw.push(candidate('wind', h.time, 'Strong wind possible', `Gusts near ${num(h.wind_gust)} ${U.wind()}`, { gust: h.wind_gust }, 'watch'));
+  }
+  if (enabled.has('sun')) for (const d of forecast?.forecast?.daily || []) {
+    for (const [kind, t, title] of [['sunrise', d.sunrise, 'Sunrise'], ['sunset', d.sunset, 'Sunset']]) {
+      if (t >= now - 24 * HOUR && t <= now + 48 * HOUR) raw.push(candidate('sun', t, title, stamp(t), { phase: kind }, 'info', 'astronomy'));
+    }
+  }
+  if (enabled.has('alert')) for (const f of nws) {
+    const p = f.properties || f;
+    const rawStart = new Date(p.onset || p.effective || Date.now()).getTime() / 1000;
+    const start = Math.max(now - 24 * HOUR, rawStart);
+    const end = new Date(p.ends || p.expires || (start + HOUR) * 1000).getTime() / 1000;
+    if (end >= now - 24 * HOUR && start <= now + 48 * HOUR) {
+      raw.push({ ...candidate('alert', start, p.event || 'Weather alert', p.headline || p.areaDesc || '', {}, 'warning', 'NWS'), end: Math.min(end, now + 48 * HOUR) });
+    }
+  }
+  const aq = air?.hourly;
+  if (enabled.has('aqi') && aq?.time) aq.time.forEach((t, i) => {
+    const v = aq.us_aqi?.[i]; const at = new Date(t).getTime() / 1000;
+    if (v >= prefs.aqi && at >= now && at <= now + 48 * HOUR) raw.push(candidate('aqi', at, 'Unhealthy air quality', `AQI near ${num(v)}`, { aqi: v }, 'warning', 'Open-Meteo'));
+  });
+  const nc = nowcast?.minutely_15;
+  if (enabled.has('precip') && nc?.time) nc.time.forEach((t, i) => {
+    const pop = nc.precipitation_probability?.[i] || 0, amount = nc.precipitation?.[i] || 0;
+    const at = new Date(t).getTime() / 1000;
+    if ((pop >= prefs.precip || amount > 0) && at >= now && at <= now + 12 * HOUR) {
+      raw.push({ ...candidate('precip', at, 'Near-term precipitation', `${num(pop)}% chance in the 15-minute nowcast`, { pop }, 'watch', 'Open-Meteo nowcast'), end: at + 900 });
+    }
+  });
+  const merged = mergeEvents(raw);
+  for (const e of merged) {
+    [e.confidence, e.confidenceReason, e.modelDetail] = e.observed
+      ? ['Observed', 'Measured by this station', '']
+      : e.kind === 'sun' ? ['High', 'Calculated from the station location and date', '']
+        : e.kind === 'alert' ? ['Official', 'Issued by the National Weather Service', '']
+          : e.source === 'Open-Meteo nowcast' ? ['Medium', 'High-resolution near-term guidance', '']
+            : e.kind === 'aqi' ? ['Unavailable', 'Air-quality guidance has one provider', '']
+            : modelConfidence(modelData, e);
+  }
+  return merged;
+}
+
+function eventMetric(e) {
+  return e.kind === 'wind' ? 'windGust' : e.kind === 'precip' ? 'rain' : e.kind === 'freeze' || e.kind === 'heat' ? 'temp' : null;
+}
+
+function card(e, compact = false) {
+  const when = e.end - e.start > HOUR ? `${stamp(e.start)}–${stamp(e.end)}` : stamp(e.start);
+  return `<article class="tl-event sev-${esc(e.severity)}" tabindex="0" data-event="${esc(e.id)}" aria-label="${esc(`${e.title}, ${when}`)}">
+    <div class="tl-when">${esc(when)}</div><b>${esc(e.title)}</b><span>${esc(e.summary)}</span>
+    ${compact ? '' : `<details><summary>${esc(e.confidence)} confidence</summary><p>${esc(e.confidenceReason)}</p>${e.modelDetail ? `<p class="muted">${esc(e.modelDetail)}</p>` : ''}<p class="muted">Source: ${esc(e.source)}</p></details>`}
+  </article>`;
+}
+
+function render() {
+  const now = Date.now() / 1000;
+  const future = events.filter((e) => e.end >= now).slice(0, 3);
+  const strip = $('timeline-strip');
+  if (strip) strip.innerHTML = future.length ? future.map((e) => card(e, true)).join('') : '<div class="muted">Quiet weather in the next 48 hours</div>';
+  const list = $('timeline-list');
+  const shown = filter === 'all' ? events : events.filter((e) => e.kind === filter);
+  if (list) list.innerHTML = shown.length ? shown.map((e) => card(e)).join('') : '<div class="muted">No matching timeline events</div>';
+  const range = $('timeline-range');
+  if (range) range.textContent = 'Past 24 hours  ·  NOW  ·  Next 48 hours';
+}
+
+async function refresh() {
+  const fc = deskForecast();
+  if (!fc) return;
+  const settled = await Promise.allSettled([api.localObs(24), api.alerts(), api.aqi(), api.nowcast()]);
+  history = settled[0].status === 'fulfilled' ? settled[0].value.obs || [] : history;
+  alerts = settled[1].status === 'fulfilled' ? settled[1].value.features || [] : alerts;
+  aqi = settled[2].status === 'fulfilled' ? settled[2].value : aqi;
+  const near = settled[3].status === 'fulfilled' ? settled[3].value : null;
+  events = buildTimeline({ forecast: fc, observations: history, nws: alerts, air: aqi, nowcast: near, modelData: models });
+  render();
+}
+
+function activate(e) {
+  const el = e.target.closest?.('[data-event]');
+  if (!el) return;
+  const item = events.find((x) => x.id === el.dataset.event);
+  const metric = item && eventMetric(item);
+  if (metric && item.observed) openDetail(metric, item.start * 1000);
+  else document.querySelector('.tab[data-section="timeline"]')?.click();
+}
+document.addEventListener('click', activate);
+document.addEventListener('click', (e) => {
+  const b = e.target.closest?.('[data-tl-filter]');
+  if (!b) return;
+  filter = b.dataset.tlFilter;
+  document.querySelectorAll('[data-tl-filter]').forEach((x) => x.classList.toggle('active', x === b));
+  render();
+});
+document.addEventListener('keydown', (e) => { if ((e.key === 'Enter' || e.key === ' ') && e.target.closest?.('[data-event]')) { e.preventDefault(); activate(e); } });
+window.addEventListener('wd:forecast', refresh);
+window.addEventListener('wd:models', (e) => { models = e.detail; refresh(); });
+window.addEventListener('wd:settings', () => { if (deskForecast()) refresh(); });
+
+export function initTimeline() {
+  every('timeline', 900, refresh);
+}
+
+if (location.search.includes('selftest')) {
+  const a = candidate('wind', 1000, 'a', 'a'), b = candidate('wind', 4600, 'b', 'b');
+  console.assert(mergeEvents([a, b]).length === 1, 'timeline: adjacent hours merge');
+  console.assert(eventId('wind', 3601) === eventId('wind', 7199), 'timeline: ids are stable within an hour');
+  console.assert(modelConfidence(null, a)[0] === 'Unavailable', 'timeline: missing models are honest');
+  const mixed = { _fetchedAt: Date.now() / 1000, hourly: { time: [new Date(1000 * 1000).toISOString()] } };
+  api.MODELS.split(',').forEach((m, i) => { mixed.hourly[`precipitation_${m}`] = [i ? 0.1 : 0]; });
+  console.assert(modelConfidence(mixed, candidate('precip', 1000, 'rain', 'rain'))[0] === 'Low',
+    'timeline: occurrence disagreement lowers confidence');
+  console.assert(Math.round(heatIndex(95, 60, true)) === 113, 'timeline: heat index uses humidity');
+  console.assert(Math.abs(heatIndex(35, 60, false) * 1.8 + 32 - heatIndex(95, 60, true)) < 0.01,
+    'timeline: heat index agrees across units');
+  const fc = { forecast: { hourly: [
+    { time: 10_000, precip_probability: 40, conditions: 'Rain' },
+    { time: 13_600, precip_probability: 50, conditions: 'Rain' },
+  ], daily: [] } };
+  const built = buildTimeline({ forecast: fc, now: 9_000, prefs: { ...timelineSettings(), categories: ['precip'] } });
+  console.assert(built.length === 1 && built[0].start === 10_000 && built[0].end === 17_200,
+    'timeline: threshold hours become one stable window');
+}

--- a/site/sw.js
+++ b/site/sw.js
@@ -6,7 +6,7 @@ const CACHE = `wd-shell-${VER}`;
 
 // The API surface. None of it is ever cached or intercepted: /events is an open SSE stream,
 // /history streams CSV, /config carries the token, and a stale copy of any of them is a bug.
-const API = /^\/(api|events|config|config-public|udp|history|history\.csv|diag|ingest|alerts|ha|discover|backup\.db|proxy)(\/|$|\?)/;
+const API = /^\/(api|events|config|config-public|udp|history|history\.csv|diag|health|ingest|alerts|ha|discover|backup(?:\.db|\.wdbak)|restore|proxy)(\/|$|\?)/;
 
 self.addEventListener('install', () => self.skipWaiting());
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4946,7 +4946,7 @@ dependencies = [
 
 [[package]]
 name = "weatherdesk"
-version = "3.4.0"
+version = "4.0.0"
 dependencies = [
  "include_dir",
  "mdns-sd",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weatherdesk"
-version = "3.4.0"
+version = "4.0.0"
 description = "Self-hosted WeatherFlow Tempest dashboard"
 authors = ["David May"]
 license = "MIT"

--- a/src-tauri/src/gui.rs
+++ b/src-tauri/src/gui.rs
@@ -2,6 +2,14 @@
 // it gets through `start_services`, so the headless build never compiles any of it.
 
 use tauri::{WebviewUrl, WebviewWindowBuilder};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static FRONTEND_READY: AtomicBool = AtomicBool::new(false);
+
+fn should_open_fallback(ready: &AtomicBool) -> bool { !ready.swap(true, Ordering::Relaxed) }
+
+#[tauri::command]
+fn frontend_ready() { FRONTEND_READY.store(true, Ordering::Relaxed); }
 
 // The tray, the server and the paths behind them are desktop-only, and so is everything imported
 // for them — Android builds warn about each one otherwise.
@@ -11,6 +19,8 @@ use tauri::{
     tray::TrayIconBuilder,
     Manager,
 };
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+use tauri_plugin_notification::NotificationExt;
 
 /// The current temperature, next to the clock, without a window in the way. Linux app
 /// indicators quietly drop tooltips, so the same string goes in the title too — on ayatana that
@@ -85,7 +95,7 @@ pub fn run() {
                 }
             }))
             .plugin(tauri_plugin_updater::Builder::new().build())
-            .invoke_handler(tauri::generate_handler![updater_check, updater_install]);
+            .invoke_handler(tauri::generate_handler![updater_check, updater_install, frontend_ready]);
     }
 
     builder = builder.plugin(tauri_plugin_notification::init());
@@ -94,6 +104,8 @@ pub fn run() {
         .setup(|app| {
             #[allow(unused_mut)]
             let mut win = WebviewWindowBuilder::new(app, "main", WebviewUrl::default());
+            #[cfg(target_os = "linux")]
+            let fallback_port;
 
             #[cfg(not(any(target_os = "android", target_os = "ios")))]
             {
@@ -104,6 +116,8 @@ pub fn run() {
                     .map(|d| d.join("config.json"))
                     .unwrap_or_else(|_| crate::default_config_dir().join("config.json"));
                 let (state, port) = crate::start_services(data_dir, cfg_path.clone());
+                #[cfg(target_os = "linux")]
+                { fallback_port = port; }
 
                 let show = MenuItem::with_id(app, "show", "Show WeatherDesk", true, None::<&str>)?;
                 let refresh = MenuItem::with_id(app, "refresh", "Refresh", true, None::<&str>)?;
@@ -152,15 +166,44 @@ pub fn run() {
                     .maximized(cfg!(target_os = "linux"))
                     // the window isn't same-origin with the LAN server, so it needs the port told to it
                     .initialization_script(format!(
-                        "window.__WD_UDP='http://localhost:{port}/udp';window.__WD_SRV='http://localhost:{port}';{}",
+                        "window.__WD_UDP='http://localhost:{port}/udp';window.__WD_SRV='http://localhost:{port}';{};addEventListener('DOMContentLoaded',()=>window.__TAURI__?.core?.invoke('frontend_ready'));",
                         crate::server::ver_script()
                     ));
             }
 
             win.build()?;
 
+            #[cfg(target_os = "linux")]
+            {
+                let app = app.handle().clone();
+                std::thread::spawn(move || {
+                    std::thread::sleep(std::time::Duration::from_secs(20));
+                    if !should_open_fallback(&FRONTEND_READY) { return; }
+                    eprintln!("weatherdesk: native window did not become ready; opening browser dashboard");
+                    let _ = crate::open_browser(fallback_port);
+                    let _ = app.notification().builder()
+                        .title("WeatherDesk opened in your browser")
+                        .body("The native window could not start on this graphics driver.")
+                        .show();
+                });
+            }
+
             Ok(())
         })
         .run(tauri::generate_context!())
         .expect("error running WeatherDesk");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn frontend_readiness_opens_the_fallback_once() {
+        let ready = AtomicBool::new(false);
+        assert!(should_open_fallback(&ready), "a timed-out frontend opens the browser");
+        assert!(!should_open_fallback(&ready), "the same launch cannot open a second tab");
+        let ready = AtomicBool::new(true);
+        assert!(!should_open_fallback(&ready), "a ready frontend keeps the native window");
+    }
 }

--- a/src-tauri/src/ingest.rs
+++ b/src-tauri/src/ingest.rs
@@ -327,6 +327,7 @@ fn n(v: Option<f64>) -> String {
 /// The counters are only advanced on a report we keep — a differenced total against a report we
 /// threw away would drop that interval's rain on the floor.
 fn take(state: &Arc<State>, f: &Fields, raw_ts: f64, src: i64, origin: &'static str) -> bool {
+    if state.maintenance.load(std::sync::atomic::Ordering::Relaxed) { return false; }
     let at = epoch();
     // A console clock that is out by a day would otherwise scatter rows across the archive and
     // defeat CWOP's staleness guard. Ten minutes of slack is more than any real drift.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -111,6 +111,27 @@ pub fn run_headless() {
     }
 }
 
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+pub fn open_browser(port: u16) -> bool {
+    let url = format!("http://127.0.0.1:{port}");
+    #[cfg(target_os = "linux")]
+    let result = std::process::Command::new("xdg-open").arg(&url).spawn();
+    #[cfg(target_os = "macos")]
+    let result = std::process::Command::new("open").arg(&url).spawn();
+    #[cfg(target_os = "windows")]
+    let result = std::process::Command::new("cmd").args(["/C", "start", "", &url]).spawn();
+    result.is_ok()
+}
+
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+pub fn run_browser() {
+    let data = default_data_dir();
+    let cfg = default_config_dir().join("config.json");
+    let (_state, port) = start_services(data, cfg);
+    if !open_browser(port) { eprintln!("weatherdesk: browser could not be opened; use http://127.0.0.1:{port}"); }
+    loop { std::thread::park(); }
+}
+
 #[cfg(feature = "gui")]
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -16,6 +16,9 @@ fn main() {
     if std::env::args().any(|a| a == "--headless") {
         return weatherdesk_lib::run_headless();
     }
+    if std::env::args().any(|a| a == "--browser") {
+        return weatherdesk_lib::run_browser();
+    }
     // WebKitGTK renderer knobs. Which ones depend on the box: the AppImage runs under XWayland
     // and an Intel iGPU there draws a blank window unless compositing is software too. Mode comes
     // from `WD_RENDER`, `--render <mode>`, then the saved setting, so a blank window can be fixed

--- a/src-tauri/src/server.rs
+++ b/src-tauri/src/server.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::net::UdpSocket;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::mpsc::{sync_channel, SyncSender};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -31,6 +31,7 @@ const HUB_PORT: u16 = 50222;
 /// Streams cost a thread each. Eight is more screens than any house has; the ninth is told so.
 const MAX_SSE: usize = 8;
 const WORKERS: usize = 4;
+static TEMP_N: AtomicUsize = AtomicUsize::new(0);
 
 pub struct State {
     /// Latest broadcast per packet type, as received. Raw JSON: the page already knows the
@@ -48,6 +49,8 @@ pub struct State {
     sse: Mutex<Vec<SyncSender<String>>>,
     sse_n: AtomicUsize,
     pub backfill: Mutex<&'static str>,
+    started: u64,
+    pub maintenance: AtomicBool,
 }
 
 impl State {
@@ -61,6 +64,8 @@ impl State {
             sse: Mutex::new(Vec::new()),
             sse_n: AtomicUsize::new(0),
             backfill: Mutex::new("off"),
+            started: now(),
+            maintenance: AtomicBool::new(false),
         })
     }
 
@@ -180,6 +185,27 @@ fn read_config(path: &Path) -> String {
     std::fs::read_to_string(path).unwrap_or_else(|_| "{}".into())
 }
 
+fn write_atomic(path: &Path, text: &str) -> std::io::Result<()> {
+    if let Some(d) = path.parent() { std::fs::create_dir_all(d)?; }
+    let tmp = path.with_extension(format!("json.tmp.{}", TEMP_N.fetch_add(1, Ordering::Relaxed)));
+    std::fs::write(&tmp, text)?;
+    match std::fs::rename(&tmp, path) {
+        Ok(()) => Ok(()),
+        // Windows does not replace an existing destination. Keep the old file until the new one
+        // is in place, and put it back if that second rename fails.
+        Err(_) if path.exists() => {
+            let old = path.with_extension("json.prev");
+            let _ = std::fs::remove_file(&old);
+            std::fs::rename(path, &old)?;
+            match std::fs::rename(&tmp, path) {
+                Ok(()) => { let _ = std::fs::remove_file(old); Ok(()) }
+                Err(next) => { let _ = std::fs::rename(old, path); Err(next) }
+            }
+        }
+        Err(e) => Err(e),
+    }
+}
+
 /// Merge a settings write.
 ///
 /// A v3 client sends only what it changed, tagged with the `_rev` it last saw, and gets the
@@ -209,10 +235,7 @@ fn write_config(path: &Path, body: &str) -> Option<(u16, String, u64)> {
     let mut merged = merged;
     merged.as_object_mut()?.insert("_rev".into(), rev.into());
     let text = merged.to_string();
-    if let Some(d) = path.parent() {
-        std::fs::create_dir_all(d).ok()?;
-    }
-    std::fs::write(path, &text).ok()?;
+    write_atomic(path, &text).ok()?;
     Some(if delta { (200, text, rev) } else { (204, String::new(), rev) })
 }
 
@@ -407,6 +430,43 @@ fn is_ingest_path(path: &str) -> bool {
         || path == "/updateweatherstation.php"
 }
 
+fn staged_restore(state: &State, id: &str) -> Option<PathBuf> {
+    if id.is_empty() || !id.bytes().all(|b| b.is_ascii_digit() || b == b'-') { return None; }
+    Some(state.data_dir.join(format!("restore-{id}.wdbak")))
+}
+
+fn cleanup_restores(state: &State) {
+    let Ok(files) = std::fs::read_dir(&state.data_dir) else { return };
+    for entry in files.flatten() {
+        let path = entry.path();
+        let old = entry.metadata().ok().and_then(|m| m.modified().ok())
+            .and_then(|t| SystemTime::now().duration_since(t).ok()).map(|d| d.as_secs() > 3600).unwrap_or(false);
+        if old && path.file_name().and_then(|n| n.to_str()).map(|n| n.starts_with("restore-") && n.ends_with(".wdbak")).unwrap_or(false) {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+}
+
+fn health_json(state: &State) -> String {
+    let db = state.db();
+    let archive = db.as_ref().map(|c| store::health(c, &store::db_path(&state.data_dir)))
+        .unwrap_or_else(|| serde_json::json!({ "ok": false, "check": "unavailable" }));
+    let diag = serde_json::from_str::<serde_json::Value>(&ingest::diag_json()).unwrap_or_default();
+    let cfg = serde_json::from_str::<serde_json::Value>(&read_config(&state.cfg_path)).unwrap_or_default();
+    let configured = |k: &str| cfg.pointer(&format!("/settings/{k}")).and_then(|v| v.as_str()).map(|v| !v.is_empty()).unwrap_or(false);
+    serde_json::json!({
+        "version": env!("CARGO_PKG_VERSION"), "uptime": now().saturating_sub(state.started),
+        "archive": archive, "ingest": diag,
+        "integrations": {
+            "mqtt": { "configured": configured("mqttUrl"), "ok": diag.pointer("/mqtt/ok").and_then(|v| v.as_bool()) },
+            "homeAssistant": { "configured": configured("haUrl") && configured("haToken") },
+            "push": { "configured": configured("ntfyTopic") || configured("webhookUrl") || configured("mqttUrl"),
+                "ok": diag.pointer("/alerts/ok").and_then(|v| v.as_bool()) }
+        },
+        "backfill": *state.backfill.lock().unwrap_or_else(|e| e.into_inner())
+    }).to_string()
+}
+
 fn handle(state: &Arc<State>, mut req: Request) {
     let url = req.url().to_string();
     let path = url.split('?').next().unwrap_or("/").to_string();
@@ -455,6 +515,20 @@ fn handle(state: &Arc<State>, mut req: Request) {
         // What each station source last did, for the drawer and for a screenshot in a bug
         // report. Fixed phrases and status codes only, so there is nothing here to gate.
         "/diag" => json(ingest::diag_json()),
+        "/health" => json(health_json(state)),
+        "/health/action" => {
+            if *req.method() != tiny_http::Method::Post { Response::empty(405).boxed() } else {
+                let mut body = String::new();
+                let _ = req.as_reader().take(1024).read_to_string(&mut body);
+                let action = serde_json::from_str::<serde_json::Value>(&body).ok()
+                    .and_then(|v| v["action"].as_str().map(String::from));
+                let ok = match action.as_deref() {
+                    Some("checkpoint") => state.with_db(store::checkpoint).unwrap_or(false),
+                    _ => false,
+                };
+                if ok { json("{\"ok\":true}".into()) } else { Response::empty(400).boxed() }
+            }
+        }
         // The versioned contract: named fields, SI, no credentials. Everything else here is
         // shaped for the page and free to change with it — this one isn't. See `api.rs`.
         "/api/v1" => json(crate::api::snapshot(state)),
@@ -586,6 +660,74 @@ fn handle(state: &Arc<State>, mut req: Request) {
             });
             return;
         }
+        "/backup.wdbak" => {
+            let Some(conn) = state.db() else { return drop(req.respond(Response::empty(503))) };
+            let dest = state.data_dir.join(format!("backup-{}-{}.wdbak", now(), TEMP_N.fetch_add(1, Ordering::Relaxed)));
+            if store::bundle_to(&conn, &dest, &read_config(&state.cfg_path)).is_err() {
+                return drop(req.respond(Response::empty(500)));
+            }
+            let Ok(file) = std::fs::File::open(&dest) else { return drop(req.respond(Response::empty(500))) };
+            let len = file.metadata().map(|m| m.len() as usize).ok();
+            let res = Response::new(tiny_http::StatusCode(200), vec![
+                header("Content-Type", "application/octet-stream"),
+                header("Content-Disposition", "attachment; filename=weatherdesk.wdbak"),
+            ], file, len, None);
+            std::thread::spawn(move || { let _ = req.respond(res); let _ = std::fs::remove_file(dest); });
+            return;
+        }
+        "/restore/inspect" => {
+            if *req.method() != tiny_http::Method::Post { Response::empty(405).boxed() } else {
+                cleanup_restores(state);
+                let id = format!("{}-{}-{}", now(), std::process::id(), TEMP_N.fetch_add(1, Ordering::Relaxed));
+                let path = staged_restore(state, &id).unwrap();
+                let result = std::fs::File::create(&path).and_then(|mut f| {
+                    let n = std::io::copy(&mut req.as_reader().take(8 * 1024 * 1024 * 1024), &mut f)?;
+                    if n == 0 { return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "empty")); }
+                    f.flush()
+                });
+                match result.ok().and_then(|_| store::inspect_bundle(&path).ok()) {
+                    Some(summary) => json(serde_json::json!({ "ok": true, "id": id, "summary": summary }).to_string()),
+                    None => { let _ = std::fs::remove_file(path); json("{\"ok\":false,\"error\":\"Backup is invalid or unsupported\"}".into()) }
+                }
+            }
+        }
+        "/restore/apply" => {
+            if *req.method() != tiny_http::Method::Post { Response::empty(405).boxed() } else {
+                let id = query(&url, "id").unwrap_or_default();
+                let Some(path) = staged_restore(state, &id).filter(|p| p.is_file()) else {
+                    return drop(req.respond(Response::empty(404)));
+                };
+                let valid = store::inspect_bundle(&path).is_ok();
+                let config = store::bundle_config(&path).ok();
+                let old_config = read_config(&state.cfg_path);
+                // VACUUM INTO refuses to overwrite. Use a private working name, then promote the
+                // successful snapshot to the stable recovery filename after the restore commits.
+                let recovery = state.data_dir.join(format!("pre-restore-{}.wdbak", TEMP_N.fetch_add(1, Ordering::Relaxed)));
+                let kept_recovery = state.data_dir.join("pre-restore.wdbak");
+                state.maintenance.store(true, Ordering::Relaxed);
+                let applied = valid && config.as_ref().map(|new_config| state.with_db(|conn| {
+                    if store::bundle_to(conn, &recovery, &old_config).is_err() { return false; }
+                    if store::replace_from_bundle(conn, &path).is_err() { return false; }
+                    if write_atomic(&state.cfg_path, new_config).is_err() {
+                        let _ = store::replace_from_bundle(conn, &recovery);
+                        return false;
+                    }
+                    true
+                }).unwrap_or(false)).unwrap_or(false);
+                state.maintenance.store(false, Ordering::Relaxed);
+                if applied {
+                    let _ = std::fs::remove_file(&kept_recovery);
+                    let _ = std::fs::rename(&recovery, &kept_recovery);
+                    *state.daily.lock().unwrap_or_else(|e| e.into_inner()) = None;
+                    state.broadcast("config", "{\"restore\":true}");
+                    let _ = std::fs::remove_file(path);
+                    json("{\"ok\":true}".into())
+                } else {
+                    let _ = std::fs::remove_file(recovery);
+                    json("{\"ok\":false,\"error\":\"Restore failed; current data was kept\"}".into())
+                }
+            }
+        }
         "/config" => match *req.method() {
             tiny_http::Method::Get => json(read_config(&state.cfg_path)),
             tiny_http::Method::Put => {
@@ -709,9 +851,11 @@ pub fn listen_udp(state: Arc<State>) {
         let Ok(mut v) = serde_json::from_slice::<serde_json::Value>(&buf[..n]) else { continue };
         let Some(kind) = v.get("type").and_then(|t| t.as_str()).map(String::from) else { continue };
         if kind == "obs_st" {
-            if let (Some(c), Some(obs)) = (conn.as_ref(), v.get("obs").and_then(|o| o.get(0)).and_then(|o| o.as_array())) {
+            if !state.maintenance.load(Ordering::Relaxed) {
+              if let (Some(c), Some(obs)) = (conn.as_ref(), v.get("obs").and_then(|o| o.get(0)).and_then(|o| o.as_array())) {
                 let tuple: Vec<Option<f64>> = obs.iter().map(|x| x.as_f64()).collect();
                 store::insert(c, &tuple, store::SRC_UDP);
+              }
             }
         }
         // stamped on arrival so the page can tell a live packet from the last one before a
@@ -897,6 +1041,23 @@ mod tests {
     #[test]
     fn malformed_config_is_not_served_raw() {
         assert_eq!(redact("not json at all"), "{}");
+    }
+
+    #[test]
+    fn health_report_reveals_configuration_state_not_secrets() {
+        let dir = std::env::temp_dir().join(format!("wd-health-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir); std::fs::create_dir_all(&dir).unwrap();
+        let cfg = dir.join("config.json");
+        std::fs::write(&cfg, r#"{"settings":{"token":"tempest-secret","mqttUrl":"mqtt://broker","mqttPass":"broker-secret","haUrl":"http://ha","haToken":"ha-secret","ntfyTopic":"push-secret"}}"#).unwrap();
+        let state = State::new(dir.clone(), cfg);
+        let out = health_json(&state);
+        for secret in ["tempest-secret", "broker-secret", "ha-secret", "push-secret", "mqtt://broker", "http://ha"] {
+            assert!(!out.contains(secret), "health leaked {secret}: {out}");
+        }
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v.pointer("/integrations/mqtt/configured").and_then(|x| x.as_bool()), Some(true));
+        assert_eq!(v.pointer("/integrations/homeAssistant/configured").and_then(|x| x.as_bool()), Some(true));
+        let _ = std::fs::remove_dir_all(dir);
     }
 
     #[test]

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -282,6 +282,21 @@ pub fn coverage_json(conn: &Connection, backfill: &str) -> String {
     )
 }
 
+/// Small, redacted facts for the Health Center. `quick_check` is intentionally used instead of
+/// `integrity_check`: it catches structural damage without turning a drawer click into a long scan.
+pub fn health(conn: &Connection, path: &Path) -> serde_json::Value {
+    let (first, last) = stamp(conn);
+    let rows: i64 = conn.query_row("SELECT COUNT(*) FROM obs", [], |r| r.get(0)).unwrap_or(0);
+    let check: String = conn.query_row("PRAGMA quick_check", [], |r| r.get(0)).unwrap_or_else(|_| "unavailable".into());
+    let bytes = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
+    serde_json::json!({ "ok": check == "ok", "check": check, "rows": rows,
+        "first": first, "last": last, "bytes": bytes })
+}
+
+pub fn checkpoint(conn: &Connection) -> bool {
+    conn.execute_batch("PRAGMA wal_checkpoint(PASSIVE)").is_ok()
+}
+
 pub const CSV_HEADER: &str =
     "time,wind_lull,wind_avg,wind_gust,wind_dir,wind_interval,pressure,temp,humidity,lux,uv,solar,rain,precip_type,strike_dist,strikes,battery,report_interval,day_rain\n";
 
@@ -365,6 +380,73 @@ pub fn backup_to(conn: &Connection, dest: &Path) -> rusqlite::Result<()> {
     Ok(())
 }
 
+pub const BACKUP_FORMAT: i64 = 1;
+
+/// A `.wdbak` is a normal SQLite snapshot with two reserved metadata rows. It can still be
+/// opened with sqlite3 when WeatherDesk is gone, which is a better recovery format than a custom
+/// archive nobody else understands.
+pub fn bundle_to(conn: &Connection, dest: &Path, config: &str) -> rusqlite::Result<()> {
+    backup_to(conn, dest)?;
+    let bundle = open(dest)?;
+    let manifest = serde_json::json!({
+        "format": BACKUP_FORMAT, "app": env!("CARGO_PKG_VERSION"),
+        "created": crate::server::epoch()
+    }).to_string();
+    bundle.execute("INSERT INTO meta (key,value) VALUES ('backup:manifest',?1)
+        ON CONFLICT(key) DO UPDATE SET value=?1", [&manifest])?;
+    bundle.execute("INSERT INTO meta (key,value) VALUES ('backup:config',?1)
+        ON CONFLICT(key) DO UPDATE SET value=?1", [config])?;
+    bundle.execute_batch("PRAGMA wal_checkpoint(TRUNCATE)")?;
+    Ok(())
+}
+
+pub fn inspect_bundle(path: &Path) -> Result<serde_json::Value, String> {
+    use rusqlite::OpenFlags;
+    let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY).map_err(|_| "not a SQLite backup")?;
+    let check: String = conn.query_row("PRAGMA quick_check", [], |r| r.get(0)).map_err(|_| "integrity check failed")?;
+    if check != "ok" { return Err("integrity check failed".into()); }
+    let manifest: serde_json::Value = serde_json::from_str(&meta_get(&conn, "backup:manifest").ok_or("missing backup manifest")?)
+        .map_err(|_| "invalid backup manifest")?;
+    let format = manifest["format"].as_i64().ok_or("invalid backup format")?;
+    if format > BACKUP_FORMAT { return Err("backup was made by a newer WeatherDesk".into()); }
+    if format < 1 { return Err("unsupported backup format".into()); }
+    let config: serde_json::Value = serde_json::from_str(&meta_get(&conn, "backup:config").ok_or("missing backup settings")?)
+        .map_err(|_| "invalid backup settings")?;
+    if !config.is_object() { return Err("invalid backup settings".into()); }
+    let mut stmt = conn.prepare("PRAGMA table_info(obs)").map_err(|_| "missing observation archive")?;
+    let cols: Vec<String> = stmt.query_map([], |r| r.get(1)).map_err(|_| "missing observation archive")?
+        .flatten().collect();
+    let required = std::iter::once("ts").chain(FIELDS.iter().copied()).chain(std::iter::once("src"));
+    if required.clone().any(|c| !cols.iter().any(|x| x == c)) { return Err("backup archive schema is incomplete".into()); }
+    let (first, last) = stamp(&conn);
+    let rows: i64 = conn.query_row("SELECT COUNT(*) FROM obs", [], |r| r.get(0)).unwrap_or(0);
+    if first < 0 || last < first { return Err("backup contains invalid timestamps".into()); }
+    Ok(serde_json::json!({ "format": format, "app": manifest["app"], "created": manifest["created"],
+        "station": config.pointer("/settings/stationName").and_then(|v| v.as_str()).unwrap_or("WeatherDesk"),
+        "first": first, "last": last, "rows": rows }))
+}
+
+pub fn bundle_config(path: &Path) -> Result<String, String> {
+    use rusqlite::OpenFlags;
+    let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY).map_err(|_| "cannot open backup")?;
+    meta_get(&conn, "backup:config").ok_or_else(|| "missing backup settings".into())
+}
+
+pub fn replace_from_bundle(conn: &Connection, path: &Path) -> rusqlite::Result<()> {
+    let cols = format!("ts, {}, src", FIELDS.join(", "));
+    conn.execute("ATTACH DATABASE ?1 AS restore", [path.to_string_lossy().to_string()])?;
+    let sql = format!("BEGIN IMMEDIATE;
+        DELETE FROM obs;
+        INSERT INTO obs ({cols}) SELECT {cols} FROM restore.obs;
+        DELETE FROM meta;
+        INSERT INTO meta SELECT key, value FROM restore.meta WHERE key NOT LIKE 'backup:%';
+        COMMIT;");
+    let result = conn.execute_batch(&sql);
+    if result.is_err() { let _ = conn.execute_batch("ROLLBACK;"); }
+    let _ = conn.execute_batch("DETACH DATABASE restore;");
+    result
+}
+
 // --- Backfill: WeatherFlow keeps the station's whole history; we only have what we heard ---
 
 /// Walk backwards from the oldest observation we hold, four days at a time, until the station's
@@ -444,6 +526,7 @@ pub fn backfill(conn: &Connection, token: &str, device_id: &str) {
 // silently drops a field, and a day boundary that puts yesterday's high on the wrong row.
 #[cfg(test)]
 mod tests {
+    use super::*;
 
     /// The writer's insert has to keep working now that `src` is a bound parameter rather than
     /// a formatted-in literal, and stay idempotent on the timestamp key.
@@ -459,6 +542,60 @@ mod tests {
         assert_eq!(src, 3);
     }
 
+    #[test]
+    fn portable_backup_round_trips_archive_metadata_and_config() {
+        let dir = std::env::temp_dir().join(format!("wd-bundle-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let source = open(&dir.join("source.db")).unwrap();
+        let mut obs = vec![None; 19]; obs[0] = Some(1_700_000_000.0); obs[7] = Some(21.5);
+        assert!(insert(&source, &obs, 3));
+        meta_set(&source, "kept", "yes");
+        let bundle = dir.join("weatherdesk.wdbak");
+        let config = r#"{"settings":{"stationName":"Back yard","token":"secret"},"layout":{"hero":{}}}"#;
+        bundle_to(&source, &bundle, config).unwrap();
+        let summary = inspect_bundle(&bundle).unwrap();
+        assert_eq!(summary["rows"], 1);
+        assert_eq!(summary["station"], "Back yard");
+        assert_eq!(bundle_config(&bundle).unwrap(), config);
+
+        let target = open(&dir.join("target.db")).unwrap();
+        let mut other = vec![None; 19]; other[0] = Some(1_800_000_000.0);
+        insert(&target, &other, 0);
+        replace_from_bundle(&target, &bundle).unwrap();
+        assert_eq!(target.query_row("SELECT COUNT(*) FROM obs", [], |r| r.get::<_, i64>(0)).unwrap(), 1);
+        assert_eq!(meta_get(&target, "kept").as_deref(), Some("yes"));
+        assert!(meta_get(&target, "backup:config").is_none());
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn portable_backup_rejects_corruption_and_newer_formats() {
+        let dir = std::env::temp_dir().join(format!("wd-bundle-bad-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir); std::fs::create_dir_all(&dir).unwrap();
+        let corrupt = dir.join("bad.wdbak"); std::fs::write(&corrupt, b"not sqlite").unwrap();
+        assert!(inspect_bundle(&corrupt).is_err());
+        let source = open(&dir.join("source.db")).unwrap();
+        let newer = dir.join("newer.wdbak");
+        bundle_to(&source, &newer, "{}").unwrap();
+        let edit = open(&newer).unwrap();
+        meta_set(&edit, "backup:manifest", &serde_json::json!({"format": BACKUP_FORMAT + 1}).to_string());
+        edit.execute_batch("PRAGMA wal_checkpoint(TRUNCATE)").unwrap(); drop(edit);
+        assert!(inspect_bundle(&newer).unwrap_err().contains("newer"));
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn failed_restore_keeps_the_live_archive() {
+        let target = open(std::path::Path::new(":memory:")).unwrap();
+        let mut live = vec![None; 19]; live[0] = Some(1_700_000_000.0);
+        assert!(insert(&target, &live, 0));
+        let missing = std::env::temp_dir().join(format!("wd-missing-{}.wdbak", std::process::id()));
+        let _ = std::fs::remove_file(&missing);
+        assert!(replace_from_bundle(&target, &missing).is_err());
+        assert_eq!(target.query_row("SELECT ts FROM obs", [], |r| r.get::<_, i64>(0)).unwrap(), 1_700_000_000);
+    }
+
     /// The cache key for /history/daily: no COUNT(*), and it still moves when the archive does.
     #[test]
     fn stamp_is_the_range_not_a_count() {
@@ -471,8 +608,6 @@ mod tests {
         insert(&conn, &obs, 0);
         assert_eq!(stamp(&conn), (100, 500));
     }
-    use super::*;
-
     fn mem() -> Connection {
         let c = Connection::open_in_memory().unwrap();
         c.execute_batch(&format!(

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "WeatherDesk",
-  "version": "3.4.0",
+  "version": "4.0.0",
   "identifier": "io.github.davidmay87.weatherdesk",
   "build": {
     "frontendDist": "../site"


### PR DESCRIPTION
## Summary

- add a normalized 72-hour Weather Timeline with observed and forecast events, category thresholds, stable merging, model confidence, accessible filters, and event-to-detail navigation
- replace passive diagnostics with a redacted Health Center and fixed safe repair actions
- add complete `.wdbak` SQLite backup, staged validation, transactional restore, rollback, and pre-restore recovery
- add guided first-run verification and a Linux webview readiness watchdog with `--browser` fallback
- preserve existing layouts, public read-only UI, motion levels, palettes, and `/api/v1`

## Verification

- `cargo test --manifest-path src-tauri/Cargo.toml` — 57 passed
- `CHROME=chromium bash .github/ci/selftest.sh` — 9/9 motion/viewport runs clean
- disposable server on port 8098: `/health`, `/health/action`, `/backup.wdbak`, `/restore/inspect`, and `/restore/apply` passed end to end
- `git diff --check`

## Release plan

Merge this PR, publish `v4.0.0-beta.1` from the merge commit, then smoke-test the beta on the desktop/AppImage, Chromebook browser fallback, G Pad, and S24 Ultra before promoting that same commit to stable.
