### PR TITLE
Fix Docker image glibc compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # whose only always-on machine is a NAS or a Pi.
 #
 # Built without the `gui` feature, so no Tauri, no GTK and no WebKit are anywhere in this image.
-FROM rust:1-slim AS build
+FROM rust:1-slim-bookworm AS build
 RUN apt-get update && apt-get install -y --no-install-recommends pkg-config libssl-dev ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 WORKDIR /src


### PR DESCRIPTION
Pins the Rust build stage to Debian Bookworm so the headless binary is compatible with the existing Bookworm runtime image.

This fixes the container startup failure:

```text
/usr/local/bin/stormdesk: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found
```

Fixes #78

Validation:

```bash
git diff --check origin/main...HEAD
# no output

docker build -t stormdesk:bookworm-glibc .
docker run --rm --network none --entrypoint /usr/local/bin/stormdesk stormdesk:bookworm-glibc --help
```