### PR TITLE
fix(android): keep controls visible and route mobile history correctly

### DIFF
--- a/.github/ci/mobile-history.html
+++ b/.github/ci/mobile-history.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<title>Mobile history regression check</title>
+<body>RUNNING</body>
+<script type="module">
+import { settings } from '../../site/js/app.js';
+import { localObs } from '../../site/js/api.js';
+
+const check = (ok, message) => { if (!ok) throw Error(message); };
+const requests = [];
+window.fetch = async (url) => {
+  requests.push(new URL(url, location.href));
+  return new Response(JSON.stringify({ obs: [] }), { headers: { 'Content-Type': 'application/json' } });
+};
+try {
+  window.__TAURI__ = {};
+  Object.assign(settings(), { token: '', deviceId: '', stationSource: '' });
+  let message = '';
+  try { await localObs(); } catch (e) { message = e.message; }
+  check(message.includes('History requires'), 'Missing archive must explain how to get history');
+  check(requests.length === 0, 'Android must not fetch its frontend as an archive');
+
+  Object.assign(settings(), { token: 'test-token', deviceId: '123' });
+  const at = 1700000000000;
+  await localObs(48, at);
+  check(requests[0].pathname.endsWith('/observations/device/123'), 'Tempest cloud history endpoint');
+  check(+requests[0].searchParams.get('time_start') === at / 1000 - 86400, 'Historical start');
+  check(+requests[0].searchParams.get('time_end') === at / 1000 + 86400, 'Historical end');
+
+  settings().stationSource = 'ambient';
+  try { await localObs(); } catch (e) { message = e.message; }
+  check(requests.length === 1, 'Other stations must not use a leftover Tempest device');
+
+  window.__WD_SRV = 'http://localhost:9999';
+  await localObs(3);
+  check(requests[1].href === 'http://localhost:9999/history/tuples?hours=3', 'Desktop keeps local archive');
+  document.body.textContent = 'PASS';
+} catch (e) {
+  document.body.textContent = `FAIL: ${e.message}`;
+}
+</script>

--- a/scripts/check-android-insets.py
+++ b/scripts/check-android-insets.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""With StormDesk open on an unlocked phone, run: ADB=/path/to/adb python3 scripts/check-android-insets.py."""
+import os
+import re
+import subprocess
+import xml.etree.ElementTree as ET
+
+
+def adb(*args):
+    return subprocess.check_output([os.environ.get("ADB", "adb"), *args], text=True)
+
+
+def rect(value):
+    return tuple(map(int, re.findall(r"\d+", value)))
+
+
+if __name__ == "__main__":
+    adb("shell", "uiautomator", "dump", "/sdcard/stormdesk-insets-check.xml")
+    root = ET.fromstring(adb("shell", "cat", "/sdcard/stormdesk-insets-check.xml"))
+    views = [rect(n.get("bounds")) for n in root.iter("node")
+             if n.get("class") == "android.webkit.WebView"
+             and n.get("package") == "io.github.davidmay87.stormdesk"]
+    assert views, "Open StormDesk before running this check"
+    bars = {rect(m) for m in re.findall(
+        r"InsetsSource id=\S+ type=(?:statusBars|navigationBars) "
+        r"frame=(\[\d+,\d+\]\[\d+,\d+\]) visible=true",
+        adb("shell", "dumpsys", "window"))}
+    assert bars, "No visible system bars found; run with system bars visible"
+    for left, top, right, bottom in views:
+        for bl, bt, br, bb in bars:
+            assert right <= bl or left >= br or bottom <= bt or top >= bb, (
+                f"WebView {(left, top, right, bottom)} overlaps system bar {(bl, bt, br, bb)}")
+    print("PASS: StormDesk WebView clears all visible system bars")

--- a/site/js/api.js
+++ b/site/js/api.js
@@ -190,6 +190,14 @@ export function siToDisplay(obs) {
 // is where every ingested report lands whatever brand sent it. Shaped like `deviceObs` so
 // `pro.js` reads one or the other without knowing which.
 export async function localObs(hours = 3, at = null) {
+  if (window.__TAURI__ && window.__WD_SRV === undefined) {
+    const s = settings();
+    if (!s.stationSource && s.token && /^\d+$/.test(s.deviceId)) {
+      const end = at ? Math.round(at / 1000) + 86400 : Math.floor(Date.now() / 1000);
+      return deviceObs(s.deviceId, end - (at ? 48 : hours) * 3600, end);
+    }
+    throw new Error('History requires a configured Tempest account or a StormDesk desktop/server archive.');
+  }
   // `at` is a moment someone clicked on a chart: a day either side of it, rather than the last
   // `hours` up to now, which for a point three weeks back is the wrong archive entirely.
   const params = at ? { from: Math.round(at / 1000) - 86400, to: Math.round(at / 1000) + 86400 } : { hours };

--- a/src-tauri/gen/android/app/src/main/java/io/github/davidmay87/stormdesk/MainActivity.kt
+++ b/src-tauri/gen/android/app/src/main/java/io/github/davidmay87/stormdesk/MainActivity.kt
@@ -1,8 +1,12 @@
 package io.github.davidmay87.stormdesk
 
 import android.os.Bundle
+import android.view.View
 import android.view.WindowManager
 import androidx.activity.enableEdgeToEdge
+import androidx.core.graphics.Insets
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 
 class MainActivity : TauriActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -12,5 +16,16 @@ class MainActivity : TauriActivity() {
     // backgrounded — no wake lock to leak and no permission to ask for.
     window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
     super.onCreate(savedInstanceState)
+    // Keep every page and fixed toolbar inside the system bars, including older WebViews
+    // that do not expose CSS safe-area insets. Clear only the insets handled here so the
+    // WebView cannot apply them twice; keyboard insets must still reach it.
+    val content = findViewById<View>(android.R.id.content)
+    ViewCompat.setOnApplyWindowInsetsListener(content) { view, windowInsets ->
+      val types = WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
+      val bars = windowInsets.getInsets(types)
+      view.setPadding(bars.left, bars.top, bars.right, bars.bottom)
+      WindowInsetsCompat.Builder(windowInsets).setInsets(types, Insets.NONE).build()
+    }
+    ViewCompat.requestApplyInsets(content)
   }
 }


### PR DESCRIPTION
StormDesk on Android drew its page and bottom toolbar beneath the system bars, and metric history tried to parse the app HTML as archive JSON. Apply system-bar and cutout padding to the native content container, zero those handled insets before forwarding them to WebView, and use Tempest cloud history on Android when configured. Other mobile station sources receive an actionable archive message.

Validation: reproduced both issues via ADB on a Galaxy S24 Ultra; the on-device inset check fails on the existing APK. The cloud-history regression check and all nine existing browser runs pass. Signed APKs from runs 34181689139 and 34182101539 were installed over the existing app without clearing data. The inset check passes in portrait and landscape, a focused settings field stays above the keyboard, and the Rain panel now loads its cloud history chart instead of a JSON parse error. The history regression check also fails against the original code. All PR checks pass.
