### PR TITLE
Record the embedded radar zoom reset fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Raspberry Pi, an Android APK, and the `ghcr.io/d4vid87/stormdesk` container imag
 
 ## [Unreleased]
 
+### Fixed
+- Fixed the embedded radar repeatedly zooming back out during zoom-in gestures. HookEcho now distinguishes its own saved URL updates from incoming navigation, preventing an older camera position from being reapplied. The shared viewer update is delivered through `hookecho.pages.dev`; see [HookEcho #320](https://github.com/d4vid87/hookecho/pull/320).
+
 ## [4.2.0] - 2026-09-07
 
 ### Changed


### PR DESCRIPTION
Record the fix for the embedded radar repeatedly zooming back out during zoom-in gestures, with a link to the merged implementation in HookEcho #320.

StormDesk loads https://hookecho.pages.dev/ directly, so the deployed shared viewer already supplies the corrected camera handling. No duplicate implementation or StormDesk application rebuild is needed. Validation: confirmed the embed URL on main and checked the changelog diff.
