### PR TITLE
Reduce renderer load on Samsung Family Hub browsers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - run: node scripts/check-browser-compat.mjs
       - run: bash .github/ci/selftest.sh
       - uses: actions/upload-artifact@v4
         if: always()

--- a/scripts/check-browser-compat.mjs
+++ b/scripts/check-browser-compat.mjs
@@ -1,0 +1,8 @@
+import assert from 'node:assert/strict';
+import { safeMode } from '../site/js/compat.js';
+assert.equal(safeMode('Mozilla/5.0 (Linux; Tizen 6.0; SAMSUNG Family Hub 9.0)', ''), true);
+assert.equal(safeMode('Mozilla/5.0 SMART-TV', '?motion=full'), true);
+assert.equal(safeMode('Mozilla/5.0 Android SamsungBrowser/25.0', ''), false);
+assert.equal(safeMode('Mozilla/5.0 Chrome/130', '?safe=1'), true);
+assert.equal(safeMode('Mozilla/5.0 Chrome/130', '?safe=0'), false);
+console.log('Browser compatibility checks passed');

--- a/site/js/app.js
+++ b/site/js/app.js
@@ -1,3 +1,4 @@
+import { safeMode } from './compat.js';
 // Shell: settings store, nav, refresh scheduler, notification banners.
 
 const DEFAULTS = {
@@ -442,6 +443,7 @@ window.addEventListener('wd:forecast', (e) => {
 });
 
 export function ecoOn() {
+  if (safeMode()) return true;
   if (_settings.eco === 'on') return true;
   if (_settings.eco === 'off') return false;
   // Two cores is a G Pad; four is an old Chromebook. Anything bigger can afford the full rate.

--- a/site/js/boot.js
+++ b/site/js/boot.js
@@ -1,3 +1,4 @@
+import { safeMode } from './compat.js';
 import './storm-watch.js';
 // Wire the shell: settings drawer, diagnostics, nav, section modules.
 import { settings, saveSettings, configured, hasSource, hasLocation, initNav, applyTabs, fullscreen, holdScreen, refreshAll, notify, load, store, applyEco, ecoOn, initKiosk, expires, num, U, msToWind, windToMs, setServerAlerts, alertsAreServerSide, every, clearJob } from './app.js';
@@ -1354,8 +1355,25 @@ window.addEventListener('wd:storm', (e) => {
 // lazy-load the Lab iframe on first visit — full chrome there, it is the roomier view
 window.addEventListener('wd:section', (e) => {
   const f = $('lab-frame');
-  if (e.detail !== 'lab' || f.src) return;
-  f.src = radarUrl(8, false);
+  if (e.detail !== 'lab') return;
+  if (safeMode()) {
+    if ($('lab-radar-still')) return;
+    const img = document.createElement('img');
+    img.id = 'lab-radar-still';
+    img.alt = 'Radar snapshot';
+    const caption = document.createElement('p');
+    caption.className = 'radar-safe-caption';
+    caption.textContent = 'Radar snapshot · refreshes every 5 minutes';
+    f.parentElement.append(img, caption);
+    f.style.display = 'none';
+    const refresh = () => { img.src = stillUrl(); };
+    img.onerror = () => { caption.textContent = 'Radar snapshot unavailable · retrying in 5 minutes'; };
+    img.onload = () => { caption.textContent = 'Radar snapshot · refreshes every 5 minutes'; };
+    refresh();
+    every('lab-radar-still', 300, refresh);
+    return;
+  }
+  if (!f.src) f.src = radarUrl(8, false);
 });
 
 // Inline radar strip on the Desk: embedded, so it holds one frame a minute until touched. A live
@@ -1391,6 +1409,7 @@ function showStill(panel) {
   if (f.src) { f.src = 'about:blank'; f.removeAttribute('src'); }
   img.hidden = false;
   $('desk-radar-caption').hidden = false;
+  if (safeMode()) $('desk-radar-caption').textContent = 'Radar snapshot · 5 min · tap to enlarge';
   panel.classList.add('loaded');
   const refresh = () => { img.src = stillUrl(); };
   img.onerror = () => panel.classList.add('unreachable');

--- a/site/js/compat.js
+++ b/site/js/compat.js
@@ -1,0 +1,5 @@
+// Appliance browsers can report plenty of cores but still have a small renderer/GPU budget.
+export function safeMode(userAgent = navigator.userAgent, search = location.search) {
+  return new URLSearchParams(search).get('safe') === '1'
+    || /Family\s*Hub|Tizen|SMART-TV|SmartHub/i.test(userAgent);
+}

--- a/site/js/motion.js
+++ b/site/js/motion.js
@@ -1,3 +1,4 @@
+import { safeMode } from './compat.js';
 // Motion: the one place that decides how much the dashboard is allowed to move, and the handful
 // of primitives every panel animates through.
 //
@@ -14,6 +15,7 @@ import { settings, ecoOn, num } from './app.js';
 const REDUCED = window.matchMedia?.('(prefers-reduced-motion: reduce)');
 
 export function motionLevel() {
+  if (safeMode()) return 'off';
   const q = new URLSearchParams(location.search).get('motion');
   if (q === 'full' || q === 'lite' || q === 'off') return q;
   // Someone who asked the OS for less motion, or picked the e-ink palette (a screen that redraws

--- a/site/storm-watch.css
+++ b/site/storm-watch.css
@@ -126,3 +126,6 @@ html[data-theme="light"]:not([data-palette="solarized"]):not([data-palette="cont
   --bg:#f2f5f8; --panel:#fff; --panel2:#e8edf3; --line:#ccd6e0;
   --text:#16202b; --muted:#526476; --accent:#087f78; --warn:#a35a00;
 }
+
+.watch-map #lab-radar-still { position:absolute; inset:0; width:100%; height:100%; object-fit:contain; }
+.radar-safe-caption { position:absolute; bottom:0; left:0; right:0; margin:0; padding:8px; background:var(--panel); color:var(--muted); text-align:center; font-size:12px; }


### PR DESCRIPTION
Samsung Family Hub users reported a browser renderer crash immediately on opening StormDesk. The existing CPU-count heuristic can select the full radar and animations on appliance browsers; renderer crash logs from the fridge are not available, so this is a compatibility mitigation rather than a confirmed diagnosis.

Use eco mode, no animation, and periodically refreshed radar snapshots for Family Hub/Tizen/Smart Hub browsers. The Radar tab follows the same restriction as the Desk, and `?safe=1` provides a recovery link for browsers with an unrecognized user agent. Normal phone and desktop browsers retain their existing behavior.

Validation: compatibility tests passed for appliance, Samsung Android, desktop, and explicit recovery URLs. Browser-tested the recovery route with `motion=full`: the Radar tab displays a snapshot and does not load the interactive viewer. Physical fridge confirmation remains necessary.
